### PR TITLE
[feat] setup github actions final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   compose-validate:
     name: Validate docker-compose.yml

--- a/services/identity-service/build.gradle
+++ b/services/identity-service/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 protobuf {

--- a/services/identity-service/src/test/java/com/Zero_Bug_Freinds/identity_service/IdentityServiceApplicationTests.java
+++ b/services/identity-service/src/test/java/com/Zero_Bug_Freinds/identity_service/IdentityServiceApplicationTests.java
@@ -2,8 +2,10 @@ package com.Zero_Bug_Freinds.identity_service;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class IdentityServiceApplicationTests {
 
 	@Test

--- a/services/identity-service/src/test/resources/application-test.properties
+++ b/services/identity-service/src/test/resources/application-test.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:identitytest;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION

## #️⃣ 연관된 이슈
> Closes #20 

## 작업 내용
- **해당 서비스**: Identity / CI
> identity-service의 테스트 컨텍스트 로딩 실패를 해결하고, gitleaks v2 라이선스 시크릿 누락으로 인한 CI 실패를 수정했습니다.

## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- `.github/workflows/ci.yml`
  - `gitleaks/gitleaks-action@v2` 실행 환경변수에 `GITLEAKS_LICENSE` 추가
- `services/identity-service/build.gradle`
  - 테스트 런타임 DB 의존성 `com.h2database:h2` 추가 (`testRuntimeOnly`)
- `services/identity-service/src/test/java/com/Zero_Bug_Freinds/identity_service/IdentityServiceApplicationTests.java`
  - `@ActiveProfiles("test")` 추가
- `services/identity-service/src/test/resources/application-test.properties` 신규 생성
  - H2 in-memory datasource 설정 추가
  - `MODE=PostgreSQL` 설정으로 테스트 환경 호환성 확보


## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부


## 📸 스크린샷 / 테스트 결과 (선택)
- CI 실패 원인
  - `identity-service`: `contextLoads()`에서 `DataSourceBeanCreationException` 발생
  - `gitleaks`: `GITLEAKS_LICENSE` 누락 오류 발생
- 조치 후 기대 결과
  - test profile + H2로 `identity-service` 테스트 통과
  - gitleaks v2 라이선스 시크릿 주입으로 스캔 단계 통과


## 리뷰 요구사항 
>
- `identity-service` 테스트를 H2로 분리한 방향이 팀 테스트 전략과 맞는지 확인 부탁드립니다.
- 저장소 Secrets에 `GITLEAKS_LICENSE`가 실제 등록되어야 CI가 정상 통과합니다.
