### PR TITLE
Feature/auth system implementation

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from "next/server"
+import { NextResponse } from "next/server"
+
+/**
+ * auth-required 페이지 진입 시 access_token 쿠키를 검사한다.
+ * 쿠키가 없으면 로그인 페이지로 이동한다.
+ */
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get("access_token")?.value
+  if (token) {
+    return NextResponse.next()
+  }
+
+  const loginUrl = new URL("/login", request.url)
+  loginUrl.searchParams.set("next", request.nextUrl.pathname)
+  return NextResponse.redirect(loginUrl)
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/settings/:path*", "/organizations/:path*", "/teams/:path*"],
+}

--- a/apps/web/src/app/api/auth/login/route.test.ts
+++ b/apps/web/src/app/api/auth/login/route.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { POST } from "./route"
+
+function jsonRequest(body: unknown) {
+  return new Request("http://localhost/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete process.env.IDENTITY_SERVICE_URL
+})
+
+describe("POST /api/auth/login (route handler)", () => {
+  it("returns 500 if IDENTITY_SERVICE_URL is missing", async () => {
+    const res = await POST(jsonRequest({}))
+    expect(res.status).toBe(500)
+    const json = (await res.json()) as { success: boolean }
+    expect(json.success).toBe(false)
+  })
+
+  it("returns 400 for invalid payload", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+    const res = await POST(jsonRequest({ email: "bad", password: "123" }))
+    expect(res.status).toBe(400)
+  })
+
+  it("sets httpOnly cookie on successful login", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            message: "로그인 성공",
+            data: {
+              accessToken: "access-token-value",
+              tokenType: "Bearer",
+              expiresInSeconds: 3600,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      })
+    )
+
+    const res = await POST(jsonRequest({ email: "happy@test.com", password: "abc123!@" }))
+    expect(res.status).toBe(200)
+
+    const setCookie = res.headers.get("set-cookie") ?? ""
+    expect(setCookie).toContain("access_token=access-token-value")
+    expect(setCookie).toContain("HttpOnly")
+    expect(setCookie).toContain("Path=/")
+    expect(setCookie).toContain("Max-Age=3600")
+
+    const cacheControl = res.headers.get("cache-control")
+    expect(cacheControl).toBe("no-store")
+  })
+
+  it("returns 502 when tokenType is not Bearer", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            message: "로그인 성공",
+            data: {
+              accessToken: "access-token-value",
+              tokenType: "Basic",
+              expiresInSeconds: 3600,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      })
+    )
+
+    const res = await POST(jsonRequest({ email: "happy@test.com", password: "abc123!@" }))
+    expect(res.status).toBe(502)
+    const json = (await res.json()) as { success: boolean }
+    expect(json.success).toBe(false)
+    expect(res.headers.get("set-cookie")).toBeNull()
+  })
+
+  it("passes through 401 and safe message", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            message: "이메일 또는 비밀번호가 올바르지 않습니다",
+            data: null,
+          }),
+          { status: 401, headers: { "Content-Type": "application/json" } }
+        )
+      })
+    )
+
+    const res = await POST(jsonRequest({ email: "happy@test.com", password: "abc123!@" }))
+    expect(res.status).toBe(401)
+    const json = (await res.json()) as { success: boolean; message: string }
+    expect(json.success).toBe(false)
+    expect(json.message).toContain("비밀번호")
+  })
+})

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from "next/server"
+import { loginRequestSchema } from "@/lib/api/identity/login.schema"
+import type { ApiResponse, LoginResponse } from "@/lib/api/identity/types"
+
+const ACCESS_TOKEN_COOKIE = "access_token"
+
+function noStoreHeaders() {
+  return { "Cache-Control": "no-store" }
+}
+
+function json<T>(status: number, body: ApiResponse<T>) {
+  return NextResponse.json(body, { status, headers: noStoreHeaders() })
+}
+
+function envIdentityBaseUrl() {
+  const url = process.env.IDENTITY_SERVICE_URL
+  if (!url) return null
+  return url.replace(/\/+$/, "")
+}
+
+function isLoginData(data: unknown): data is LoginResponse {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "accessToken" in data &&
+    typeof (data as { accessToken?: unknown }).accessToken === "string" &&
+    "tokenType" in data &&
+    typeof (data as { tokenType?: unknown }).tokenType === "string" &&
+    "expiresInSeconds" in data &&
+    typeof (data as { expiresInSeconds?: unknown }).expiresInSeconds === "number"
+  )
+}
+
+export async function POST(request: Request) {
+  const identityBaseUrl = envIdentityBaseUrl()
+  if (!identityBaseUrl) {
+    return json(500, {
+      success: false,
+      message: "서버 설정이 필요합니다 (IDENTITY_SERVICE_URL)",
+      data: null,
+    })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return json(400, { success: false, message: "JSON 형식이 올바르지 않습니다", data: null })
+  }
+
+  const parsed = loginRequestSchema.safeParse(payload)
+  if (!parsed.success) {
+    const first = parsed.error.issues[0]
+    return json(400, { success: false, message: first?.message ?? "입력값이 올바르지 않습니다", data: null })
+  }
+
+  let upstream: Response
+  try {
+    upstream = await fetch(`${identityBaseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsed.data),
+    })
+  } catch {
+    return json(502, { success: false, message: "인증 서비스에 연결할 수 없습니다", data: null })
+  }
+
+  let upstreamJson: unknown = null
+  try {
+    upstreamJson = await upstream.json()
+  } catch {
+    upstreamJson = null
+  }
+
+  if (upstream.ok) {
+    const body = upstreamJson as ApiResponse<LoginResponse>
+    if (!body?.success || !isLoginData(body.data)) {
+      return json(502, { success: false, message: "로그인 응답 형식이 올바르지 않습니다", data: null })
+    }
+    if (body.data.tokenType !== "Bearer") {
+      return json(502, { success: false, message: "로그인 토큰 타입이 올바르지 않습니다", data: null })
+    }
+
+    const response = json(200, {
+      success: true,
+      message: body.message || "로그인되었습니다",
+      data: null,
+    })
+    response.cookies.set({
+      name: ACCESS_TOKEN_COOKIE,
+      value: body.data.accessToken,
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: body.data.expiresInSeconds,
+    })
+    return response
+  }
+
+  const message =
+    typeof upstreamJson === "object" &&
+    upstreamJson !== null &&
+    "message" in upstreamJson &&
+    typeof (upstreamJson as { message?: unknown }).message === "string"
+      ? (upstreamJson as { message: string }).message
+      : "요청 처리에 실패했습니다"
+
+  return json(upstream.status, { success: false, message, data: null })
+}

--- a/apps/web/src/app/api/auth/session/route.test.ts
+++ b/apps/web/src/app/api/auth/session/route.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { GET } from "./route"
+
+describe("GET /api/auth/session (route handler)", () => {
+  it("returns 401 when access_token cookie is missing", async () => {
+    const req = new Request("http://localhost/api/auth/session", { method: "GET" })
+
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+    const json = (await res.json()) as { success: boolean; data: null }
+    expect(json.success).toBe(false)
+    expect(json.data).toBeNull()
+    expect(res.headers.get("cache-control")).toBe("no-store")
+  })
+
+  it("returns 200 when access_token cookie exists", async () => {
+    const req = new Request("http://localhost/api/auth/session", {
+      method: "GET",
+      headers: { cookie: "access_token=test-token-value" },
+    })
+
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { success: boolean; data: { authenticated: boolean } }
+    expect(json.success).toBe(true)
+    expect(json.data.authenticated).toBe(true)
+    expect(res.headers.get("cache-control")).toBe("no-store")
+  })
+})

--- a/apps/web/src/app/api/auth/session/route.ts
+++ b/apps/web/src/app/api/auth/session/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server"
+import type { ApiResponse, SessionResponse } from "@/lib/api/identity/types"
+
+const ACCESS_TOKEN_COOKIE = "access_token"
+
+function noStoreHeaders() {
+  return { "Cache-Control": "no-store" }
+}
+
+function json<T>(status: number, body: ApiResponse<T>) {
+  return NextResponse.json(body, { status, headers: noStoreHeaders() })
+}
+
+function hasCookieValue(cookieHeader: string | null, name: string) {
+  if (!cookieHeader) return false
+  return cookieHeader
+    .split(";")
+    .map((part) => part.trim())
+    .some((part) => part.startsWith(`${name}=`) && part.slice(name.length + 1).length > 0)
+}
+
+export async function GET(request: Request) {
+  const cookieHeader = request.headers.get("cookie")
+  const hasToken = hasCookieValue(cookieHeader, ACCESS_TOKEN_COOKIE)
+
+  if (!hasToken) {
+    return json(401, {
+      success: false,
+      message: "로그인이 필요합니다",
+      data: null,
+    })
+  }
+
+  return json<SessionResponse>(200, {
+    success: true,
+    message: "세션이 유효합니다",
+    data: { authenticated: true },
+  })
+}

--- a/apps/web/src/app/api/auth/signup/route.test.ts
+++ b/apps/web/src/app/api/auth/signup/route.test.ts
@@ -2,6 +2,9 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { POST } from "./route"
 
+/** Identity SignupRequest 비밀번호 정책에 맞는 예시 */
+const validPassword = "abc123!@"
+
 function jsonRequest(body: unknown) {
   return new Request("http://localhost/api/auth/signup", {
     method: "POST",
@@ -42,6 +45,7 @@ describe("POST /api/auth/signup (route handler)", () => {
       jsonRequest({
         email: "bad",
         password: "123",
+        passwordConfirm: "123",
         name: "",
         role: "USER",
       })
@@ -52,33 +56,41 @@ describe("POST /api/auth/signup (route handler)", () => {
   it("passes through 201 success payload from identity", async () => {
     process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => {
-        return new Response(
-          JSON.stringify({
-            success: true,
-            message: "회원가입이 완료되었습니다",
-            data: { userId: 1, email: "happy@test.com", name: "testDemo", role: "USER" },
-          }),
-          { status: 201, headers: { "Content-Type": "application/json" } }
-        )
-      })
-    )
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          success: true,
+          message: "회원가입이 완료되었습니다",
+          data: { userId: 1, email: "happy@test.com", name: "testDemo", role: "USER" },
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } }
+      )
+    })
+    vi.stubGlobal("fetch", fetchMock)
 
-    const res = await POST(
-      jsonRequest({
-        email: "happy@test.com",
-        password: "password0000",
-        name: "testDemo",
-        role: "USER",
-      })
-    )
+    const body = {
+      email: "happy@test.com",
+      password: validPassword,
+      passwordConfirm: validPassword,
+      name: "testDemo",
+      role: "USER",
+    }
+
+    const res = await POST(jsonRequest(body))
 
     expect(res.status).toBe(201)
     const json = (await res.json()) as { success: boolean; data: { userId: number } }
     expect(json.success).toBe(true)
     expect(json.data.userId).toBe(1)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8080/api/auth/signup",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+    )
   })
 
   it("returns safe failure body when identity returns 409", async () => {
@@ -97,7 +109,8 @@ describe("POST /api/auth/signup (route handler)", () => {
     const res = await POST(
       jsonRequest({
         email: "happy@test.com",
-        password: "password0000",
+        password: validPassword,
+        passwordConfirm: validPassword,
         name: "testDemo",
         role: "USER",
       })
@@ -110,4 +123,3 @@ describe("POST /api/auth/signup (route handler)", () => {
     expect(json.message).toContain("이메일")
   })
 })
-

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,9 @@
+import { LoginForm } from "@/components/login/login-form"
+
+export default function LoginPage() {
+  return (
+    <div className="flex flex-1 items-center justify-center bg-background px-4 py-16">
+      <LoginForm />
+    </div>
+  )
+}

--- a/apps/web/src/components/login/login-form.tsx
+++ b/apps/web/src/components/login/login-form.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import Link from "next/link"
+import * as React from "react"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { loginRequestSchema, type LoginRequestInput } from "@/lib/api/identity/login.schema"
+import type { ApiResponse } from "@/lib/api/identity/types"
+
+type FormState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string }
+
+function safeMessage(err: unknown, fallback: string) {
+  return typeof err === "string" ? err : fallback
+}
+
+export function LoginForm() {
+  const [state, setState] = React.useState<FormState>({ status: "idle" })
+
+  const form = useForm<LoginRequestInput>({
+    resolver: zodResolver(loginRequestSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+    mode: "onSubmit",
+  })
+
+  async function onSubmit(values: LoginRequestInput) {
+    setState({ status: "submitting" })
+
+    let res: Response
+    try {
+      res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      })
+    } catch {
+      setState({ status: "error", message: "네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요." })
+      return
+    }
+
+    let json: ApiResponse<null> | null = null
+    try {
+      json = (await res.json()) as ApiResponse<null>
+    } catch {
+      json = null
+    }
+
+    if (res.ok && json && json.success) {
+      setState({ status: "success", message: json.message || "로그인되었습니다" })
+      return
+    }
+
+    const message = json?.message ?? "로그인에 실패했습니다"
+    setState({ status: "error", message: safeMessage(message, "로그인에 실패했습니다") })
+  }
+
+  const isSubmitting = state.status === "submitting"
+
+  return (
+    <div className="w-full max-w-md rounded-xl border bg-card p-6 shadow-sm">
+      <div className="space-y-1">
+        <h1 className="text-xl font-semibold tracking-tight">로그인</h1>
+        <p className="text-sm text-muted-foreground">이메일과 비밀번호로 로그인합니다.</p>
+      </div>
+
+      <form className="mt-6 space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+        <div className="space-y-2">
+          <Label htmlFor="email">이메일</Label>
+          <Input
+            id="email"
+            type="email"
+            autoComplete="email"
+            placeholder="you@example.com"
+            aria-invalid={!!form.formState.errors.email}
+            {...form.register("email")}
+          />
+          {form.formState.errors.email?.message ? (
+            <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">비밀번호</Label>
+          <Input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            placeholder="비밀번호를 입력하세요"
+            aria-invalid={!!form.formState.errors.password}
+            {...form.register("password")}
+          />
+          {form.formState.errors.password?.message ? (
+            <p className="text-sm text-destructive">{form.formState.errors.password.message}</p>
+          ) : null}
+        </div>
+
+        {state.status === "error" ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {state.message}
+          </div>
+        ) : null}
+
+        {state.status === "success" ? (
+          <div className="rounded-lg border bg-muted px-3 py-2 text-sm">
+            <p className="font-medium">{state.message}</p>
+          </div>
+        ) : null}
+
+        <Button type="submit" className="w-full" disabled={isSubmitting}>
+          {isSubmitting ? "로그인 중..." : "로그인"}
+        </Button>
+      </form>
+
+      <p className="mt-4 text-sm text-muted-foreground">
+        아직 계정이 없나요?{" "}
+        <Link href="/signup" className="font-medium text-foreground underline underline-offset-4">
+          회원가입
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/apps/web/src/components/login/login-form.tsx
+++ b/apps/web/src/components/login/login-form.tsx
@@ -8,6 +8,7 @@ import { useForm } from "react-hook-form"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { apiFetch } from "@/lib/api/client-fetch"
 import { loginRequestSchema, type LoginRequestInput } from "@/lib/api/identity/login.schema"
 import type { ApiResponse } from "@/lib/api/identity/types"
 
@@ -37,22 +38,22 @@ export function LoginForm() {
     setState({ status: "submitting" })
 
     let res: Response
+    let json: ApiResponse<null> | null = null
     try {
-      res = await fetch("/api/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(values),
-      })
+      const result = await apiFetch<null>(
+        "/api/auth/login",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(values),
+        },
+        { authRequired: false }
+      )
+      res = result.response
+      json = result.json
     } catch {
       setState({ status: "error", message: "네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요." })
       return
-    }
-
-    let json: ApiResponse<null> | null = null
-    try {
-      json = (await res.json()) as ApiResponse<null>
-    } catch {
-      json = null
     }
 
     if (res.ok && json && json.success) {

--- a/apps/web/src/components/signup/signup-form.tsx
+++ b/apps/web/src/components/signup/signup-form.tsx
@@ -14,7 +14,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { signupRequestSchema, type SignupRequestInput } from "@/lib/api/identity/signup.schema"
+import {
+  signupPasswordPolicyMessage,
+  signupRequestSchema,
+  type SignupRequestInput,
+} from "@/lib/api/identity/signup.schema"
 import type { ApiResponse, SignupResponse } from "@/lib/api/identity/types"
 
 type FormState =
@@ -35,6 +39,7 @@ export function SignupForm() {
     defaultValues: {
       email: "",
       password: "",
+      passwordConfirm: "",
       name: "",
       role: "USER",
     },
@@ -111,13 +116,32 @@ export function SignupForm() {
             id="password"
             type="password"
             autoComplete="new-password"
-            placeholder="8자 이상"
+            placeholder="예: abc123!@"
             aria-invalid={!!form.formState.errors.password}
             {...form.register("password")}
           />
           {form.formState.errors.password?.message ? (
             <p className="text-sm text-destructive">
               {form.formState.errors.password.message}
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">{signupPasswordPolicyMessage}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="passwordConfirm">비밀번호 확인</Label>
+          <Input
+            id="passwordConfirm"
+            type="password"
+            autoComplete="new-password"
+            placeholder="비밀번호를 다시 입력하세요"
+            aria-invalid={!!form.formState.errors.passwordConfirm}
+            {...form.register("passwordConfirm")}
+          />
+          {form.formState.errors.passwordConfirm?.message ? (
+            <p className="text-sm text-destructive">
+              {form.formState.errors.passwordConfirm.message}
             </p>
           ) : null}
         </div>

--- a/apps/web/src/components/signup/signup-form.tsx
+++ b/apps/web/src/components/signup/signup-form.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import * as React from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm, Controller } from "react-hook-form"
@@ -204,6 +205,12 @@ export function SignupForm() {
           {isSubmitting ? "가입 중..." : "회원가입"}
         </Button>
       </form>
+      <p className="mt-4 text-sm text-muted-foreground">
+        이미 계정이 있나요?{" "}
+        <Link href="/login" className="font-medium text-foreground underline underline-offset-4">
+          로그인
+        </Link>
+      </p>
     </div>
   )
 }

--- a/apps/web/src/components/signup/signup-form.tsx
+++ b/apps/web/src/components/signup/signup-form.tsx
@@ -8,6 +8,7 @@ import { useForm, Controller } from "react-hook-form"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { apiFetch } from "@/lib/api/client-fetch"
 import {
   Select,
   SelectContent,
@@ -51,22 +52,22 @@ export function SignupForm() {
     setState({ status: "submitting" })
 
     let res: Response
+    let json: ApiResponse<SignupResponse> | ApiResponse<null> | null = null
     try {
-      res = await fetch("/api/auth/signup", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(values),
-      })
+      const result = await apiFetch<SignupResponse>(
+        "/api/auth/signup",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(values),
+        },
+        { authRequired: false }
+      )
+      res = result.response
+      json = result.json
     } catch {
       setState({ status: "error", message: "네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요." })
       return
-    }
-
-    let json: ApiResponse<SignupResponse> | ApiResponse<null> | null = null
-    try {
-      json = (await res.json()) as ApiResponse<SignupResponse>
-    } catch {
-      json = null
     }
 
     if (res.ok && json && json.success && json.data) {

--- a/apps/web/src/lib/api/client-fetch.test.ts
+++ b/apps/web/src/lib/api/client-fetch.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { apiFetch } from "./client-fetch"
+
+describe("apiFetch", () => {
+  it("returns response/json for normal success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            message: "ok",
+            data: null,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      })
+    )
+
+    const result = await apiFetch<null>("/api/sample", { method: "GET" })
+    expect(result.response.status).toBe(200)
+    expect(result.json?.success).toBe(true)
+  })
+
+  it("does not trigger redirect callback for 401 when authRequired is false", async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            message: "unauthorized",
+            data: null,
+          }),
+          { status: 401, headers: { "Content-Type": "application/json" } }
+        )
+      })
+    )
+
+    const result = await apiFetch<null>("/api/public", { method: "GET" }, { onUnauthorized })
+    expect(result.response.status).toBe(401)
+    expect(onUnauthorized).not.toHaveBeenCalled()
+  })
+
+  it("triggers redirect callback for 401 when authRequired is true", async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            message: "unauthorized",
+            data: null,
+          }),
+          { status: 401, headers: { "Content-Type": "application/json" } }
+        )
+      })
+    )
+
+    const result = await apiFetch<null>("/api/protected", { method: "GET" }, { authRequired: true, onUnauthorized })
+    expect(result.response.status).toBe(401)
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/lib/api/client-fetch.ts
+++ b/apps/web/src/lib/api/client-fetch.ts
@@ -1,0 +1,44 @@
+import type { ApiResponse } from "@/lib/api/identity/types"
+
+type ApiFetchOptions = {
+  authRequired?: boolean
+  onUnauthorized?: () => void
+}
+
+type ApiFetchResult<T> = {
+  response: Response
+  json: ApiResponse<T> | null
+}
+
+function defaultUnauthorizedHandler() {
+  if (typeof window !== "undefined") {
+    window.location.assign("/login")
+  }
+}
+
+/**
+ * 프론트 공통 API 호출 래퍼.
+ * - `authRequired=true`인 요청에서만 401 공통 처리(`/login` 이동)를 수행한다.
+ * - 일반 API 요청은 401을 반환값으로 그대로 넘겨 화면 에러 처리에 사용한다.
+ */
+export async function apiFetch<T>(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  options?: ApiFetchOptions
+): Promise<ApiFetchResult<T>> {
+  const response = await fetch(input, init)
+
+  let json: ApiResponse<T> | null = null
+  try {
+    json = (await response.json()) as ApiResponse<T>
+  } catch {
+    json = null
+  }
+
+  if (response.status === 401 && options?.authRequired) {
+    const handleUnauthorized = options.onUnauthorized ?? defaultUnauthorizedHandler
+    handleUnauthorized()
+  }
+
+  return { response, json }
+}

--- a/apps/web/src/lib/api/identity/login.schema.test.ts
+++ b/apps/web/src/lib/api/identity/login.schema.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { loginRequestSchema } from "./login.schema"
+
+describe("loginRequestSchema", () => {
+  it("accepts a valid payload", () => {
+    const parsed = loginRequestSchema.safeParse({
+      email: "happy@test.com",
+      password: "abc123!@",
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it("rejects an invalid email", () => {
+    const parsed = loginRequestSchema.safeParse({
+      email: "not-an-email",
+      password: "abc123!@",
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it("rejects a short password", () => {
+    const parsed = loginRequestSchema.safeParse({
+      email: "happy@test.com",
+      password: "123",
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+})

--- a/apps/web/src/lib/api/identity/login.schema.ts
+++ b/apps/web/src/lib/api/identity/login.schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const loginRequestSchema = z.object({
+  email: z.string().email("이메일 형식이 올바르지 않습니다"),
+  password: z.string().min(8, "비밀번호는 8자 이상이어야 합니다").max(100, "비밀번호는 100자 이하여야 합니다"),
+})
+
+export type LoginRequestInput = z.infer<typeof loginRequestSchema>

--- a/apps/web/src/lib/api/identity/signup.schema.test.ts
+++ b/apps/web/src/lib/api/identity/signup.schema.test.ts
@@ -1,25 +1,26 @@
 import { describe, expect, it } from "vitest"
 
-import { signupRequestSchema } from "./signup.schema"
+import { signupPasswordPolicyMessage, signupRequestSchema } from "./signup.schema"
+
+const validBase = {
+  email: "happy@test.com",
+  password: "abc123!@",
+  passwordConfirm: "abc123!@",
+  name: "testDemo",
+  role: "USER" as const,
+}
 
 describe("signupRequestSchema", () => {
   it("accepts a valid payload", () => {
-    const parsed = signupRequestSchema.safeParse({
-      email: "happy@test.com",
-      password: "password0000",
-      name: "testDemo",
-      role: "USER",
-    })
+    const parsed = signupRequestSchema.safeParse(validBase)
 
     expect(parsed.success).toBe(true)
   })
 
   it("rejects an invalid email", () => {
     const parsed = signupRequestSchema.safeParse({
+      ...validBase,
       email: "not-an-email",
-      password: "password0000",
-      name: "testDemo",
-      role: "USER",
     })
 
     expect(parsed.success).toBe(false)
@@ -27,13 +28,56 @@ describe("signupRequestSchema", () => {
 
   it("rejects a short password", () => {
     const parsed = signupRequestSchema.safeParse({
-      email: "happy@test.com",
+      ...validBase,
       password: "123",
-      name: "testDemo",
-      role: "USER",
+      passwordConfirm: "123",
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it("rejects password without special character", () => {
+    const parsed = signupRequestSchema.safeParse({
+      ...validBase,
+      password: "password00",
+      passwordConfirm: "password00",
+    })
+
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(parsed.error.issues.some((i) => i.message === signupPasswordPolicyMessage)).toBe(true)
+    }
+  })
+
+  it("rejects password with uppercase", () => {
+    const parsed = signupRequestSchema.safeParse({
+      ...validBase,
+      password: "Abc123!@",
+      passwordConfirm: "Abc123!@",
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it("rejects password mismatch", () => {
+    const parsed = signupRequestSchema.safeParse({
+      ...validBase,
+      passwordConfirm: "abc123!@x",
+    })
+
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      const msg = parsed.error.issues.find((i) => i.path.includes("passwordConfirm"))?.message
+      expect(msg).toBe("비밀번호가 일치하지 않습니다")
+    }
+  })
+
+  it("rejects empty passwordConfirm", () => {
+    const parsed = signupRequestSchema.safeParse({
+      ...validBase,
+      passwordConfirm: "",
     })
 
     expect(parsed.success).toBe(false)
   })
 })
-

--- a/apps/web/src/lib/api/identity/signup.schema.ts
+++ b/apps/web/src/lib/api/identity/signup.schema.ts
@@ -2,15 +2,25 @@ import { z } from "zod"
 
 export const roleSchema = z.enum(["USER", "ADMIN"])
 
-export const signupRequestSchema = z.object({
-  email: z.string().email("이메일 형식이 올바르지 않습니다"),
-  password: z
-    .string()
-    .min(8, "비밀번호는 8자 이상이어야 합니다")
-    .max(100, "비밀번호는 100자 이하여야 합니다"),
-  name: z.string().min(1, "이름은 필수입니다").max(100, "이름은 100자 이하여야 합니다"),
-  role: roleSchema,
-})
+/** Identity `SignupRequest` `@Pattern` 메시지와 동일 (services/identity-service) */
+export const signupPasswordPolicyMessage =
+  "비밀번호는 소문자/숫자/특수문자를 각각 1개 이상 포함하고 대문자 없이 8~100자여야 합니다"
+
+/** 백엔드 `SignupRequest` 정규식과 동일 */
+const SIGNUP_PASSWORD_REGEX =
+  /^(?=.*[a-z])(?=.*\d)(?=.*[^a-zA-Z0-9])(?=\S+$)[^A-Z]{8,100}$/
+
+export const signupRequestSchema = z
+  .object({
+    email: z.string().email("이메일 형식이 올바르지 않습니다"),
+    password: z.string().regex(SIGNUP_PASSWORD_REGEX, signupPasswordPolicyMessage),
+    passwordConfirm: z.string().min(1, "비밀번호 확인을 입력해주세요"),
+    name: z.string().min(1, "이름은 필수입니다").max(100, "이름은 100자 이하여야 합니다"),
+    role: roleSchema,
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    message: "비밀번호가 일치하지 않습니다",
+    path: ["passwordConfirm"],
+  })
 
 export type SignupRequestInput = z.infer<typeof signupRequestSchema>
-

--- a/apps/web/src/lib/api/identity/types.ts
+++ b/apps/web/src/lib/api/identity/types.ts
@@ -32,3 +32,7 @@ export type LoginResponse = {
   expiresInSeconds: number
 }
 
+export type SessionResponse = {
+  authenticated: boolean
+}
+

--- a/apps/web/src/lib/api/identity/types.ts
+++ b/apps/web/src/lib/api/identity/types.ts
@@ -21,3 +21,14 @@ export type SignupResponse = {
   role: Role
 }
 
+export type LoginRequest = {
+  email: string
+  password: string
+}
+
+export type LoginResponse = {
+  accessToken: string
+  tokenType: string
+  expiresInSeconds: number
+}
+

--- a/apps/web/src/lib/api/identity/types.ts
+++ b/apps/web/src/lib/api/identity/types.ts
@@ -9,6 +9,7 @@ export type Role = "USER" | "ADMIN"
 export type SignupRequest = {
   email: string
   password: string
+  passwordConfirm: string
   name: string
   role: Role
 }

--- a/docs/contracts/web-identity-bff.md
+++ b/docs/contracts/web-identity-bff.md
@@ -18,9 +18,11 @@
 |------|-----------------------|-------------------|
 | 회원가입 | `POST /api/auth/signup` | `POST /api/auth/signup` |
 | 로그인 | `POST /api/auth/login` | `POST /api/auth/login` |
+| 세션(로그인 여부 단일 기준) | `GET /api/auth/session` | (BFF가 쿠키·토큰 검증으로 판단; 필요 시 Identity 보호 API 호출) |
 
 - Web BFF는 `IDENTITY_SERVICE_URL` 환경 변수를 사용해 Identity로 프록시한다.
 - BFF 입력 검증은 Zod 스키마로 수행한다.
+- **`GET /api/auth/session`** 은 프론트가 “로그인됨/만료”를 판단할 때 사용하는 **단일 기준 엔드포인트**로 둔다. 응답에도 `Cache-Control: no-store`를 적용한다(§8).
 
 ---
 
@@ -44,8 +46,9 @@
 
 ### 4.2 `tokenType` 검증
 
-- BFF는 `tokenType === "Bearer"` 인지 검증한다.
-- 불일치 시 쿠키를 저장하지 않고 `502 Bad Gateway`를 반환한다.
+- BFF는 로그인 응답의 `tokenType`이 정확히 **`Bearer`** 인지 검증한다.
+- 불일치 시 토큰(쿠키)을 저장하지 않고 **`502 Bad Gateway`** 로만 응답한다.
+- **에러 코드 통일:** `tokenType` 불일치는 업스트림(Identity) 계약 위반에 가깝다. **`502`로 고정**하고, **`500`과 혼용하지 않는다**(프론트 예외 처리 분기 최소화).
 
 ### 4.3 쿠키 옵션
 
@@ -69,10 +72,16 @@
 
 ## 6. 401 / 만료 처리 정책
 
-- 백엔드 401 응답 형식은 공통 JSON(`success`, `message`, `data`)을 유지한다.
-- BFF는 401을 그대로 전달한다.
-- 프론트는 **auth-required** 요청/페이지에 대해서만 `/login` 리다이렉트 공통 처리를 적용한다.
-  - 일반 API의 401은 화면 에러(토스트/메시지)로 처리 후 필요 시 로그인 유도한다.
+- 백엔드 401 응답은 공통 JSON(`success=false`, `message`, `data=null`)을 유지한다.
+- BFF는 Identity에서 받은 **401을 프론트에 그대로 전달**한다(상태 코드·본문 유지).
+
+### 6.1 프론트에서 `/login` 리다이렉트 범위 (합의)
+
+- **“모든 401을 받으면 즉시 `/login`으로 보낸다”는 방식은 지양**한다.
+- **`auth-required`** 인 요청·페이지(로그인이 필요한 화면/흐름)에서만, 공통 처리로 **`/login` 리다이렉트**를 적용한다.
+- **일반 API** 호출에서 401이 나오면 즉시 리다이렉트하지 않고, **화면에서 에러 상태(토스트/메시지 등)로 처리**한 뒤 필요 시 로그인을 유도한다.
+
+위 범위는 초기 논의에서 “401 시 항상 로그인 페이지”로 읽힐 수 있는 문구와 구분되므로, **정본은 본 절(6.1)을 따른다.**
 
 ---
 
@@ -86,9 +95,9 @@
 
 ## 8. 캐시/보안 정책
 
-- 로그인/로그아웃/세션 체크 응답에는 `Cache-Control: no-store`를 적용한다.
+- 로그인/로그아웃/**`GET /api/auth/session`(세션 체크)** 응답에는 `Cache-Control: no-store`를 적용한다.
 - MVP는 **Access Token only**(Refresh Token 미포함)로 운영하고, 만료 시 재로그인한다.
-- CSRF는 MVP에서 `SameSite=Lax + BFF 경유`를 기본으로 하고, 차기 스프린트에서 상태 변경 API에 대해 `Origin/Referer` 검증(또는 CSRF 토큰)을 표준 적용한다.
+- CSRF는 MVP에서 `SameSite=Lax + BFF 경유`를 기본으로 하고, **차기 스프린트에서 상태 변경 API는 BFF 경유에 더해 `Origin/Referer` 검증(또는 CSRF 토큰) 적용을 표준으로 한다.**
 
 ---
 

--- a/docs/contracts/web-identity-bff.md
+++ b/docs/contracts/web-identity-bff.md
@@ -23,6 +23,9 @@
 - Web BFF는 `IDENTITY_SERVICE_URL` 환경 변수를 사용해 Identity로 프록시한다.
 - BFF 입력 검증은 Zod 스키마로 수행한다.
 - **`GET /api/auth/session`** 은 프론트가 “로그인됨/만료”를 판단할 때 사용하는 **단일 기준 엔드포인트**로 둔다. 응답에도 `Cache-Control: no-store`를 적용한다(§8).
+- `GET /api/auth/session` 응답 형식:
+  - 로그인 상태: `200` + `ApiResponse<{ authenticated: true }>`
+  - 비로그인/만료: `401` + `ApiResponse<null>` (`success=false`, `message`, `data=null`)
 
 ---
 

--- a/docs/contracts/web-identity-bff.md
+++ b/docs/contracts/web-identity-bff.md
@@ -1,0 +1,100 @@
+# Web(Next.js) ↔ Identity 인증 BFF 계약
+
+버전: 1.0  
+관련: [docs/architecture.md](../architecture.md) §1.3, §3.3
+
+---
+
+## 1. 목적
+
+- `apps/web`는 브라우저가 Identity 서비스를 직접 호출하지 않고, **Next Route Handler(BFF)** 를 통해 회원가입/로그인을 처리한다.
+- 인증 토큰은 프론트 JavaScript에 노출하지 않고, **httpOnly 쿠키**로만 관리한다.
+
+---
+
+## 2. 엔드포인트 계약
+
+| 구분 | Web BFF (`apps/web`) | Upstream Identity |
+|------|-----------------------|-------------------|
+| 회원가입 | `POST /api/auth/signup` | `POST /api/auth/signup` |
+| 로그인 | `POST /api/auth/login` | `POST /api/auth/login` |
+
+- Web BFF는 `IDENTITY_SERVICE_URL` 환경 변수를 사용해 Identity로 프록시한다.
+- BFF 입력 검증은 Zod 스키마로 수행한다.
+
+---
+
+## 3. 회원가입 계약 (정합성)
+
+- `passwordConfirm`은 필수이며, `password`와 일치해야 한다.
+- 비밀번호 정책은 Identity와 동일하게 유지한다.
+  - 소문자/숫자/특수문자 각각 1개 이상
+  - 대문자 불가
+  - 공백 불가
+  - 길이 8~100자
+
+---
+
+## 4. 로그인 응답 처리 계약
+
+### 4.1 토큰 저장 위치
+
+- BFF가 Identity 로그인 응답의 `accessToken`을 받아, 브라우저에 **httpOnly 쿠키**로 저장한다.
+- 프론트(JavaScript)는 토큰 원문에 직접 접근하지 않는다.
+
+### 4.2 `tokenType` 검증
+
+- BFF는 `tokenType === "Bearer"` 인지 검증한다.
+- 불일치 시 쿠키를 저장하지 않고 `502 Bad Gateway`를 반환한다.
+
+### 4.3 쿠키 옵션
+
+| 항목 | 값 |
+|------|----|
+| `name` | `access_token` |
+| `httpOnly` | `true` |
+| `sameSite` | `lax` |
+| `path` | `/` |
+| `secure` | `production=true`, `local=false` |
+| `maxAge` | `expiresInSeconds`(기본 3600초) |
+
+---
+
+## 5. 보호 API 호출 방식
+
+1. 브라우저 → BFF: 쿠키 자동 전송
+2. BFF → 백엔드 보호 API: `Authorization: Bearer {accessToken}` 헤더로 전달
+
+---
+
+## 6. 401 / 만료 처리 정책
+
+- 백엔드 401 응답 형식은 공통 JSON(`success`, `message`, `data`)을 유지한다.
+- BFF는 401을 그대로 전달한다.
+- 프론트는 **auth-required** 요청/페이지에 대해서만 `/login` 리다이렉트 공통 처리를 적용한다.
+  - 일반 API의 401은 화면 에러(토스트/메시지)로 처리 후 필요 시 로그인 유도한다.
+
+---
+
+## 7. 로그아웃 쿠키 삭제 규칙
+
+- BFF 로그아웃 API에서 `access_token` 쿠키를 만료 처리한다.
+- 저장 시와 동일한 옵션(`path`, `sameSite`, `secure`, `httpOnly`)을 사용한다.
+- `maxAge: 0` + 과거 `expires`를 함께 명시해 삭제를 보장한다.
+
+---
+
+## 8. 캐시/보안 정책
+
+- 로그인/로그아웃/세션 체크 응답에는 `Cache-Control: no-store`를 적용한다.
+- MVP는 **Access Token only**(Refresh Token 미포함)로 운영하고, 만료 시 재로그인한다.
+- CSRF는 MVP에서 `SameSite=Lax + BFF 경유`를 기본으로 하고, 차기 스프린트에서 상태 변경 API에 대해 `Origin/Referer` 검증(또는 CSRF 토큰)을 표준 적용한다.
+
+---
+
+## 9. 로컬 실행 참고
+
+- `apps/web/.env`에 `IDENTITY_SERVICE_URL`을 설정한다.  
+  예: `IDENTITY_SERVICE_URL=http://localhost:8080`
+- 로컬 기본 실행 순서: Postgres → Identity → Web
+- 포트 충돌 주의: Gateway와 Identity가 동시에 `8080`을 사용하지 않도록 환경별 포트를 조정한다.

--- a/docs/local-run-and-usage-verification.md
+++ b/docs/local-run-and-usage-verification.md
@@ -3,13 +3,14 @@
 버전: 1.0  
 
 OpenAI 등 API 키를 두고 **게이트웨이 → 프록시 → Provider** 호출 시 **`UsageRecordedEvent`가 RabbitMQ로 발행**되고 **`usage-service`가 DB에 저장**하는 흐름을 로컬에서 재현·검증하는 절차입니다.  
-관련 설계 문서: [`contracts/gateway-proxy.md`](contracts/gateway-proxy.md), [`event-consumer-flow.md`](event-consumer-flow.md), [`usage-analytics-relationship.md`](usage-analytics-relationship.md) §3.1(패턴 A).
+관련 설계 문서: [`contracts/gateway-proxy.md`](contracts/gateway-proxy.md), [`contracts/web-identity-bff.md`](contracts/web-identity-bff.md), [`event-consumer-flow.md`](event-consumer-flow.md), [`usage-analytics-relationship.md`](usage-analytics-relationship.md) §3.1(패턴 A).
 
 ---
 
 ## 전제
 
 - **인증·로그인 서비스는 사용하지 않는다**고 가정(캡스톤/개발 모드). Gateway는 `GATEWAY_DEV_MODE=true`(기본에 가깝게)일 때 **`X-User-Id` 헤더**만으로 `/api/v1/ai/**` 진입 가능.
+- Identity 로그인/회원가입(BFF, 쿠키 정책) 기준은 [`contracts/web-identity-bff.md`](contracts/web-identity-bff.md)를 따른다.
 - **Google(Gemini)만** 테스트하려면 **`PROXY_GOOGLE_TEST_API_KEY`** 와 아래 §2.1의 **Google 경로**만 맞추면 된다. OpenAI를 쓰려면 **`PROXY_OPENAI_TEST_API_KEY`** 와 §2.2 경로가 필요하다. 두 키를 동시에 둘 수 있으며, **어느 쪽을 “기본”으로 강제하지는 않는다.** 선택적으로 **`PROXY_MOCK_KEY_FALLBACK`** 을 둘 수 있다. 키는 **커밋하지 말고** `.env` 등 로컬에만 둔다(`.env.example` 참고). 상세: [`multi-provider-usage-and-google-path.md`](multi-provider-usage-and-google-path.md).
 
 ---


### PR DESCRIPTION

## #️⃣ 연관된 이슈
> ex) #이슈번호 등

## 작업 내용
- **해당 서비스**: Web(Frontend, apps/web)
> Identity 로그인/회원가입 연동 계약에 맞춰 프론트 BFF 인증 흐름을 보강했습니다.
로그인 API/BFF, 세션 체크 엔드포인트, auth-required 401 공통 처리 기반, 관련 문서 계약 정합화까지 포함합니다.

  
## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- 로그인 기능 추가
POST /api/auth/login BFF 추가 (apps/web/src/app/api/auth/login/route.ts)
Identity 응답 tokenType === Bearer 검증, 불일치 시 502 고정
로그인 성공 시 access_token을 httpOnly 쿠키로 저장
로그인 응답 Cache-Control: no-store 적용
- 회원가입 정합성 강화
passwordConfirm 필드 추가 및 비밀번호 일치 검증
비밀번호 정책을 백엔드 규칙(소문자/숫자/특수문자, 대문자 금지, 8~100자)과 일치
- 세션 기준 엔드포인트 추가
GET /api/auth/session 구현 (apps/web/src/app/api/auth/session/route.ts)
쿠키 존재 시 200 + ApiResponse<{ authenticated: true }>
쿠키 미존재 시 401 + ApiResponse<null>
no-store 헤더 적용
- 401 공통 처리 기반 추가
공통 fetch 래퍼 apiFetch 추가 (apps/web/src/lib/api/client-fetch.ts)
authRequired 옵션으로 401 처리 범위 분리
로그인/회원가입 폼에서 공통 래퍼 사용
- 라우트 가드(미들웨어) 추가
apps/web/middleware.ts
보호 경로(dashboard/settings/organizations/teams)에서 쿠키 없으면 /login?next=... 리다이렉트
- 문서 반영
docs/contracts/web-identity-bff.md 신규/보완
401 처리 범위, 502 고정, /api/auth/session 단일 기준 및 응답 형식 명시
docs/local-run-and-usage-verification.md에 계약 문서 링크 추가

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
- apps/web 기준
npm test 통과 (최종: 25 tests passed)
npm run lint 통과
- 수동 확인
로그인 성공 시 set-cookie(access_token, HttpOnly, SameSite=Lax, Path=/, Max-Age) 확인
/api/auth/session 200/401 분기 확인

## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- tokenType 불일치 시 502 고정 정책이 합의 문서와 코드에서 동일하게 반영되었는지 확인 부탁드립니다.
- 401 리다이렉트 범위(auth-required 한정)가 정책 의도와 맞는지 검토 부탁드립니다.
- GET /api/auth/session 응답 포맷(200/401 + ApiResponse)이 프론트 상태 판별 기준으로 충분한지 확인 부탁드립니다.
