### PR TITLE
Feature/usage service with analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,8 @@ REDIS_PORT=6379
 # identity-service 는 Compose 가 아닌 호스트에서 실행. 컨테이너 proxy → 호스트 키 서비스:
 # PROXY_KEY_SERVICE_BASE_URL=http://host.docker.internal:8080
 # (identity 가 8090 이면 :8090 으로; application.yml 의 key-service 포트와 일치)
+# Gateway → usage-service HTTP (기본값은 application.yml 의 localhost:8092). Compose 의 api-gateway 컨테이너가 호스트의 usage 를 부를 때:
+# GATEWAY_USAGE_URI=http://host.docker.internal:8092
+# usage-service dashboard API (optional)
+# USAGE_GATEWAY_SHARED_SECRET=
+# USAGE_ANALYTICS_MAX_RANGE_DAYS=400

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# Local infrastructure for the monorepo (see docs/architecture.md §10).
+﻿# Local infrastructure for the monorepo (see docs/architecture.md §10).
 # Copy `.env.example` to `.env` and set secrets locally; do not commit `.env`.
 #
 # 앱 이미지 빌드 전 각 서비스에서 ./gradlew bootJar 로 app.jar 생성:
@@ -60,6 +60,7 @@ services:
       - proxy-service
     environment:
       GATEWAY_PROXY_URI: http://proxy-service:8081
+      GATEWAY_USAGE_URI: ${GATEWAY_USAGE_URI:-http://host.docker.internal:8092}
       PROXY_GATEWAY_SHARED_SECRET: ${PROXY_GATEWAY_SHARED_SECRET:-}
       GATEWAY_JWT_SECRET: ${GATEWAY_JWT_SECRET:-}
       GATEWAY_DEV_MODE: ${GATEWAY_DEV_MODE:-true}

--- a/docs/class-diagram.md
+++ b/docs/class-diagram.md
@@ -1,8 +1,54 @@
 # Class Diagram
 
-`docs/c4-architecture-diagrams.md`에 그대로 붙여 넣을 수 있도록, 전체 다이어그램과 서비스별 서브다이어그램을 한 문서에 함께 정리합니다.
+`docs/c4-architecture-diagrams.md`에 붙여 넣을 수 있도록 Mermaid 클래스 다이어그램을 정리합니다. 최근 변경(Usage 대시보드·분석 API, 게이트웨이 신뢰 필터, Identity 세션 API 등)을 반영했습니다.
 
-## 1) Integrated Class Diagram
+**가독성:** 전 서비스를 한 그림에 넣으면 노드가 과다해지므로, **① 교차 서비스 개요** 후 **② 서비스·관심사별 서브다이어그램**으로 나눴습니다.
+
+**이름 충돌:** Java 코드에서 `SecurityConfiguration`이 proxy-service와 api-gateway-service에 각각 있습니다. 아래 다이어그램에서는 **`ProxySecurityConfiguration`** / **`GatewaySecurityConfiguration`** 으로 구분합니다 (각각 `com.eevee.proxyservice.security.SecurityConfiguration`, `com.eevee.apigateway.config.SecurityConfiguration`).
+
+---
+
+## 1) Cross-service overview (경량)
+
+```mermaid
+classDiagram
+direction LR
+
+class AuthController
+class UserService
+class ProxyController
+class ProxyRelayService
+class UsageEventPublisher
+class ProxyTrustHeadersGatewayFilter
+class GatewaySecurityConfiguration
+class JwtDecoderConfiguration
+class GatewayProperties
+class ReactiveJwtDecoder
+class UsageAnalyticsController
+class UsageDashboardService
+class UsageRecordedEventListener
+class UsageRecordedService
+class UsageRecordedEvent
+
+AuthController --> UserService
+ProxyController --> ProxyRelayService
+ProxyRelayService --> UsageEventPublisher
+UsageEventPublisher ..> UsageRecordedEvent : publishes JSON
+UsageRecordedEventListener --> UsageRecordedService
+UsageRecordedEventListener ..> UsageRecordedEvent : deserializes
+
+ProxyTrustHeadersGatewayFilter --> GatewayProperties
+GatewaySecurityConfiguration --> GatewayProperties
+GatewaySecurityConfiguration ..> ReactiveJwtDecoder
+JwtDecoderConfiguration --> GatewayProperties
+JwtDecoderConfiguration ..> ReactiveJwtDecoder
+
+UsageAnalyticsController --> UsageDashboardService
+```
+
+---
+
+## 2) Identity Service
 
 ```mermaid
 classDiagram
@@ -19,6 +65,7 @@ class SignupRequest
 class SignupResponse
 class LoginRequest
 class LoginResponse
+class SessionResponse
 class SecurityConfig
 class JwtAuthenticationFilter
 class OncePerRequestFilter
@@ -26,46 +73,12 @@ class JwtTokenProvider
 class RestAuthenticationEntryPoint
 class AuthenticationEntryPoint
 
-class ProxyController
-class ProxyRelayService
-class ProviderHandler
-class ProviderRegistry
-class OpenAiProviderHandler
-class AnthropicProviderHandler
-class GoogleProviderHandler
-class ApiKeyClient
-class UsageEventPublisher
-class GatewayAuthWebFilter
-class LocalUserHeadersWebFilter
-class WebFilter
-class UserContextResolver
-class UserContext
-class ProxyProperties
-
-class ProxyTrustHeadersGatewayFilter
-class GlobalFilter
-class Ordered
-class ApiGatewaySecurityConfiguration
-class GatewayProperties
-class ReactiveJwtDecoder
-
-class UsageRecordedEventListener
-class UsageRecordedService
-class UsageRecordedLogRepository
-class UsageRecordedLogEntity
-class UsageRabbitConfiguration
-class UsageRabbitProperties
-
-class UsageRecordedEvent
-class TokenUsage
-class AiProvider
-
 AuthController --> UserService
 AuthController ..> SignupRequest
 AuthController ..> SignupResponse
 AuthController ..> LoginRequest
 AuthController ..> LoginResponse
-
+AuthController ..> SessionResponse
 UserService --> UserRepository
 UserService --> JwtTokenProvider
 UserService ..> User
@@ -73,96 +86,6 @@ UserService ..> SignupRequest
 UserService ..> SignupResponse
 UserService ..> LoginRequest
 UserService ..> LoginResponse
-
-UserRepository --|> JpaRepository
-User --> Role
-
-JwtAuthenticationFilter --|> OncePerRequestFilter
-JwtAuthenticationFilter --> JwtTokenProvider
-RestAuthenticationEntryPoint --|> AuthenticationEntryPoint
-SecurityConfig --> JwtAuthenticationFilter
-SecurityConfig --> RestAuthenticationEntryPoint
-
-ProxyController --> ProxyRelayService
-ProxyRelayService --> ProviderRegistry
-ProxyRelayService --> ApiKeyClient
-ProxyRelayService --> UsageEventPublisher
-ProxyRelayService --> UserContextResolver
-ProxyRelayService ..> ProviderHandler
-ProxyRelayService ..> UserContext
-ProxyRelayService ..> UsageRecordedEvent
-ProxyRelayService ..> TokenUsage
-ProxyRelayService ..> AiProvider
-
-ProviderRegistry --> ProviderHandler
-OpenAiProviderHandler --|> ProviderHandler
-AnthropicProviderHandler --|> ProviderHandler
-GoogleProviderHandler --|> ProviderHandler
-OpenAiProviderHandler ..> TokenUsage
-AnthropicProviderHandler ..> TokenUsage
-GoogleProviderHandler ..> TokenUsage
-
-GatewayAuthWebFilter --|> WebFilter
-LocalUserHeadersWebFilter --|> WebFilter
-GatewayAuthWebFilter --> ProxyProperties
-UserContextResolver ..> UserContext
-
-UsageEventPublisher --> ProxyProperties
-UsageEventPublisher ..> UsageRecordedEvent
-
-ProxyTrustHeadersGatewayFilter --|> GlobalFilter
-ProxyTrustHeadersGatewayFilter --|> Ordered
-ProxyTrustHeadersGatewayFilter --> GatewayProperties
-ApiGatewaySecurityConfiguration --> GatewayProperties
-ApiGatewaySecurityConfiguration ..> ReactiveJwtDecoder
-
-UsageRecordedEventListener --> UsageRecordedService
-UsageRecordedEventListener ..> UsageRecordedEvent
-UsageRecordedService --> UsageRecordedLogRepository
-UsageRecordedService ..> UsageRecordedLogEntity
-UsageRecordedService ..> UsageRecordedEvent
-UsageRecordedService ..> TokenUsage
-UsageRecordedLogRepository --|> JpaRepository
-UsageRecordedLogEntity --> AiProvider
-
-UsageRabbitConfiguration --> UsageRabbitProperties
-
-UsageRecordedEvent --> TokenUsage
-UsageRecordedEvent --> AiProvider
-```
-
-## 2) Identity Service Sub Diagram
-
-```mermaid
-classDiagram
-direction TB
-
-class AuthController
-class GlobalExceptionHandler
-class UserService
-class UserRepository
-class JpaRepository
-class User
-class Role
-class SignupRequest
-class SignupResponse
-class LoginRequest
-class LoginResponse
-class SecurityConfig
-class JwtAuthenticationFilter
-class OncePerRequestFilter
-class JwtTokenProvider
-class RestAuthenticationEntryPoint
-class AuthenticationEntryPoint
-
-AuthController --> UserService
-AuthController ..> SignupRequest
-AuthController ..> SignupResponse
-AuthController ..> LoginRequest
-AuthController ..> LoginResponse
-UserService --> UserRepository
-UserService --> JwtTokenProvider
-UserService ..> User
 UserRepository --|> JpaRepository
 User --> Role
 JwtAuthenticationFilter --|> OncePerRequestFilter
@@ -172,7 +95,11 @@ SecurityConfig --> JwtAuthenticationFilter
 SecurityConfig --> RestAuthenticationEntryPoint
 ```
 
-## 3) Proxy Service Sub Diagram
+---
+
+## 3) Proxy Service
+
+WebFlux 보안은 코드상 `com.eevee.proxyservice.security.SecurityConfiguration` 이 `SecurityWebFilterChain`을 등록합니다. 아래는 릴레이·프로바이더·신뢰 헤더 중심입니다.
 
 ```mermaid
 classDiagram
@@ -222,7 +149,9 @@ UsageEventPublisher --> ProxyProperties
 UsageEventPublisher ..> UsageRecordedEvent
 ```
 
-## 4) API Gateway Service Sub Diagram
+---
+
+## 4) API Gateway Service
 
 ```mermaid
 classDiagram
@@ -231,18 +160,55 @@ direction TB
 class ProxyTrustHeadersGatewayFilter
 class GlobalFilter
 class Ordered
-class ApiGatewaySecurityConfiguration
+class GatewaySecurityConfiguration
+class JwtDecoderConfiguration
 class GatewayProperties
 class ReactiveJwtDecoder
 
 ProxyTrustHeadersGatewayFilter --|> GlobalFilter
 ProxyTrustHeadersGatewayFilter --|> Ordered
 ProxyTrustHeadersGatewayFilter --> GatewayProperties
-ApiGatewaySecurityConfiguration --> GatewayProperties
-ApiGatewaySecurityConfiguration ..> ReactiveJwtDecoder
+GatewaySecurityConfiguration --> GatewayProperties
+GatewaySecurityConfiguration ..> ReactiveJwtDecoder
+JwtDecoderConfiguration --> GatewayProperties
+JwtDecoderConfiguration ..> ReactiveJwtDecoder
 ```
 
-## 5) Usage Service Sub Diagram
+---
+
+## 5) Usage Service — Gateway trust & dashboard HTTP
+
+게이트웨이가 넘긴 `X-User-Id` / `X-Gateway-Auth`를 **`UsageGatewayTrustFilter`**에서 검증·요청 속성으로 두고, **`UsageAnalyticsController`**가 **`UsageDashboardService`**로 대시보드·로그 조회를 위임합니다.
+
+```mermaid
+classDiagram
+direction TB
+
+class UsageGatewayTrustFilter
+class OncePerRequestFilter
+class UsageServiceProperties
+class UsageAnalyticsController
+class UsageDashboardService
+class UsageAnalyticsJdbcRepository
+class UsageRecordedLogRepository
+class JdbcTemplate
+class UsageApiExceptionHandler
+
+UsageApiExceptionHandler ..> UsageAnalyticsController
+
+UsageGatewayTrustFilter --|> OncePerRequestFilter
+UsageGatewayTrustFilter --> UsageServiceProperties
+UsageAnalyticsController --> UsageDashboardService
+UsageAnalyticsController ..> UsageGatewayTrustFilter : ATTR_USER_ID
+UsageDashboardService --> UsageAnalyticsJdbcRepository
+UsageDashboardService --> UsageRecordedLogRepository
+UsageDashboardService --> UsageServiceProperties
+UsageAnalyticsJdbcRepository ..> JdbcTemplate
+```
+
+---
+
+## 6) Usage Service — Rabbit ingestion & persistence
 
 ```mermaid
 classDiagram
@@ -255,10 +221,14 @@ class UsageRecordedLogEntity
 class JpaRepository
 class UsageRabbitConfiguration
 class UsageRabbitProperties
+class UsageJacksonConfiguration
+class ObjectMapper
 class UsageRecordedEvent
 class TokenUsage
 class AiProvider
 
+UsageJacksonConfiguration ..> ObjectMapper
+UsageRecordedEventListener --> ObjectMapper
 UsageRecordedEventListener --> UsageRecordedService
 UsageRecordedEventListener ..> UsageRecordedEvent
 UsageRecordedService --> UsageRecordedLogRepository
@@ -272,9 +242,27 @@ UsageRecordedEvent --> TokenUsage
 UsageRecordedEvent --> AiProvider
 ```
 
-## 6) Web (`apps/web`) — 다이어그램 (팀원 C)
+---
 
-Java 백엔드 절(1–5)과 달리, **Next.js 앱 Mermaid 도식은 `docs/c4-architecture-diagrams.md` 한 곳에만 두고** 디렉터리·BFF·미들웨어가 바뀔 때 그 절(W1–W4)을 갱신한다.
+## 7) Lib — `usage-events` (공유 계약)
+
+```mermaid
+classDiagram
+direction TB
+
+class UsageRecordedEvent
+class TokenUsage
+class AiProvider
+
+UsageRecordedEvent --> TokenUsage
+UsageRecordedEvent --> AiProvider
+```
+
+---
+
+## 8) Web (`apps/web`) — 다이어그램 (팀원 C)
+
+Java 백엔드 절(1–7)과 달리, **Next.js 앱 Mermaid 도식은 `docs/c4-architecture-diagrams.md` 한 곳에만 두고** 디렉터리·BFF·미들웨어가 바뀔 때 그 절(W1–W4)을 갱신한다.
 
 | 구분 | 문서 위치 |
 |------|-----------|

--- a/libs/usage-events/src/main/java/com/eevee/usage/events/UsageRecordedEvent.java
+++ b/libs/usage-events/src/main/java/com/eevee/usage/events/UsageRecordedEvent.java
@@ -24,7 +24,9 @@ public record UsageRecordedEvent(
         BigDecimal estimatedCost,
         String requestPath,
         String upstreamHost,
-        Boolean streaming
+        Boolean streaming,
+        Boolean requestSuccessful,
+        Integer upstreamStatusCode
 ) {
     public UsageRecordedEvent {
         if (eventId == null) {
@@ -32,6 +34,9 @@ public record UsageRecordedEvent(
         }
         if (occurredAt == null) {
             occurredAt = Instant.now();
+        }
+        if (requestSuccessful == null) {
+            requestSuccessful = Boolean.TRUE;
         }
     }
 }

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/config/SecurityConfiguration.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/config/SecurityConfiguration.java
@@ -26,6 +26,7 @@ public class SecurityConfiguration {
             http.authorizeExchange(ex -> ex
                     .pathMatchers("/actuator/health", "/actuator/info").permitAll()
                     .pathMatchers("/api/v1/ai/**").permitAll()
+                    .pathMatchers("/api/v1/usage/**").permitAll()
                     .anyExchange().denyAll()
             );
         } else {
@@ -37,6 +38,7 @@ public class SecurityConfiguration {
             http.authorizeExchange(ex -> ex
                     .pathMatchers("/actuator/health", "/actuator/info").permitAll()
                     .pathMatchers("/api/v1/ai/**").authenticated()
+                    .pathMatchers("/api/v1/usage/**").authenticated()
                     .anyExchange().denyAll()
             );
         }

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersGatewayFilter.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersGatewayFilter.java
@@ -17,7 +17,7 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 /**
- * After security, attaches {@code X-User-Id}, optional org/team, and {@code X-Gateway-Auth} for Proxy.
+ * After security, attaches {@code X-User-Id}, optional org/team, and {@code X-Gateway-Auth} for Proxy and Usage HTTP.
  * See {@code docs/contracts/gateway-proxy.md}.
  */
 @Component
@@ -38,7 +38,7 @@ public class ProxyTrustHeadersGatewayFilter implements GlobalFilter, Ordered {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         String path = exchange.getRequest().getPath().value();
-        if (!path.startsWith("/api/v1/ai/")) {
+        if (!requiresGatewayTrustHeaders(path)) {
             return chain.filter(exchange);
         }
         return ReactiveSecurityContextHolder.getContext()
@@ -108,5 +108,9 @@ public class ProxyTrustHeadersGatewayFilter implements GlobalFilter, Ordered {
     @Override
     public int getOrder() {
         return Ordered.HIGHEST_PRECEDENCE + 1000;
+    }
+
+    static boolean requiresGatewayTrustHeaders(String path) {
+        return path.startsWith("/api/v1/ai/") || path.startsWith("/api/v1/usage/");
     }
 }

--- a/services/api-gateway-service/src/main/resources/application.yml
+++ b/services/api-gateway-service/src/main/resources/application.yml
@@ -18,6 +18,14 @@ spring:
                 - RemoveRequestHeader=Authorization
                 - RewritePath=/api/v1/ai/(?<segment>.*), /proxy/${segment}
 
+            # Usage HTTP (dashboard / analytics REST). Path unchanged downstream.
+            - id: usage-http
+              uri: ${GATEWAY_USAGE_URI:http://localhost:8092}
+              predicates:
+                - Path=/api/v1/usage/**
+              filters:
+                - RemoveRequestHeader=Authorization
+
 management:
   endpoints:
     web:

--- a/services/proxy-service/src/main/java/com/eevee/proxyservice/relay/ProxyRelayService.java
+++ b/services/proxy-service/src/main/java/com/eevee/proxyservice/relay/ProxyRelayService.java
@@ -1,6 +1,5 @@
 package com.eevee.proxyservice.relay;
 
-import com.eevee.proxyservice.config.ProxyProperties;
 import com.eevee.proxyservice.key.ApiKeyClient;
 import com.eevee.proxyservice.mq.UsageEventPublisher;
 import com.eevee.proxyservice.provider.ProviderHandler;
@@ -142,7 +141,7 @@ public class ProxyRelayService {
                     })
                     .doOnComplete(() -> {
                         TokenUsage u = handler.parseUsageFromSse(acc.toString());
-                        publishUsage(ctx, provider, requestPath, u, upstreamHost, true).subscribe();
+                        publishUsage(ctx, provider, requestPath, u, upstreamHost, true, status).subscribe();
                     });
             return Mono.just(ResponseEntity.status(status).headers(responseHeaders).body(body));
         }
@@ -154,7 +153,7 @@ public class ProxyRelayService {
                     TokenUsage u = handler.parseUsageFromResponseJson(bodyStr);
                     byte[] bytes = bodyStr.getBytes(StandardCharsets.UTF_8);
                     Flux<DataBuffer> flux = Flux.just(bufferFactory.wrap(bytes));
-                    return publishUsage(ctx, provider, requestPath, u, safeHost(requestUri), false)
+                    return publishUsage(ctx, provider, requestPath, u, safeHost(requestUri), false, status)
                             .thenReturn(ResponseEntity.status(status).headers(responseHeaders).body(flux));
                 });
     }
@@ -180,8 +179,11 @@ public class ProxyRelayService {
             String requestPath,
             TokenUsage usage,
             String upstreamHost,
-            boolean streaming
+            boolean streaming,
+            HttpStatusCode upstreamStatus
     ) {
+        boolean successful = upstreamStatus.is2xxSuccessful();
+        Integer statusCode = upstreamStatus.value();
         UsageRecordedEvent event = new UsageRecordedEvent(
                 null,
                 null,
@@ -195,7 +197,9 @@ public class ProxyRelayService {
                 BigDecimal.ZERO,
                 requestPath,
                 upstreamHost,
-                streaming
+                streaming,
+                successful,
+                statusCode
         );
         return usageEventPublisher.publish(event);
     }

--- a/services/usage-service/src/main/java/com/eevee/usageservice/UsageServiceApplication.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/UsageServiceApplication.java
@@ -1,14 +1,15 @@
 package com.eevee.usageservice;
 
 import com.eevee.usageservice.config.UsageRabbitProperties;
+import com.eevee.usageservice.config.UsageServiceProperties;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 
 @SpringBootApplication
 @EnableRabbit
-@EnableConfigurationProperties(UsageRabbitProperties.class)
+@EnableConfigurationProperties({UsageRabbitProperties.class, UsageServiceProperties.class})
 public class UsageServiceApplication {
 
     public static void main(String[] args) {

--- a/services/usage-service/src/main/java/com/eevee/usageservice/api/UsageAnalyticsController.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/api/UsageAnalyticsController.java
@@ -1,0 +1,92 @@
+package com.eevee.usageservice.api;
+
+import com.eevee.usage.events.AiProvider;
+import com.eevee.usageservice.api.dto.DailyUsagePoint;
+import com.eevee.usageservice.api.dto.ModelUsageAggregate;
+import com.eevee.usageservice.api.dto.MonthlyUsagePoint;
+import com.eevee.usageservice.api.dto.PagedLogsResponse;
+import com.eevee.usageservice.api.dto.UsageSummaryResponse;
+import com.eevee.usageservice.security.UsageGatewayTrustFilter;
+import com.eevee.usageservice.service.UsageDashboardService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/usage")
+public class UsageAnalyticsController {
+
+    private final UsageDashboardService dashboardService;
+
+    public UsageAnalyticsController(UsageDashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping("/dashboard/summary")
+    public UsageSummaryResponse summary(
+            HttpServletRequest request,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
+    ) {
+        String userId = currentUser(request);
+        return dashboardService.summary(userId, from, to);
+    }
+
+    @GetMapping("/dashboard/series/daily")
+    public List<DailyUsagePoint> daily(
+            HttpServletRequest request,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
+    ) {
+        String userId = currentUser(request);
+        return dashboardService.dailySeries(userId, from, to);
+    }
+
+    @GetMapping("/dashboard/series/monthly")
+    public List<MonthlyUsagePoint> monthly(
+            HttpServletRequest request,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
+    ) {
+        String userId = currentUser(request);
+        return dashboardService.monthlySeries(userId, from, to);
+    }
+
+    @GetMapping("/dashboard/by-model")
+    public List<ModelUsageAggregate> byModel(
+            HttpServletRequest request,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
+    ) {
+        String userId = currentUser(request);
+        return dashboardService.byModel(userId, from, to);
+    }
+
+    @GetMapping("/logs")
+    public PagedLogsResponse logs(
+            HttpServletRequest request,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) AiProvider provider,
+            @RequestParam(required = false) String model,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        String userId = currentUser(request);
+        return dashboardService.logs(userId, from, to, provider, model, page, size);
+    }
+
+    private static String currentUser(HttpServletRequest request) {
+        Object v = request.getAttribute(UsageGatewayTrustFilter.ATTR_USER_ID);
+        if (v instanceof String s && !s.isBlank()) {
+            return s;
+        }
+        throw new IllegalStateException("Missing authenticated user");
+    }
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/DailyUsagePoint.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/DailyUsagePoint.java
@@ -1,0 +1,13 @@
+package com.eevee.usageservice.api.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record DailyUsagePoint(
+        LocalDate date,
+        long requestCount,
+        long errorCount,
+        long inputTokens,
+        BigDecimal estimatedCost
+) {
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/ModelUsageAggregate.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/ModelUsageAggregate.java
@@ -1,0 +1,9 @@
+package com.eevee.usageservice.api.dto;
+
+public record ModelUsageAggregate(
+        String model,
+        String provider,
+        long requestCount,
+        long inputTokens
+) {
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/MonthlyUsagePoint.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/MonthlyUsagePoint.java
@@ -1,0 +1,12 @@
+package com.eevee.usageservice.api.dto;
+
+import java.math.BigDecimal;
+
+public record MonthlyUsagePoint(
+        String yearMonth,
+        long requestCount,
+        long errorCount,
+        long inputTokens,
+        BigDecimal estimatedCost
+) {
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/PagedLogsResponse.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/PagedLogsResponse.java
@@ -1,0 +1,12 @@
+package com.eevee.usageservice.api.dto;
+
+import java.util.List;
+
+public record PagedLogsResponse(
+        List<UsageLogEntryResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/UsageLogEntryResponse.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/UsageLogEntryResponse.java
@@ -1,0 +1,23 @@
+package com.eevee.usageservice.api.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record UsageLogEntryResponse(
+        UUID eventId,
+        Instant occurredAt,
+        String correlationId,
+        String provider,
+        String model,
+        Long promptTokens,
+        Long completionTokens,
+        Long totalTokens,
+        BigDecimal estimatedCost,
+        String requestPath,
+        String upstreamHost,
+        Boolean streaming,
+        boolean requestSuccessful,
+        Integer upstreamStatusCode
+) {
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/UsageSummaryResponse.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/api/dto/UsageSummaryResponse.java
@@ -1,0 +1,11 @@
+package com.eevee.usageservice.api.dto;
+
+import java.math.BigDecimal;
+
+public record UsageSummaryResponse(
+        long totalRequests,
+        long totalErrors,
+        long totalInputTokens,
+        BigDecimal totalEstimatedCost
+) {
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/config/UsageServiceProperties.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/config/UsageServiceProperties.java
@@ -1,0 +1,42 @@
+package com.eevee.usageservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "usage")
+public class UsageServiceProperties {
+
+    private final Analytics analytics = new Analytics();
+    private final Gateway gateway = new Gateway();
+
+    public Analytics getAnalytics() {
+        return analytics;
+    }
+
+    public Gateway getGateway() {
+        return gateway;
+    }
+
+    public static class Analytics {
+        private int maxRangeDays = 400;
+
+        public int getMaxRangeDays() {
+            return maxRangeDays;
+        }
+
+        public void setMaxRangeDays(int maxRangeDays) {
+            this.maxRangeDays = maxRangeDays;
+        }
+    }
+
+    public static class Gateway {
+        private String sharedSecret = "";
+
+        public String getSharedSecret() {
+            return sharedSecret;
+        }
+
+        public void setSharedSecret(String sharedSecret) {
+            this.sharedSecret = sharedSecret;
+        }
+    }
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/domain/UsageRecordedLogEntity.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/domain/UsageRecordedLogEntity.java
@@ -12,9 +12,6 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
-/**
- * Persists {@link com.eevee.usage.events.UsageRecordedEvent} for authoritative usage ledger (pattern A).
- */
 @Entity
 @Table(name = "usage_recorded_log")
 public class UsageRecordedLogEntity {
@@ -56,6 +53,12 @@ public class UsageRecordedLogEntity {
 
     private Boolean streaming;
 
+    @Column(name = "request_successful", nullable = false)
+    private boolean requestSuccessful = true;
+
+    @Column(name = "upstream_status_code")
+    private Integer upstreamStatusCode;
+
     @Column(nullable = false)
     private Instant persistedAt;
 
@@ -78,6 +81,8 @@ public class UsageRecordedLogEntity {
             String requestPath,
             String upstreamHost,
             Boolean streaming,
+            boolean requestSuccessful,
+            Integer upstreamStatusCode,
             Instant persistedAt
     ) {
         this.eventId = eventId;
@@ -95,10 +100,27 @@ public class UsageRecordedLogEntity {
         this.requestPath = requestPath;
         this.upstreamHost = upstreamHost;
         this.streaming = streaming;
+        this.requestSuccessful = requestSuccessful;
+        this.upstreamStatusCode = upstreamStatusCode;
         this.persistedAt = persistedAt;
     }
 
-    public UUID getEventId() {
-        return eventId;
-    }
+    public UUID getEventId() { return eventId; }
+    public Instant getOccurredAt() { return occurredAt; }
+    public String getCorrelationId() { return correlationId; }
+    public String getUserId() { return userId; }
+    public String getOrganizationId() { return organizationId; }
+    public String getTeamId() { return teamId; }
+    public AiProvider getProvider() { return provider; }
+    public String getModel() { return model; }
+    public Long getPromptTokens() { return promptTokens; }
+    public Long getCompletionTokens() { return completionTokens; }
+    public Long getTotalTokens() { return totalTokens; }
+    public BigDecimal getEstimatedCost() { return estimatedCost; }
+    public String getRequestPath() { return requestPath; }
+    public String getUpstreamHost() { return upstreamHost; }
+    public Boolean getStreaming() { return streaming; }
+    public boolean isRequestSuccessful() { return requestSuccessful; }
+    public Integer getUpstreamStatusCode() { return upstreamStatusCode; }
+    public Instant getPersistedAt() { return persistedAt; }
 }

--- a/services/usage-service/src/main/java/com/eevee/usageservice/exception/UsageApiExceptionHandler.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/exception/UsageApiExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.eevee.usageservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class UsageApiExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> badRequest(IllegalArgumentException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("error", "bad_request", "message", ex.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Map<String, String>> illegalState(IllegalStateException ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", "internal_error", "message", ex.getMessage()));
+    }
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/repository/UsageRecordedLogRepository.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/repository/UsageRecordedLogRepository.java
@@ -1,11 +1,45 @@
 package com.eevee.usageservice.repository;
 
+import com.eevee.usage.events.AiProvider;
 import com.eevee.usageservice.domain.UsageRecordedLogEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.UUID;
 
 public interface UsageRecordedLogRepository extends JpaRepository<UsageRecordedLogEntity, UUID> {
 
     boolean existsByEventId(UUID eventId);
+
+    @Query(
+            value = """
+                    select u from UsageRecordedLogEntity u
+                    where u.userId = :userId
+                    and u.occurredAt >= :from
+                    and u.occurredAt < :toExclusive
+                    and (:provider is null or u.provider = :provider)
+                    and (:modelMask is null or :modelMask = '' or lower(coalesce(u.model, '')) like lower(concat('%', :modelMask, '%')))
+                    order by u.occurredAt desc
+                    """,
+            countQuery = """
+                    select count(u) from UsageRecordedLogEntity u
+                    where u.userId = :userId
+                    and u.occurredAt >= :from
+                    and u.occurredAt < :toExclusive
+                    and (:provider is null or u.provider = :provider)
+                    and (:modelMask is null or :modelMask = '' or lower(coalesce(u.model, '')) like lower(concat('%', :modelMask, '%')))
+                    """
+    )
+    Page<UsageRecordedLogEntity> pageLogs(
+            @Param("userId") String userId,
+            @Param("from") Instant from,
+            @Param("toExclusive") Instant toExclusive,
+            @Param("provider") AiProvider provider,
+            @Param("modelMask") String modelMask,
+            Pageable pageable
+    );
 }

--- a/services/usage-service/src/main/java/com/eevee/usageservice/repository/analytics/UsageAnalyticsJdbcRepository.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/repository/analytics/UsageAnalyticsJdbcRepository.java
@@ -1,0 +1,131 @@
+package com.eevee.usageservice.repository.analytics;
+
+import com.eevee.usageservice.api.dto.DailyUsagePoint;
+import com.eevee.usageservice.api.dto.ModelUsageAggregate;
+import com.eevee.usageservice.api.dto.MonthlyUsagePoint;
+import com.eevee.usageservice.api.dto.UsageSummaryResponse;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public class UsageAnalyticsJdbcRepository {
+
+    private static final String ERR_PRED = "(NOT request_successful OR (upstream_status_code IS NOT NULL AND upstream_status_code >= 400))";
+
+    private final JdbcTemplate jdbc;
+
+    public UsageAnalyticsJdbcRepository(JdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    public UsageSummaryResponse aggregateSummary(String userId, Instant from, Instant toExclusive) {
+        String sql = """
+                SELECT COUNT(*)::bigint,
+                       COALESCE(SUM(CASE WHEN %s THEN 1 ELSE 0 END), 0)::bigint,
+                       COALESCE(SUM(prompt_tokens), 0)::bigint,
+                       COALESCE(SUM(estimated_cost), 0)
+                FROM usage_recorded_log
+                WHERE user_id = ? AND occurred_at >= ? AND occurred_at < ?
+                """.formatted(ERR_PRED);
+        return jdbc.queryForObject(
+                sql,
+                (rs, rowNum) -> new UsageSummaryResponse(
+                        rs.getLong(1),
+                        rs.getLong(2),
+                        rs.getLong(3),
+                        rs.getBigDecimal(4) != null ? rs.getBigDecimal(4) : BigDecimal.ZERO
+                ),
+                userId,
+                Timestamp.from(from),
+                Timestamp.from(toExclusive)
+        );
+    }
+
+    public List<DailyUsagePoint> aggregateDaily(String userId, Instant from, Instant toExclusive) {
+        String sql = """
+                SELECT (occurred_at AT TIME ZONE 'UTC')::date AS d,
+                       COUNT(*)::bigint,
+                       COALESCE(SUM(CASE WHEN %s THEN 1 ELSE 0 END), 0)::bigint,
+                       COALESCE(SUM(prompt_tokens), 0)::bigint,
+                       COALESCE(SUM(estimated_cost), 0)
+                FROM usage_recorded_log
+                WHERE user_id = ? AND occurred_at >= ? AND occurred_at < ?
+                GROUP BY (occurred_at AT TIME ZONE 'UTC')::date
+                ORDER BY d
+                """.formatted(ERR_PRED);
+        return jdbc.query(
+                sql,
+                (rs, rowNum) -> {
+                    LocalDate day = rs.getDate("d").toLocalDate();
+                    return new DailyUsagePoint(
+                            day,
+                            rs.getLong(2),
+                            rs.getLong(3),
+                            rs.getLong(4),
+                            rs.getBigDecimal(5) != null ? rs.getBigDecimal(5) : BigDecimal.ZERO
+                    );
+                },
+                userId,
+                Timestamp.from(from),
+                Timestamp.from(toExclusive)
+        );
+    }
+
+    public List<MonthlyUsagePoint> aggregateMonthly(String userId, Instant from, Instant toExclusive) {
+        String sql = """
+                SELECT to_char((occurred_at AT TIME ZONE 'UTC'), 'YYYY-MM') AS ym,
+                       COUNT(*)::bigint,
+                       COALESCE(SUM(CASE WHEN %s THEN 1 ELSE 0 END), 0)::bigint,
+                       COALESCE(SUM(prompt_tokens), 0)::bigint,
+                       COALESCE(SUM(estimated_cost), 0)
+                FROM usage_recorded_log
+                WHERE user_id = ? AND occurred_at >= ? AND occurred_at < ?
+                GROUP BY to_char((occurred_at AT TIME ZONE 'UTC'), 'YYYY-MM')
+                ORDER BY ym
+                """.formatted(ERR_PRED);
+        return jdbc.query(
+                sql,
+                (rs, rowNum) -> new MonthlyUsagePoint(
+                        rs.getString("ym"),
+                        rs.getLong(2),
+                        rs.getLong(3),
+                        rs.getLong(4),
+                        rs.getBigDecimal(5) != null ? rs.getBigDecimal(5) : BigDecimal.ZERO
+                ),
+                userId,
+                Timestamp.from(from),
+                Timestamp.from(toExclusive)
+        );
+    }
+
+    public List<ModelUsageAggregate> aggregateByModel(String userId, Instant from, Instant toExclusive) {
+        String sql = """
+                SELECT COALESCE(NULLIF(trim(model), ''), '_unknown') AS m,
+                       provider,
+                       COUNT(*)::bigint,
+                       COALESCE(SUM(prompt_tokens), 0)::bigint
+                FROM usage_recorded_log
+                WHERE user_id = ? AND occurred_at >= ? AND occurred_at < ?
+                GROUP BY COALESCE(NULLIF(trim(model), ''), '_unknown'), provider
+                ORDER BY COUNT(*) DESC
+                """;
+        return jdbc.query(
+                sql,
+                (rs, rowNum) -> new ModelUsageAggregate(
+                        rs.getString("m"),
+                        rs.getString("provider"),
+                        rs.getLong(3),
+                        rs.getLong(4)
+                ),
+                userId,
+                Timestamp.from(from),
+                Timestamp.from(toExclusive)
+        );
+    }
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/security/UsageGatewayTrustFilter.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/security/UsageGatewayTrustFilter.java
@@ -1,0 +1,64 @@
+package com.eevee.usageservice.security;
+
+import com.eevee.usageservice.config.UsageServiceProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Trusts {@code X-User-Id} (and optional {@code X-Gateway-Auth}) for requests behind API Gateway.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class UsageGatewayTrustFilter extends OncePerRequestFilter {
+
+    public static final String ATTR_USER_ID = "usage.authenticatedUserId";
+
+    private static final String HDR_USER = "X-User-Id";
+    private static final String HDR_GATEWAY_AUTH = "X-Gateway-Auth";
+
+    private final UsageServiceProperties properties;
+
+    public UsageGatewayTrustFilter(UsageServiceProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path == null || !path.startsWith("/api/v1/usage");
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String expected = properties.getGateway().getSharedSecret();
+        if (StringUtils.hasText(expected)) {
+            String actual = request.getHeader(HDR_GATEWAY_AUTH);
+            if (!expected.equals(actual)) {
+                response.sendError(HttpStatus.FORBIDDEN.value());
+                return;
+            }
+        }
+
+        String userId = request.getHeader(HDR_USER);
+        if (!StringUtils.hasText(userId)) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "Missing X-User-Id");
+            return;
+        }
+        request.setAttribute(ATTR_USER_ID, userId.trim());
+        filterChain.doFilter(request, response);
+    }
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/service/UsageDashboardService.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/service/UsageDashboardService.java
@@ -1,0 +1,136 @@
+package com.eevee.usageservice.service;
+
+import com.eevee.usage.events.AiProvider;
+import com.eevee.usageservice.api.dto.DailyUsagePoint;
+import com.eevee.usageservice.api.dto.ModelUsageAggregate;
+import com.eevee.usageservice.api.dto.MonthlyUsagePoint;
+import com.eevee.usageservice.api.dto.PagedLogsResponse;
+import com.eevee.usageservice.api.dto.UsageLogEntryResponse;
+import com.eevee.usageservice.api.dto.UsageSummaryResponse;
+import com.eevee.usageservice.config.UsageServiceProperties;
+import com.eevee.usageservice.domain.UsageRecordedLogEntity;
+import com.eevee.usageservice.repository.UsageRecordedLogRepository;
+import com.eevee.usageservice.repository.analytics.UsageAnalyticsJdbcRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Service
+public class UsageDashboardService {
+
+    private final UsageAnalyticsJdbcRepository analyticsJdbcRepository;
+    private final UsageRecordedLogRepository logRepository;
+    private final UsageServiceProperties properties;
+
+    public UsageDashboardService(
+            UsageAnalyticsJdbcRepository analyticsJdbcRepository,
+            UsageRecordedLogRepository logRepository,
+            UsageServiceProperties properties
+    ) {
+        this.analyticsJdbcRepository = analyticsJdbcRepository;
+        this.logRepository = logRepository;
+        this.properties = properties;
+    }
+
+    @Transactional(readOnly = true)
+    public UsageSummaryResponse summary(String userId, LocalDate from, LocalDate toInclusive) {
+        Range r = validateRange(from, toInclusive);
+        return analyticsJdbcRepository.aggregateSummary(userId, r.from(), r.toExclusive());
+    }
+
+    @Transactional(readOnly = true)
+    public List<DailyUsagePoint> dailySeries(String userId, LocalDate from, LocalDate toInclusive) {
+        Range r = validateRange(from, toInclusive);
+        return analyticsJdbcRepository.aggregateDaily(userId, r.from(), r.toExclusive());
+    }
+
+    @Transactional(readOnly = true)
+    public List<MonthlyUsagePoint> monthlySeries(String userId, LocalDate from, LocalDate toInclusive) {
+        Range r = validateRange(from, toInclusive);
+        return analyticsJdbcRepository.aggregateMonthly(userId, r.from(), r.toExclusive());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ModelUsageAggregate> byModel(String userId, LocalDate from, LocalDate toInclusive) {
+        Range r = validateRange(from, toInclusive);
+        return analyticsJdbcRepository.aggregateByModel(userId, r.from(), r.toExclusive());
+    }
+
+    @Transactional(readOnly = true)
+    public PagedLogsResponse logs(
+            String userId,
+            LocalDate from,
+            LocalDate toInclusive,
+            AiProvider provider,
+            String modelMask,
+            int page,
+            int size
+    ) {
+        Range r = validateRange(from, toInclusive);
+        int pageIndex = Math.max(0, page);
+        int pageSize = Math.min(200, Math.max(1, size));
+        Page<UsageRecordedLogEntity> p = logRepository.pageLogs(
+                userId,
+                r.from(),
+                r.toExclusive(),
+                provider,
+                modelMask,
+                PageRequest.of(pageIndex, pageSize, Sort.by(Sort.Direction.DESC, "occurredAt"))
+        );
+        List<UsageLogEntryResponse> content = p.getContent().stream().map(UsageDashboardService::toLogDto).toList();
+        return new PagedLogsResponse(
+                content,
+                p.getNumber(),
+                p.getSize(),
+                p.getTotalElements(),
+                p.getTotalPages()
+        );
+    }
+
+    private static UsageLogEntryResponse toLogDto(UsageRecordedLogEntity e) {
+        return new UsageLogEntryResponse(
+                e.getEventId(),
+                e.getOccurredAt(),
+                e.getCorrelationId(),
+                e.getProvider().name(),
+                e.getModel(),
+                e.getPromptTokens(),
+                e.getCompletionTokens(),
+                e.getTotalTokens(),
+                e.getEstimatedCost(),
+                e.getRequestPath(),
+                e.getUpstreamHost(),
+                e.getStreaming(),
+                e.isRequestSuccessful(),
+                e.getUpstreamStatusCode()
+        );
+    }
+
+    private Range validateRange(LocalDate from, LocalDate toInclusive) {
+        if (from == null || toInclusive == null) {
+            throw new IllegalArgumentException("from and to are required");
+        }
+        if (toInclusive.isBefore(from)) {
+            throw new IllegalArgumentException("to must be on or after from");
+        }
+        long days = ChronoUnit.DAYS.between(from, toInclusive) + 1;
+        int max = properties.getAnalytics().getMaxRangeDays();
+        if (days > max) {
+            throw new IllegalArgumentException("Date range too large (max " + max + " days)");
+        }
+        Instant start = from.atStartOfDay(ZoneOffset.UTC).toInstant();
+        Instant toExclusive = toInclusive.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+        return new Range(start, toExclusive);
+    }
+
+    private record Range(Instant from, Instant toExclusive) {
+    }
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/service/UsageRecordedService.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/service/UsageRecordedService.java
@@ -22,9 +22,6 @@ public class UsageRecordedService {
         this.repository = repository;
     }
 
-    /**
-     * Idempotent: duplicate {@code eventId} is ignored (pattern A — safe replays).
-     */
     @Transactional
     public void persist(UsageRecordedEvent event) {
         if (repository.existsByEventId(event.eventId())) {
@@ -50,6 +47,7 @@ public class UsageRecordedService {
             completion = tu.completionTokens();
             total = tu.totalTokens();
         }
+        boolean successful = Boolean.TRUE.equals(event.requestSuccessful());
         return new UsageRecordedLogEntity(
                 event.eventId(),
                 event.occurredAt(),
@@ -66,6 +64,8 @@ public class UsageRecordedService {
                 event.requestPath(),
                 event.upstreamHost(),
                 event.streaming(),
+                successful,
+                event.upstreamStatusCode(),
                 Instant.now()
         );
     }

--- a/services/usage-service/src/main/resources/application.yml
+++ b/services/usage-service/src/main/resources/application.yml
@@ -39,3 +39,7 @@ usage:
     exchange: usage.events
     routing-key: usage.recorded
     queue: usage-service.queue
+  analytics:
+    max-range-days: ${USAGE_ANALYTICS_MAX_RANGE_DAYS:400}
+  gateway:
+    shared-secret: ${USAGE_GATEWAY_SHARED_SECRET:}

--- a/services/usage-service/src/test/java/com/eevee/usageservice/integration/UsageRecordedEventPipelineIntegrationTest.java
+++ b/services/usage-service/src/test/java/com/eevee/usageservice/integration/UsageRecordedEventPipelineIntegrationTest.java
@@ -81,7 +81,9 @@ class UsageRecordedEventPipelineIntegrationTest {
                 BigDecimal.ZERO,
                 "/proxy/openai/v1/chat/completions",
                 "api.openai.com",
-                false
+                false,
+                true,
+                200
         );
 
         String json = objectMapper.writeValueAsString(event);

--- a/services/usage-service/src/test/java/com/eevee/usageservice/json/LegacyUsageRecordedEventJsonTest.java
+++ b/services/usage-service/src/test/java/com/eevee/usageservice/json/LegacyUsageRecordedEventJsonTest.java
@@ -1,0 +1,42 @@
+package com.eevee.usageservice.json;
+
+import com.eevee.usage.events.UsageRecordedEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Older proxy payloads without {@code requestSuccessful} / {@code upstreamStatusCode} must still deserialize.
+ */
+class LegacyUsageRecordedEventJsonTest {
+
+    @Test
+    void jsonWithoutSuccessFields_defaultsRequestSuccessful() throws Exception {
+        String json = """
+                {
+                  "eventId": "11111111-1111-1111-1111-111111111111",
+                  "occurredAt": "2025-06-01T12:00:00Z",
+                  "correlationId": "c",
+                  "userId": "u",
+                  "organizationId": null,
+                  "teamId": null,
+                  "provider": "OPENAI",
+                  "model": "gpt-4o-mini",
+                  "tokenUsage": { "model": "gpt-4o-mini", "promptTokens": 1, "completionTokens": 2, "totalTokens": 3 },
+                  "estimatedCost": 0,
+                  "requestPath": "/proxy/openai/v1/chat/completions",
+                  "upstreamHost": "api.openai.com",
+                  "streaming": false
+                }
+                """;
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        UsageRecordedEvent e = mapper.readValue(json, UsageRecordedEvent.class);
+
+        assertThat(e.requestSuccessful()).isTrue();
+        assertThat(e.upstreamStatusCode()).isNull();
+    }
+}

--- a/services/usage-service/src/test/java/com/eevee/usageservice/json/UsageRecordedEventWireFormatTest.java
+++ b/services/usage-service/src/test/java/com/eevee/usageservice/json/UsageRecordedEventWireFormatTest.java
@@ -40,7 +40,9 @@ class UsageRecordedEventWireFormatTest {
                 new BigDecimal("0.0012"),
                 "/proxy/openai/v1/chat/completions",
                 "api.openai.com",
-                false
+                false,
+                true,
+                200
         );
 
         String json = mapper.writeValueAsString(original);

--- a/services/usage-service/src/test/java/com/eevee/usageservice/service/UsageDashboardServiceTest.java
+++ b/services/usage-service/src/test/java/com/eevee/usageservice/service/UsageDashboardServiceTest.java
@@ -1,0 +1,52 @@
+package com.eevee.usageservice.service;
+
+import com.eevee.usageservice.config.UsageServiceProperties;
+import com.eevee.usageservice.repository.UsageRecordedLogRepository;
+import com.eevee.usageservice.repository.analytics.UsageAnalyticsJdbcRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class UsageDashboardServiceTest {
+
+    @Mock
+    private UsageAnalyticsJdbcRepository analyticsJdbcRepository;
+
+    @Mock
+    private UsageRecordedLogRepository logRepository;
+
+    private final UsageServiceProperties properties = new UsageServiceProperties();
+
+    private UsageDashboardService service;
+
+    @BeforeEach
+    void setUp() {
+        properties.getAnalytics().setMaxRangeDays(10);
+        service = new UsageDashboardService(analyticsJdbcRepository, logRepository, properties);
+    }
+
+    @Test
+    void summary_rejectsInvertedRange() {
+        assertThatThrownBy(() -> service.summary(
+                "user",
+                LocalDate.of(2025, 2, 1),
+                LocalDate.of(2025, 1, 1)
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void summary_rejectsRangeExceedingMax() {
+        assertThatThrownBy(() -> service.summary(
+                "user",
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 1, 20)
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/services/usage-service/src/test/java/com/eevee/usageservice/service/UsageRecordedServiceTest.java
+++ b/services/usage-service/src/test/java/com/eevee/usageservice/service/UsageRecordedServiceTest.java
@@ -47,7 +47,9 @@ class UsageRecordedServiceTest {
                 BigDecimal.ZERO,
                 "/proxy/openai/v1/chat/completions",
                 "api.openai.com",
-                false
+                false,
+                true,
+                200
         );
 
         when(repository.existsByEventId(eventId)).thenReturn(true);
@@ -73,7 +75,9 @@ class UsageRecordedServiceTest {
                 BigDecimal.ZERO,
                 "/proxy/openai/v1/chat/completions",
                 "api.openai.com",
-                false
+                false,
+                true,
+                200
         );
 
         when(repository.existsByEventId(eventId)).thenReturn(false);


### PR DESCRIPTION

## #️⃣ 연관된 이슈
> 없음

## 작업 내용
- **해당 서비스**:  usage-service, api-gateway-service, proxy-service, libs/usage-events, docker-compose / .env.example, docs/class-diagram.md
> class-diagram.md를 현재 Identity·Gateway·Usage·libs 구조에 맞게 갱신
> usage 이벤트·대시보드 관련 테스트 보강(생성자·레거시 JSON·구간 검증)
> docker-compose에 GATEWAY_USAGE_URI 기본값, .env.example에 usage/게이트웨이 힌트
> 게이트웨이에 /api/v1/usage/** 라우트, JWT에서 usage도 authenticated(), 신뢰 헤더 필터 범위에 usage 포함
> usage-service에 대시보드·로그 REST, UsageGatewayTrustFilter, usage.analytics / usage.gateway 설정, 예외 응답
> JDBC 집계·JPA 로그 페이지·UsageDashboardService
> proxy가 업스트림 HTTP status를 usage 이벤트에 반영
> 원장 엔티티에 성공 여부·upstream status 컬럼 및 매핑
> UsageRecordedEvent에 요청 성공·HTTP 상태 필드(없으면 성공으로 간주)
  
## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- 이벤트·원장: UsageRecordedEvent에 성공 여부·업스트림 상태 코드를 추가하고, usage DB 원장에 반영했습니다.  프록시가 실제 업스트림 응답 status를 이벤트에 넣도록 정리했습니다. 
- 집계·API: 일/월/모델별 집계와 기간 요약은 JDBC, 로그 목록은 JPA 페이지. 엔드포인트는 모두 GET, 쿼리 파라미터 from·to(ISO 날짜) 필수; /logs는 provider, model, page, size 선택했습니다. 
- 보안·경로: /api/v1/usage/**는 게이트웨이 뒤에서 JWT 검증(운영) 또는 개발 모드 규칙을 거친 뒤, 게이트웨이가 X-User-Id(및 JWT 클레임 기반 X-Org-Id / X-Team-Id), 선택적으로 공유 시크릿과 함께 **X-Gateway-Auth**를 붙여 usage-service로 전달했습니다.  usage-service는 동일 시크릿(USAGE_GATEWAY_SHARED_SECRET ↔ PROXY_GATEWAY_SHARED_SECRET)이 설정된 경우 X-Gateway-Auth를 검증했습니다. 
- 문서·다이어그램: 클래스 다이어그램을 위 구성요소 기준으로 수정했습니다. 

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [x] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [x] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
> usage 이벤트·대시보드 서비스·레거시 JSON 역직렬화 등 테스트 보강 커밋 포함.
## 리뷰 요구사항 
> API 호출·연결 권장 경로: 브라우저/앱 → API Gateway → usage-service
> 게이트웨이 RemoveRequestHeader=Authorization 이 usage 라우트에도 적용되는지, downstream이 JWT를 다시 요구하지 않는지 확인 부탁드립니다.
> USAGE_GATEWAY_SHARED_SECRET / PROXY_GATEWAY_SHARED_SECRET 정합 및 운영 시 필수 여부
