### PR TITLE
feat: implement secure external api key vault

### DIFF
--- a/docs/identity-auth-api-contract.md
+++ b/docs/identity-auth-api-contract.md
@@ -37,6 +37,7 @@
 | `POST` | `/api/auth/signup`  | 불필요 | 회원가입                     |
 | `POST` | `/api/auth/login`   | 불필요 | 로그인 및 액세스 토큰 발급          |
 | `GET`  | `/api/auth/session` | 필요  | 세션(인증 상태) 확인             |
+| `POST` | `/api/auth/external-keys` | 필요  | 외부 AI API 키 등록 (`provider`, `externalKey`, `alias`) |
 | `POST` | `/api/auth/logout`  | 불필요 | 로그아웃 신호 응답(BFF 쿠키 삭제 유도) |
 
 
@@ -84,7 +85,86 @@
 
 ---
 
-## 6. 로그아웃 계약
+## 6. 외부 API 키 등록 계약
+
+클라이언트가 Gemini 등 **제3자에서 발급받은 API 키 평문**과 **제공자(`provider`)**, **별칭(`alias`)**을 전달하면, 서버는 키 평문을 **AES-256-GCM으로 암호화해 DB에 저장**하고, 응답 본문에는 **평문·암호문을 포함하지 않는다**. 동일 사용자가 동일 `provider`에 대해 동일 키 평문을 중복 등록하면 `409`를 반환한다.
+
+### 6.1 요청
+
+| 항목 | 값 |
+| --- | --- |
+| 메서드 | `POST` |
+| 경로 | `/api/auth/external-keys` |
+| 인증 | 필요 (액세스 토큰, 일반적으로 `Authorization: Bearer <jwt>`) |
+| `Content-Type` | `application/json` |
+
+요청 본문 필드:
+
+| 필드 | 타입 | 필수 | 제약 | 예시 값 |
+| --- | --- | --- | --- | --- |
+| `provider` | string (enum) | 예 | `GEMINI`, `OPENAI`, `ANTHROPIC` 중 하나 | `"GEMINI"` |
+| `externalKey` | string | 예 | 공백만 불가, 최대 4096자 | 제3자가 발급한 비밀 키 |
+| `alias` | string | 예 | 공백만 불가, 최대 100자 | `"데모용 Gemini"` |
+
+요청 본문 예시:
+
+| 항목 | 예시 JSON |
+| --- | --- |
+| Body | `{"provider":"GEMINI","externalKey":"<비밀키>","alias":"데모용 Gemini"}` |
+
+### 6.2 성공 응답 (`201 Created`)
+
+공통 래퍼 `ApiResponse`와 `data` 객체 형태는 아래와 같다. **`data`에 키 평문은 포함되지 않는다.**
+
+| 항목 | 값 |
+| --- | --- |
+| 상태 코드 | `201` |
+| `Cache-Control` | `no-store` (본 서비스는 API 응답 전반에 적용) |
+
+응답 필드 예시:
+
+| 필드 | 타입 | 예시 값 | 설명 |
+| --- | --- | --- | --- |
+| `success` | boolean | `true` | 처리 성공 여부 |
+| `message` | string | `"외부 API 키가 등록되었습니다"` | 사용자에게 보일 메시지 |
+| `data.id` | number | `1` | 등록 레코드 ID |
+| `data.provider` | string | `"GEMINI"` | 제공자 |
+| `data.alias` | string | `"데모용 제미나이 키"` | 별칭 |
+| `data.createdAt` | string | `"2026-03-29T08:05:19.296098200Z"` | 등록 시각(ISO-8601 UTC, 나노초 포함 가능) |
+
+응답 본문 예시:
+
+```json
+{
+  "success": true,
+  "message": "외부 API 키가 등록되었습니다",
+  "data": {
+    "id": 1,
+    "provider": "GEMINI",
+    "alias": "데모용 제미나이 키",
+    "createdAt": "2026-03-29T08:05:19.296098200Z"
+  }
+}
+```
+
+오류 응답 예시 (`success=false`, `data=null`):
+
+| 상황 | 상태 코드 | 예시 JSON |
+| --- | --- | --- |
+| `provider` 누락 | `400` | `{"success":false,"message":"provider는 필수입니다","data":null}` |
+| `externalKey` 누락 | `400` | `{"success":false,"message":"externalKey는 필수입니다","data":null}` |
+| `alias` 누락 | `400` | `{"success":false,"message":"alias는 필수입니다","data":null}` |
+| `provider` 값 불가 | `400` | `{"success":false,"message":"provider 값이 올바르지 않습니다. 허용: GEMINI, OPENAI, ANTHROPIC","data":null}` (또는 본문 형식 오류 메시지) |
+| 사용자당 외부 키 상한 초과 | `400` | `{"success":false,"message":"외부 API 키는 사용자당 최대 5개까지 등록할 수 있습니다","data":null}` |
+| 동일 provider·동일 키 재등록 | `409` | `{"success":false,"message":"이미 등록된 API 키입니다","data":null}` |
+
+### 6.3 캐시 정책
+
+- identity-service는 HTTP 응답에 `Cache-Control: no-store`를 적용한다.
+
+---
+
+## 7. 로그아웃 계약
 
 - `POST /api/auth/logout`은 Stateless 정책에 따라 서버 토큰 무효화를 수행하지 않는다.
 - 대신 BFF가 `access_token` 쿠키를 삭제할 수 있도록 성공 신호를 반환한다.
@@ -92,7 +172,7 @@
 
 ---
 
-## 7. 회원가입 입력 정책
+## 8. 회원가입 입력 정책
 
 - `passwordConfirm`은 필수이며 `password`와 일치해야 한다.
 - 비밀번호 정책:
@@ -103,22 +183,26 @@
 
 ---
 
-## 8. 오류 코드 기준
+## 9. 오류 코드 기준
 
 
 | 상황        | 상태 코드 | 설명                           |
 | --------- | ----- | ---------------------------- |
-| 입력 검증 실패  | `400` | 필드 유효성/정책 위반                 |
+| 입력 검증 실패  | `400` | 필드 유효성/정책 위반 (`provider`·`externalKey`·`alias` 등) |
+| 외부 API 키 개수 초과 | `400` | 사용자당 최대 5개까지 등록 가능        |
 | 로그인 인증 실패 | `401` | 이메일/비밀번호 불일치                 |
+| 보호 API 미인증 | `401` | 액세스 토큰 없음/무효 (`POST /api/auth/external-keys` 등) |
+| 외부 API 키 중복 등록 | `409` | 동일 사용자·동일 키 평문 재등록           |
 | 이메일 중복    | `409` | 회원가입 중복                      |
 | 인증 계약 위반  | `502` | 업스트림/내부 계약 위반(`tokenType` 등) |
 
 
 ---
 
-## 9. 구현 시 주의
+## 10. 구현 시 주의
 
-- 인증 관련 응답은 캐시 금지(`Cache-Control: no-store`)를 유지한다.
+- 인증 관련 응답은 캐시 금지(`Cache-Control: no-store`)를 유지한다(identity-service는 필터로 API 응답 전반에 적용).
 - 인증 실패 응답은 프론트/BFF에서 공통 처리할 수 있도록 코드/본문 일관성을 유지한다.
-- 토큰 원문, 비밀값, 인증 헤더를 로그에 남기지 않는다.
+- 토큰 원문, 비밀값, 인증 헤더, **외부 API 키 평문**을 로그에 남기지 않는다.
+- 외부 API 키 평문은 DB에 저장하지 않으며, AES-256-GCM 암호문만 저장한다. 암호화 재료는 `identity.api-key.encryption.secret` / `IDENTITY_API_KEY_ENCRYPTION_SECRET` 등으로 운영 환경에 안전하게 주입한다.
 

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
@@ -1,0 +1,50 @@
+package com.zerobugfreinds.identity_service.controller;
+
+import com.zerobugfreinds.identity_service.common.ApiResponse;
+import com.zerobugfreinds.identity_service.dto.ExternalApiKeyRegisterRequest;
+import com.zerobugfreinds.identity_service.dto.ExternalApiKeyRegisterResponse;
+import com.zerobugfreinds.identity_service.entity.ExternalApiKeyEntity;
+import com.zerobugfreinds.identity_service.security.IdentityUserPrincipal;
+import com.zerobugfreinds.identity_service.service.ExternalApiKeyService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 외부 AI API 키 등록 HTTP API.
+ */
+@RestController
+@RequestMapping("/api/auth")
+public class ExternalApiKeyController {
+
+	private final ExternalApiKeyService externalApiKeyService;
+
+	public ExternalApiKeyController(ExternalApiKeyService externalApiKeyService) {
+		this.externalApiKeyService = externalApiKeyService;
+	}
+
+	@PostMapping("/external-keys")
+	public ResponseEntity<ApiResponse<ExternalApiKeyRegisterResponse>> register(
+			@AuthenticationPrincipal IdentityUserPrincipal principal,
+			@Valid @RequestBody ExternalApiKeyRegisterRequest request
+	) {
+		ExternalApiKeyEntity saved = externalApiKeyService.register(
+				principal.userId(),
+				request.provider(),
+				request.alias(),
+				request.externalKey()
+		);
+		ExternalApiKeyRegisterResponse data = new ExternalApiKeyRegisterResponse(
+				saved.getId(),
+				saved.getProvider().name(),
+				saved.getKeyAlias(),
+				saved.getCreatedAt()
+		);
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok("외부 API 키가 등록되었습니다", data));
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
@@ -1,11 +1,14 @@
 package com.zerobugfreinds.identity_service.controller;
 
 import com.zerobugfreinds.identity_service.common.ApiResponse;
+import com.zerobugfreinds.identity_service.exception.ApiKeyLimitExceededException;
 import com.zerobugfreinds.identity_service.exception.AuthContractViolationException;
+import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyException;
 import com.zerobugfreinds.identity_service.exception.DuplicateEmailException;
 import com.zerobugfreinds.identity_service.exception.InvalidCredentialsException;
 import com.zerobugfreinds.identity_service.exception.InvalidSignupRequestException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -41,6 +44,18 @@ public class GlobalExceptionHandler {
 		return ApiResponse.fail(ex.getMessage());
 	}
 
+	@ExceptionHandler(ApiKeyLimitExceededException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ApiResponse<Void> handleApiKeyLimitExceeded(ApiKeyLimitExceededException ex) {
+		return ApiResponse.fail(ex.getMessage());
+	}
+
+	@ExceptionHandler(DuplicateExternalApiKeyException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ApiResponse<Void> handleDuplicateExternalApiKey(DuplicateExternalApiKeyException ex) {
+		return ApiResponse.fail(ex.getMessage());
+	}
+
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ApiResponse<Void> handleValidation(MethodArgumentNotValidException ex) {
@@ -49,5 +64,15 @@ public class GlobalExceptionHandler {
 				.map(err -> err.getDefaultMessage())
 				.orElse("입력값이 올바르지 않습니다");
 		return ApiResponse.fail(message);
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ApiResponse<Void> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
+		String detail = ex.getMostSpecificCause().getMessage();
+		if (detail != null && detail.contains("ExternalApiKeyProvider")) {
+			return ApiResponse.fail("provider 값이 올바르지 않습니다. 허용: GEMINI, OPENAI, ANTHROPIC");
+		}
+		return ApiResponse.fail("요청 본문 형식이 올바르지 않습니다");
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/domain/ExternalApiKeyProvider.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/domain/ExternalApiKeyProvider.java
@@ -1,0 +1,10 @@
+package com.zerobugfreinds.identity_service.domain;
+
+/**
+ * 사용자가 등록하는 외부 AI API 제공자.
+ */
+public enum ExternalApiKeyProvider {
+	GEMINI,
+	OPENAI,
+	ANTHROPIC
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ExternalApiKeyRegisterRequest.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ExternalApiKeyRegisterRequest.java
@@ -1,0 +1,26 @@
+package com.zerobugfreinds.identity_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 외부 API 키 등록 요청. JSON 필드명은 {@code provider}, {@code externalKey}, {@code alias}.
+ */
+public record ExternalApiKeyRegisterRequest(
+		@NotNull(message = "provider는 필수입니다")
+		ExternalApiKeyProvider provider,
+
+		@NotBlank(message = "externalKey는 필수입니다")
+		@Size(max = 4096)
+		@JsonProperty("externalKey")
+		String externalKey,
+
+		@NotBlank(message = "alias는 필수입니다")
+		@Size(max = 100)
+		@JsonProperty("alias")
+		String alias
+) {
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ExternalApiKeyRegisterResponse.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ExternalApiKeyRegisterResponse.java
@@ -1,0 +1,16 @@
+package com.zerobugfreinds.identity_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+/**
+ * 등록 성공 시 메타데이터만 반환한다. 키 평문·암호문은 포함하지 않는다.
+ */
+public record ExternalApiKeyRegisterResponse(
+		Long id,
+		String provider,
+		@JsonProperty("alias") String alias,
+		Instant createdAt
+) {
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/ExternalApiKeyEntity.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/ExternalApiKeyEntity.java
@@ -1,0 +1,102 @@
+package com.zerobugfreinds.identity_service.entity;
+
+import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.Instant;
+
+/**
+ * 사용자가 등록한 외부 AI API 키. 실제 키 평문은 DB에 두지 않고 암호문만 저장한다.
+ */
+@Entity
+@Table(
+		name = "external_api_keys",
+		uniqueConstraints = @UniqueConstraint(
+				name = "uk_external_api_keys_user_provider_key_hash",
+				columnNames = {"user_id", "provider", "key_hash"}
+		)
+)
+public class ExternalApiKeyEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "provider", nullable = false, length = 32)
+	private ExternalApiKeyProvider provider;
+
+	@Column(name = "key_alias", nullable = false, length = 100)
+	private String keyAlias;
+
+	@Column(name = "key_hash", nullable = false, length = 64)
+	private String keyHash;
+
+	@Lob
+	@Column(name = "encrypted_key", nullable = false)
+	private String encryptedKey;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	protected ExternalApiKeyEntity() {
+	}
+
+	public static ExternalApiKeyEntity register(
+			Long userId,
+			ExternalApiKeyProvider provider,
+			String keyAlias,
+			String keyHash,
+			String encryptedKey
+	) {
+		ExternalApiKeyEntity entity = new ExternalApiKeyEntity();
+		entity.userId = userId;
+		entity.provider = provider;
+		entity.keyAlias = keyAlias;
+		entity.keyHash = keyHash;
+		entity.encryptedKey = encryptedKey;
+		entity.createdAt = Instant.now();
+		return entity;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Long getUserId() {
+		return userId;
+	}
+
+	public ExternalApiKeyProvider getProvider() {
+		return provider;
+	}
+
+	public String getKeyAlias() {
+		return keyAlias;
+	}
+
+	public String getKeyHash() {
+		return keyHash;
+	}
+
+	public String getEncryptedKey() {
+		return encryptedKey;
+	}
+
+	public Instant getCreatedAt() {
+		return createdAt;
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/exception/ApiKeyLimitExceededException.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/exception/ApiKeyLimitExceededException.java
@@ -1,0 +1,11 @@
+package com.zerobugfreinds.identity_service.exception;
+
+/**
+ * 사용자당 API 키 개수 상한을 초과했을 때 발생하는 예외.
+ */
+public class ApiKeyLimitExceededException extends RuntimeException {
+
+	public ApiKeyLimitExceededException(String message) {
+		super(message);
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/exception/DuplicateExternalApiKeyException.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/exception/DuplicateExternalApiKeyException.java
@@ -1,0 +1,11 @@
+package com.zerobugfreinds.identity_service.exception;
+
+/**
+ * 동일 사용자가 이미 등록한 외부 API 키를 다시 등록하려 할 때.
+ */
+public class DuplicateExternalApiKeyException extends RuntimeException {
+
+	public DuplicateExternalApiKeyException(String message) {
+		super(message);
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
@@ -1,0 +1,15 @@
+package com.zerobugfreinds.identity_service.repository;
+
+import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
+import com.zerobugfreinds.identity_service.entity.ExternalApiKeyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 외부 API 키 영속성.
+ */
+public interface ExternalApiKeyRepository extends JpaRepository<ExternalApiKeyEntity, Long> {
+
+	boolean existsByUserIdAndProviderAndKeyHash(Long userId, ExternalApiKeyProvider provider, String keyHash);
+
+	long countByUserId(Long userId);
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/security/CacheControlNoStoreFilter.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/security/CacheControlNoStoreFilter.java
@@ -1,0 +1,28 @@
+package com.zerobugfreinds.identity_service.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * 모든 HTTP 응답에 {@code Cache-Control: no-store}를 붙인다.
+ */
+@Component
+public class CacheControlNoStoreFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			FilterChain filterChain
+	) throws ServletException, IOException {
+		response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+		filterChain.doFilter(request, response);
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/security/IdentityUserPrincipal.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/security/IdentityUserPrincipal.java
@@ -1,0 +1,14 @@
+package com.zerobugfreinds.identity_service.security;
+
+import org.springframework.security.core.AuthenticatedPrincipal;
+
+/**
+ * JWT 인증 성공 시 SecurityContext 에 담기는 로그인 사용자 정보.
+ */
+public record IdentityUserPrincipal(Long userId, String email, String role) implements AuthenticatedPrincipal {
+
+	@Override
+	public String getName() {
+		return email;
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/security/JwtAuthenticationFilter.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/security/JwtAuthenticationFilter.java
@@ -46,12 +46,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 			try {
 				Claims claims = jwtTokenProvider.validateAndGetClaims(token);
+				Long userId = claimToLong(claims.get("userId"));
 				String email = claims.getSubject();
 				String role = claims.get("role", String.class);
 
+				if (userId == null || email == null || role == null) {
+					SecurityContextHolder.clearContext();
+					log.debug("JWT 클레임이 불완전하여 인증을 설정하지 않습니다");
+					filterChain.doFilter(request, response);
+					return;
+				}
+
+				IdentityUserPrincipal principal = new IdentityUserPrincipal(userId, email, role);
 				UsernamePasswordAuthenticationToken authenticationToken =
 						new UsernamePasswordAuthenticationToken(
-								email,
+								principal,
 								null,
 								List.of(new SimpleGrantedAuthority("ROLE_" + role))
 						);
@@ -65,5 +74,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		}
 
 		filterChain.doFilter(request, response);
+	}
+
+	private static Long claimToLong(Object value) {
+		if (value == null) {
+			return null;
+		}
+		if (value instanceof Number number) {
+			return number.longValue();
+		}
+		return Long.parseLong(value.toString());
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
@@ -1,0 +1,82 @@
+package com.zerobugfreinds.identity_service.service;
+
+import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
+import com.zerobugfreinds.identity_service.entity.ExternalApiKeyEntity;
+import com.zerobugfreinds.identity_service.exception.ApiKeyLimitExceededException;
+import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyException;
+import com.zerobugfreinds.identity_service.repository.ExternalApiKeyRepository;
+import com.zerobugfreinds.identity_service.util.EncryptionUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * 외부 AI API 키 등록.
+ */
+@Service
+public class ExternalApiKeyService {
+
+	private static final Logger log = LoggerFactory.getLogger(ExternalApiKeyService.class);
+
+	private static final int MAX_KEYS_PER_USER = 5;
+
+	private final ExternalApiKeyRepository externalApiKeyRepository;
+	private final EncryptionUtil encryptionUtil;
+
+	public ExternalApiKeyService(ExternalApiKeyRepository externalApiKeyRepository, EncryptionUtil encryptionUtil) {
+		this.externalApiKeyRepository = externalApiKeyRepository;
+		this.encryptionUtil = encryptionUtil;
+	}
+
+	@Transactional
+	public ExternalApiKeyEntity register(Long userId, ExternalApiKeyProvider provider, String alias, String plainKey) {
+		if (userId == null) {
+			throw new IllegalArgumentException("userId는 필수입니다");
+		}
+		if (provider == null) {
+			throw new IllegalArgumentException("provider는 필수입니다");
+		}
+		String trimmedAlias = StringUtils.hasText(alias) ? alias.trim() : "";
+		if (!StringUtils.hasText(trimmedAlias)) {
+			throw new IllegalArgumentException("alias는 필수입니다");
+		}
+		String normalizedKey = StringUtils.hasText(plainKey) ? plainKey.trim() : "";
+		if (!StringUtils.hasText(normalizedKey)) {
+			throw new IllegalArgumentException("externalKey는 필수입니다");
+		}
+
+		long count = externalApiKeyRepository.countByUserId(userId);
+		if (count >= MAX_KEYS_PER_USER) {
+			throw new ApiKeyLimitExceededException(
+					"외부 API 키는 사용자당 최대 " + MAX_KEYS_PER_USER + "개까지 등록할 수 있습니다"
+			);
+		}
+
+		String keyHash = encryptionUtil.sha256HexForUniqueness(provider.name(), normalizedKey);
+		if (externalApiKeyRepository.existsByUserIdAndProviderAndKeyHash(userId, provider, keyHash)) {
+			throw new DuplicateExternalApiKeyException("이미 등록된 API 키입니다");
+		}
+
+		String encrypted = encryptionUtil.encryptAes256Gcm(normalizedKey);
+		ExternalApiKeyEntity entity = ExternalApiKeyEntity.register(
+				userId,
+				provider,
+				trimmedAlias,
+				keyHash,
+				encrypted
+		);
+		ExternalApiKeyEntity saved = externalApiKeyRepository.save(entity);
+
+		log.info(
+				"[AUDIT] external_api_key_registered userId={} provider={} alias={} keyId={}",
+				userId,
+				provider.name(),
+				trimmedAlias,
+				saved.getId()
+		);
+
+		return saved;
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/util/EncryptionUtil.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/util/EncryptionUtil.java
@@ -1,0 +1,77 @@
+package com.zerobugfreinds.identity_service.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HexFormat;
+
+/**
+ * 외부 API 키 평문을 AES-256-GCM으로 암호화하고, 중복 검사용 SHA-256 해시를 만든다.
+ * 평문은 DB에 저장하지 않는다.
+ */
+@Component
+public class EncryptionUtil {
+
+	private static final int GCM_IV_LENGTH = 12;
+	private static final int GCM_TAG_BITS = 128;
+	private static final String AES_GCM = "AES/GCM/NoPadding";
+
+	private final SecretKey aesKey;
+	private final SecureRandom secureRandom = new SecureRandom();
+
+	public EncryptionUtil(@Value("${identity.api-key.encryption.secret}") String encryptionSecret) {
+		this.aesKey = deriveAes256Key(encryptionSecret);
+	}
+
+	/**
+	 * 동일 키 재등록 방지용 SHA-256 해시(16진 문자열). provider·키 평문을 함께 넣어 구분한다.
+	 */
+	public String sha256HexForUniqueness(String providerName, String normalizedPlainKey) {
+		String payload = providerName + "\0" + normalizedPlainKey;
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hash = digest.digest(payload.getBytes(StandardCharsets.UTF_8));
+			return HexFormat.of().formatHex(hash);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 not available", e);
+		}
+	}
+
+	/**
+	 * AES-256-GCM으로 암호화한 뒤 Base64(IV + ciphertext) 문자열로 반환한다.
+	 */
+	public String encryptAes256Gcm(String plainText) {
+		byte[] iv = new byte[GCM_IV_LENGTH];
+		secureRandom.nextBytes(iv);
+		try {
+			Cipher cipher = Cipher.getInstance(AES_GCM);
+			cipher.init(Cipher.ENCRYPT_MODE, aesKey, new GCMParameterSpec(GCM_TAG_BITS, iv));
+			byte[] cipherBytes = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+			ByteBuffer buffer = ByteBuffer.allocate(iv.length + cipherBytes.length);
+			buffer.put(iv);
+			buffer.put(cipherBytes);
+			return java.util.Base64.getEncoder().encodeToString(buffer.array());
+		} catch (Exception e) {
+			throw new IllegalStateException("외부 API 키 암호화에 실패했습니다", e);
+		}
+	}
+
+	private static SecretKey deriveAes256Key(String secret) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] keyBytes = digest.digest(secret.getBytes(StandardCharsets.UTF_8));
+			return new SecretKeySpec(keyBytes, "AES");
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 not available", e);
+		}
+	}
+}

--- a/services/identity-service/src/main/resources/application.properties
+++ b/services/identity-service/src/main/resources/application.properties
@@ -12,3 +12,6 @@ spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 # User 엔티티는 @Column 으로 snake_case 명시; 이후 엔티티 기본 규칙용
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
+
+# 외부 API 키 저장용 AES 키 유도 문자열(운영에서는 IDENTITY_API_KEY_ENCRYPTION_SECRET 등으로 충분히 긴 값 권장)
+identity.api-key.encryption.secret=${IDENTITY_API_KEY_ENCRYPTION_SECRET:change-this-external-api-key-encryption-secret-min-32-chars}

--- a/services/identity-service/src/test/resources/application.properties
+++ b/services/identity-service/src/test/resources/application.properties
@@ -5,3 +5,5 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
+
+identity.api-key.encryption.secret=test-external-api-key-encryption-secret-for-ci-only-32chars


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Ref: (이슈 번호 미연결)
- Related to: #35 (기존 API Key 로직 리팩토링 및 기능 통합)

## 작업 내용
- **해당 서비스**: Identity Service (**Code & Docs**)
- **외부 API 키 보안 수탁(Vault) 기능 구현**: 사용자가 가져온 외부 AI API 키(Gemini 등)를 안전하게 수납하고 관리하는 백엔드 로직을 완벽히 구현했습니다.
- **문서 정식 반영**: `docs/identity-auth-api-contract.md`에 실제 구현된 API 스펙 및 보안 주의사항을 업데이트했습니다.

## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [x] 리팩토링 (`refactor`) - *기존 자체 발급 로직 삭제 및 외부 키 등록 전환*
- [ ] 버그 수정 (`fix`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용 (Implementation Details)

### 1. 보안 중심의 데이터 설계 (Security-First Design)
- **`ExternalApiKeyEntity` 구현**: `external_api_keys` 테이블을 신규 생성하여 유저별 외부 API 키 데이터를 관리합니다.
- **AES-256-GCM 암호화**: `EncryptionUtil`을 통해 실제 API 키를 DB 저장 시점에 암호화 처리하여 기밀성을 확보했습니다.
- **SHA-256 해싱 (`keyHash`)**: 키 평문을 노출하지 않으면서도 DB 수준에서 중복 등록을 원천 차단하기 위해 해시값을 이용한 복합 유니크 인덱스를 적용했습니다.

### 2. API 및 비즈니스 로직
- **`ExternalApiKeyController`**: `POST /api/auth/external-keys` 엔드포인트를 구현하여 프론트엔드/BFF 연동 준비를 마쳤습니다.
- **보안 필터 적용**: `CacheControlNoStoreFilter`를 통해 모든 인증 관련 응답에 `Cache-Control: no-store` 헤더를 강제 적용했습니다.
- **코드 정규화**: 프로젝트 방향성에 맞지 않는 기존 `ApiKey*` 관련 클래스와 엔드포인트를 모두 제거하고 신규 로직으로 통일했습니다.

### 3. 예외 처리 가이드 준수 (Exception Handling)
- **400 (Bad Request)**: 필드 누락, 지원하지 않는 Provider(Enum), 사용자당 키 보유 상한(5개) 초과 시 명확한 에러 메시지 반환.
- **409 (Conflict)**: 해시값 대조를 통해 동일한 API 키 중복 등록 시도 차단.
- **401 (Unauthorized)**: JWT 토큰 만료 또는 미포함 접근에 대한 보안 처리.

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 해당 사항 없음
- [ ] **RabbitMQ**: 해당 사항 없음
- [x] **DB**: 신규 테이블 `external_api_keys` 추가
  - 유니크 제약 조건: `(user_id, provider, key_hash)`

## 📸 스크린샷 / 테스트 결과
- **백엔드 유닛 테스트**: `./gradlew test` 전체 통과 완료.
- **Postman 기능 검증**: 정상 등록(201), 중복 등록 차단(409), 인증 실패(401) 시나리오 테스트 통과.

## 리뷰 요구사항
- **암호화 방식**: `AES-256-GCM`과 `SHA-256`을 결합한 보관 방식이 우리 팀 인프라 보안 기준에 적합한지 확인 부탁드립니다.
- **에러 메시지**: 사용자에게 노출되는 문구(`이미 등록된 API 키입니다` 등)가 적절한지 검토 부탁드립니다.
- **BFF 연동**: 기존 로직 삭제로 인해 민선 언니의 BFF 영역에서 수정이 필요한 부분이 있는지 확인 부탁드립니다.