### PR TITLE
Feature/register api key UI

### DIFF
--- a/apps/web/src/app/api/auth/external-keys/route.test.ts
+++ b/apps/web/src/app/api/auth/external-keys/route.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { POST } from "./route"
+
+function jsonRequest(body: unknown, cookie?: string) {
+  return new Request("http://localhost/api/auth/external-keys", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(cookie ? { cookie } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete process.env.IDENTITY_SERVICE_URL
+})
+
+describe("POST /api/auth/external-keys (route handler)", () => {
+  it("returns 401 when access_token cookie is missing", async () => {
+    const res = await POST(jsonRequest({ provider: "OPENAI", externalKey: "k", alias: "a" }))
+    expect(res.status).toBe(401)
+    const json = (await res.json()) as { success: boolean; data: null }
+    expect(json.success).toBe(false)
+    expect(json.data).toBeNull()
+    expect(res.headers.get("cache-control")).toBe("no-store")
+  })
+
+  it("returns 500 when IDENTITY_SERVICE_URL is missing", async () => {
+    const res = await POST(
+      jsonRequest(
+        { provider: "OPENAI", externalKey: "k", alias: "a" },
+        "access_token=test-token-value"
+      )
+    )
+    expect(res.status).toBe(500)
+    const json = (await res.json()) as { success: boolean; message: string }
+    expect(json.success).toBe(false)
+    expect(json.message).toContain("IDENTITY_SERVICE_URL")
+    expect(res.headers.get("cache-control")).toBe("no-store")
+  })
+
+  it("returns 400 for invalid JSON body", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+    const req = new Request("http://localhost/api/auth/external-keys", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        cookie: "access_token=test-token-value",
+      },
+      body: "{not-json",
+    })
+
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as { success: boolean; data: null }
+    expect(json.success).toBe(false)
+    expect(json.data).toBeNull()
+    expect(res.headers.get("cache-control")).toBe("no-store")
+  })
+
+  it("passes through 201 success payload from identity", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("http://localhost:8080/api/auth/external-keys")
+      expect(init?.method).toBe("POST")
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer test-token-value",
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      })
+      expect(init?.body).toBe(
+        JSON.stringify({ provider: "OPENAI", externalKey: "sk-live", alias: "OpenAI 키 1" })
+      )
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          message: "등록되었습니다",
+          data: {
+            id: 123,
+            provider: "OPENAI",
+            alias: "OpenAI 키 1",
+            createdAt: "2026-03-30T00:00:00Z",
+          },
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } }
+      )
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await POST(
+      jsonRequest(
+        { provider: "OPENAI", externalKey: "sk-live", alias: "OpenAI 키 1" },
+        "access_token=test-token-value"
+      )
+    )
+
+    expect(res.status).toBe(201)
+    const json = (await res.json()) as { success: boolean; data: { id: number } }
+    expect(json.success).toBe(true)
+    expect(json.data.id).toBe(123)
+    expect(res.headers.get("cache-control")).toBe("no-store")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("passes through upstream 400 and safe message", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({ success: false, message: "잘못된 요청입니다", data: null }),
+          { status: 400, headers: { "Content-Type": "application/json" } }
+        )
+      })
+    )
+
+    const res = await POST(
+      jsonRequest(
+        { provider: "OPENAI", externalKey: "sk", alias: "a" },
+        "access_token=test-token-value"
+      )
+    )
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as { success: boolean; message: string; data: null }
+    expect(json.success).toBe(false)
+    expect(json.data).toBeNull()
+    expect(json.message).toContain("요청")
+    expect(res.headers.get("cache-control")).toBe("no-store")
+  })
+
+  it("passes through upstream 409 and safe message", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({ success: false, message: "이미 등록된 키입니다", data: null }),
+          { status: 409, headers: { "Content-Type": "application/json" } }
+        )
+      })
+    )
+
+    const res = await POST(
+      jsonRequest(
+        { provider: "OPENAI", externalKey: "sk", alias: "a" },
+        "access_token=test-token-value"
+      )
+    )
+    expect(res.status).toBe(409)
+    const json = (await res.json()) as { success: boolean; message: string; data: null }
+    expect(json.success).toBe(false)
+    expect(json.data).toBeNull()
+    expect(json.message).toContain("등록")
+    expect(res.headers.get("cache-control")).toBe("no-store")
+  })
+
+  it("returns 502 when Identity is unreachable", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+    vi.stubGlobal("fetch", vi.fn(async () => Promise.reject(new Error("ECONNREFUSED"))))
+
+    const res = await POST(
+      jsonRequest(
+        { provider: "OPENAI", externalKey: "sk", alias: "a" },
+        "access_token=test-token-value"
+      )
+    )
+    expect(res.status).toBe(502)
+    const json = (await res.json()) as { success: boolean; data: null }
+    expect(json.success).toBe(false)
+    expect(json.data).toBeNull()
+    expect(res.headers.get("cache-control")).toBe("no-store")
+  })
+})
+

--- a/apps/web/src/app/api/auth/external-keys/route.ts
+++ b/apps/web/src/app/api/auth/external-keys/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import type { ApiResponse } from "@/lib/api/identity/types"
+
+const ACCESS_TOKEN_COOKIE = "access_token"
+
+function noStoreHeaders() {
+  return { "Cache-Control": "no-store" }
+}
+
+function json<T>(status: number, body: ApiResponse<T>) {
+  return NextResponse.json(body, { status, headers: noStoreHeaders() })
+}
+
+function envIdentityBaseUrl() {
+  const url = process.env.IDENTITY_SERVICE_URL
+  if (!url) return null
+  return url.replace(/\/+$/, "")
+}
+
+/** Cookie 헤더에서 지정 이름의 값을 추출한다 (첫 일치). */
+function getCookieValue(cookieHeader: string | null, name: string): string | null {
+  if (!cookieHeader) return null
+  const prefix = `${name}=`
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim()
+    if (trimmed.startsWith(prefix)) {
+      const value = trimmed.slice(prefix.length)
+      return value.length > 0 ? value : null
+    }
+  }
+  return null
+}
+
+const createExternalKeyRequestSchema = z.object({
+  provider: z.enum(["GEMINI", "OPENAI", "ANTHROPIC"], {
+    message: "provider는 GEMINI/OPENAI/ANTHROPIC 중 하나여야 합니다",
+  }),
+  externalKey: z
+    .string({ message: "externalKey는 문자열이어야 합니다" })
+    .trim()
+    .min(1, "externalKey는 필수입니다"),
+  alias: z.string({ message: "alias는 문자열이어야 합니다" }).trim().min(1, "alias는 필수입니다"),
+})
+
+function getUpstreamMessage(upstreamJson: unknown): string | null {
+  return typeof upstreamJson === "object" &&
+    upstreamJson !== null &&
+    "message" in upstreamJson &&
+    typeof (upstreamJson as { message?: unknown }).message === "string"
+    ? (upstreamJson as { message: string }).message
+    : null
+}
+
+export async function POST(request: Request) {
+  const token = getCookieValue(request.headers.get("cookie"), ACCESS_TOKEN_COOKIE)
+  if (!token) {
+    return json(401, { success: false, message: "로그인이 필요합니다", data: null })
+  }
+
+  const identityBaseUrl = envIdentityBaseUrl()
+  if (!identityBaseUrl) {
+    return json(500, {
+      success: false,
+      message: "서버 설정이 필요합니다 (IDENTITY_SERVICE_URL)",
+      data: null,
+    })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return json(400, { success: false, message: "JSON 형식이 올바르지 않습니다", data: null })
+  }
+
+  const parsed = createExternalKeyRequestSchema.safeParse(payload)
+  if (!parsed.success) {
+    const first = parsed.error.issues[0]
+    return json(400, {
+      success: false,
+      message: first?.message ?? "입력값이 올바르지 않습니다",
+      data: null,
+    })
+  }
+
+  let upstream: Response
+  try {
+    upstream = await fetch(`${identityBaseUrl}/api/auth/external-keys`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(parsed.data),
+    })
+  } catch {
+    return json(502, { success: false, message: "인증 서비스에 연결할 수 없습니다", data: null })
+  }
+
+  let upstreamJson: unknown = null
+  try {
+    upstreamJson = await upstream.json()
+  } catch {
+    upstreamJson = null
+  }
+
+  if (upstream.ok) {
+    // Identity의 ApiResponse를 최대한 유지한다.
+    if (typeof upstreamJson === "object" && upstreamJson !== null) {
+      return NextResponse.json(upstreamJson, { status: upstream.status, headers: noStoreHeaders() })
+    }
+    return json(502, { success: false, message: "응답 형식이 올바르지 않습니다", data: null })
+  }
+
+  const message = getUpstreamMessage(upstreamJson) ?? "요청 처리에 실패했습니다"
+
+  if (upstream.status === 400 || upstream.status === 401 || upstream.status === 409) {
+    return json(upstream.status, { success: false, message, data: null })
+  }
+
+  return json(502, { success: false, message, data: null })
+}
+

--- a/apps/web/src/components/account/account-settings-view.tsx
+++ b/apps/web/src/components/account/account-settings-view.tsx
@@ -5,6 +5,18 @@ import * as React from "react"
 import { apiFetch } from "@/lib/api/client-fetch"
 import type { SessionResponse } from "@/lib/api/identity/types"
 
+type ExternalKeyProvider = "GEMINI" | "OPENAI" | "ANTHROPIC"
+
+function providerLabel(provider: ExternalKeyProvider) {
+  if (provider === "OPENAI") return "OpenAI"
+  if (provider === "GEMINI") return "Gemini"
+  return "Anthropic"
+}
+
+function defaultAlias(provider: ExternalKeyProvider) {
+  return `${providerLabel(provider)} 키 1`
+}
+
 function roleLabel(role: string) {
   if (role === "ADMIN") return "관리자"
   if (role === "USER") return "사용자"
@@ -15,6 +27,15 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
   const [session, setSession] = React.useState<SessionResponse | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+
+  const [provider, setProvider] = React.useState<ExternalKeyProvider>("OPENAI")
+  const [alias, setAlias] = React.useState(() => defaultAlias("OPENAI"))
+  const [externalKey, setExternalKey] = React.useState("")
+  const [aliasTouched, setAliasTouched] = React.useState(false)
+  const [submitLoading, setSubmitLoading] = React.useState(false)
+  const [submitMessage, setSubmitMessage] = React.useState<{ kind: "success" | "error"; text: string } | null>(
+    null
+  )
 
   React.useEffect(() => {
     let cancelled = false
@@ -44,7 +65,63 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
     }
   }, [])
 
+  React.useEffect(() => {
+    if (!aliasTouched || !alias.trim()) setAlias(defaultAlias(provider))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [provider])
+
   const subpath = pathSegments?.length ? pathSegments.join(" / ") : null
+
+  async function onSubmitExternalKey(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (submitLoading) return
+
+    const aliasTrimmed = alias.trim()
+    const externalKeyTrimmed = externalKey.trim()
+
+    if (!aliasTrimmed) {
+      setSubmitMessage({ kind: "error", text: "별칭(alias)은 필수입니다" })
+      return
+    }
+    if (!externalKeyTrimmed) {
+      setSubmitMessage({ kind: "error", text: "외부 API Key는 필수입니다" })
+      return
+    }
+
+    setSubmitLoading(true)
+    setSubmitMessage(null)
+
+    try {
+      const { response, json } = await apiFetch<unknown>(
+        "/api/auth/external-keys",
+        {
+          method: "POST",
+          credentials: "include",
+          cache: "no-store",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            provider,
+            alias: aliasTrimmed,
+            externalKey: externalKeyTrimmed,
+          }),
+        },
+        { authRequired: true }
+      )
+
+      if (response.ok && (json as any)?.success) {
+        setSubmitMessage({ kind: "success", text: (json as any)?.message ?? "등록되었습니다" })
+        setAliasTouched(false)
+        setAlias(defaultAlias(provider))
+      } else {
+        setSubmitMessage({ kind: "error", text: (json as any)?.message ?? "등록에 실패했습니다" })
+      }
+    } catch {
+      setSubmitMessage({ kind: "error", text: "등록에 실패했습니다" })
+    } finally {
+      setExternalKey("")
+      setSubmitLoading(false)
+    }
+  }
 
   return (
     <div className="flex min-h-[40vh] flex-col gap-8 py-4">
@@ -80,6 +157,89 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
             </div>
           </dl>
         ) : null}
+      </section>
+
+      <section className="max-w-lg space-y-3 rounded-lg border border-border bg-card p-5 shadow-sm">
+        <div className="space-y-1">
+          <h2 className="text-sm font-semibold tracking-tight">외부 API Key 등록</h2>
+          <p className="text-sm text-muted-foreground">
+            개인 용도의 외부 Provider 키를 등록합니다. 키 값은 저장되기 전에 서버에서 암호화됩니다.
+          </p>
+        </div>
+
+        <form className="space-y-3" onSubmit={onSubmitExternalKey}>
+          <div className="grid gap-1.5">
+            <label className="text-sm font-medium" htmlFor="external-key-provider">
+              Provider
+            </label>
+            <select
+              id="external-key-provider"
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+              value={provider}
+              onChange={(e) => setProvider(e.target.value as ExternalKeyProvider)}
+              disabled={submitLoading}
+            >
+              <option value="GEMINI">GEMINI</option>
+              <option value="OPENAI">OPENAI</option>
+              <option value="ANTHROPIC">ANTHROPIC</option>
+            </select>
+          </div>
+
+          <div className="grid gap-1.5">
+            <label className="text-sm font-medium" htmlFor="external-key-alias">
+              별칭(alias)
+            </label>
+            <input
+              id="external-key-alias"
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+              value={alias}
+              onChange={(e) => {
+                setAliasTouched(true)
+                setAlias(e.target.value)
+              }}
+              placeholder={defaultAlias(provider)}
+              autoComplete="off"
+              disabled={submitLoading}
+              required
+            />
+          </div>
+
+          <div className="grid gap-1.5">
+            <label className="text-sm font-medium" htmlFor="external-key-value">
+              외부 API Key
+            </label>
+            <input
+              id="external-key-value"
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+              type="password"
+              value={externalKey}
+              onChange={(e) => setExternalKey(e.target.value)}
+              placeholder="키를 입력하세요"
+              autoComplete="off"
+              disabled={submitLoading}
+              required
+            />
+          </div>
+
+          {submitMessage ? (
+            <p className={submitMessage.kind === "success" ? "text-sm text-emerald-600" : "text-sm text-destructive"}>
+              {submitMessage.text}
+            </p>
+          ) : null}
+
+          <div className="flex items-center gap-2">
+            <button
+              type="submit"
+              className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={submitLoading}
+            >
+              {submitLoading ? "등록 중…" : "등록"}
+            </button>
+            <p className="text-xs text-muted-foreground">
+              제출 후에는 보안을 위해 입력한 키 값이 즉시 초기화됩니다.
+            </p>
+          </div>
+        </form>
       </section>
     </div>
   )

--- a/apps/web/src/components/account/account-settings-view.tsx
+++ b/apps/web/src/components/account/account-settings-view.tsx
@@ -3,9 +3,19 @@
 import * as React from "react"
 
 import { apiFetch } from "@/lib/api/client-fetch"
+import type { ApiResponse } from "@/lib/api/identity/types"
 import type { SessionResponse } from "@/lib/api/identity/types"
 
 type ExternalKeyProvider = "GEMINI" | "OPENAI" | "ANTHROPIC"
+
+function asApiResponse(json: unknown): ApiResponse<unknown> | null {
+  if (!json || typeof json !== "object") return null
+  const record = json as Record<string, unknown>
+  if (typeof record.success !== "boolean") return null
+  if (typeof record.message !== "string") return null
+  if (!("data" in record)) return null
+  return record as ApiResponse<unknown>
+}
 
 function providerLabel(provider: ExternalKeyProvider) {
   if (provider === "OPENAI") return "OpenAI"
@@ -108,12 +118,14 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
         { authRequired: true }
       )
 
-      if (response.ok && (json as any)?.success) {
-        setSubmitMessage({ kind: "success", text: (json as any)?.message ?? "등록되었습니다" })
+      const apiResponse = asApiResponse(json)
+
+      if (response.ok && apiResponse?.success) {
+        setSubmitMessage({ kind: "success", text: apiResponse.message || "등록되었습니다" })
         setAliasTouched(false)
         setAlias(defaultAlias(provider))
       } else {
-        setSubmitMessage({ kind: "error", text: (json as any)?.message ?? "등록에 실패했습니다" })
+        setSubmitMessage({ kind: "error", text: apiResponse?.message || "등록에 실패했습니다" })
       }
     } catch {
       setSubmitMessage({ kind: "error", text: "등록에 실패했습니다" })

--- a/apps/web/src/lib/api/identity/external-keys.schema.test.ts
+++ b/apps/web/src/lib/api/identity/external-keys.schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { createExternalKeyRequestSchema } from "./external-keys.schema"
+
+describe("createExternalKeyRequestSchema", () => {
+  it("accepts a valid payload", () => {
+    const parsed = createExternalKeyRequestSchema.safeParse({
+      provider: "OPENAI",
+      externalKey: "sk-test",
+      alias: "OpenAI 키 1",
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it("rejects empty externalKey", () => {
+    const parsed = createExternalKeyRequestSchema.safeParse({
+      provider: "GEMINI",
+      externalKey: "   ",
+      alias: "Gemini 키 1",
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it("rejects empty alias", () => {
+    const parsed = createExternalKeyRequestSchema.safeParse({
+      provider: "ANTHROPIC",
+      externalKey: "test",
+      alias: " ",
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+})

--- a/apps/web/src/lib/api/identity/external-keys.schema.ts
+++ b/apps/web/src/lib/api/identity/external-keys.schema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod"
+
+export const externalKeyProviderSchema = z.enum(["GEMINI", "OPENAI", "ANTHROPIC"], {
+  message: "provider는 GEMINI/OPENAI/ANTHROPIC 중 하나여야 합니다",
+})
+
+export const createExternalKeyRequestSchema = z.object({
+  provider: externalKeyProviderSchema,
+  externalKey: z
+    .string({ message: "externalKey는 문자열이어야 합니다" })
+    .trim()
+    .min(1, "externalKey는 필수입니다"),
+  alias: z.string({ message: "alias는 문자열이어야 합니다" }).trim().min(1, "alias는 필수입니다"),
+})
+
+export type CreateExternalKeyRequestInput = z.infer<typeof createExternalKeyRequestSchema>

--- a/apps/web/src/lib/api/identity/types.ts
+++ b/apps/web/src/lib/api/identity/types.ts
@@ -32,6 +32,22 @@ export type LoginResponse = {
   expiresInSeconds: number
 }
 
+export type ExternalKeyProvider = "GEMINI" | "OPENAI" | "ANTHROPIC"
+
+export type CreateExternalKeyRequest = {
+  provider: ExternalKeyProvider
+  externalKey: string
+  alias: string
+}
+
+/** Identity `POST /api/auth/external-keys`의 `data` 본문과 동기화 */
+export type CreateExternalKeyResponseData = {
+  id: number
+  provider: ExternalKeyProvider
+  alias: string
+  createdAt: string
+}
+
 /** Identity `GET /api/auth/session`의 `data` 본문과 동기화 */
 export type SessionResponse = {
   email: string


### PR DESCRIPTION

## #️⃣ 연관된 이슈
> ex) #이슈번호 등

## 작업 내용
- **해당 서비스**: Web(Next.js, apps/web) + Web BFF(Route Handler)
> 개인(사용자 단위) 외부 API Key 등록 UI를 settings에 추가하고, 웹 BFF POST /api/auth/external-keys를 통해 Identity의 POST /api/auth/external-keys로 안전하게 프록시해 실제 등록까지 동작하도록 연결했습니다.
조직/팀 범위 기능(목록/수정/삭제 포함)은 이번 PR 범위에서 제외했습니다.

  
## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- BFF(Route Handler) 추가: apps/web/src/app/api/auth/external-keys/route.ts
  - 쿠키의 access token을 Bearer로 추출해 Identity POST {IDENTITY_SERVICE_URL}/api/auth/external-keys로 프록시
  - Zod 기반 입력 검증(기존 login/signup 패턴 준수)
  - Cache-Control: no-store 적용
  - 오류 매핑/전달: 400/401/409 및 업스트림 실패(502) 등 상태코드/응답 형식을 최대한 유지
  - 보안: externalKey 평문이 로그/에러 메시지에 포함되지 않도록 처리
  - 웹 스키마/타입 추가: external-keys 요청/응답용 Zod schema 및 타입 추가(기존 login.schema.ts, types.ts 패턴 준수)
- 설정 UI 추가: AccountSettingsView에 “외부 API Key 등록” 섹션 추가
  - provider 선택: GEMINI / OPENAI / ANTHROPIC
  - alias 기본값 자동 생성(예: OpenAI 키 1) + 수정 가능(제출 시 필수)
  - externalKey 입력은 password 타입
  - 성공/실패 메시지 처리, 성공 시 externalKey 입력값 즉시 초기화
- 테스트 추가: apps/web/src/app/api/auth/external-keys/route.test.ts
  - 쿠키 없음(401), IDENTITY_SERVICE_URL 미설정(500), 정상 201 프록시, 업스트림 400/409 전달, 업스트림 실패 502, 잘못된 JSON 400

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- BFF에서 오류 매핑(400/401/409/502)과 ApiResponse 전달 방식이 계약 의도에 맞는지 확인 부탁드립니다.
- UI에서 alias 자동 생성/수정 UX 및 성공 시 externalKey 초기화 처리가 적절한지 확인 부탁드립니다.
