### PR TITLE
Feat: 외부 API 키 조회 API 및 계약 문서 반영

### DIFF
--- a/docs/c4-architecture-diagrams.md
+++ b/docs/c4-architecture-diagrams.md
@@ -404,6 +404,12 @@ sequenceDiagram
   I-->>H: ApiResponse
   H-->>B: 200 or 401
 
+  B->>H: GET /api/auth/external-keys
+  Note over B,H: settings 화면에서 개인 키 목록 조회
+  H->>I: GET external-keys + Bearer
+  I-->>H: 200/401 ApiResponse
+  H-->>B: ApiResponse (no-store)
+
   B->>H: POST /api/auth/external-keys
   Note over B,H: settings 화면에서 개인 키 등록(상태 변경)
   H->>I: POST external-keys + Bearer
@@ -439,7 +445,7 @@ flowchart TB
     RL["POST login"]
     RS["POST signup"]
     RQ["GET session"]
-    RE["POST external-keys"]
+    RE["GET/POST external-keys"]
   end
   subgraph LB["lib"]
     CF["client-fetch"]

--- a/docs/contracts/web-identity-bff.md
+++ b/docs/contracts/web-identity-bff.md
@@ -18,6 +18,7 @@
 |------|-----------------------|-------------------|
 | 회원가입 | `POST /api/auth/signup` | `POST /api/auth/signup` |
 | 로그인 | `POST /api/auth/login` | `POST /api/auth/login` |
+| 외부 API 키 조회(개인) | `GET /api/auth/external-keys` | `GET /api/auth/external-keys` |
 | 외부 API 키 등록(개인) | `POST /api/auth/external-keys` | `POST /api/auth/external-keys` |
 | 세션(로그인 여부 단일 기준) | `GET /api/auth/session` | `GET /api/auth/session` (BFF가 쿠키 JWT를 Bearer로 전달해 프록시) |
 | 로그아웃 | `POST /api/auth/logout` | `POST /api/auth/logout` (선택 프록시; stateless이며 실질 로그아웃은 BFF의 쿠키 삭제) |
@@ -44,7 +45,18 @@
 5. **Identity가 `401` 등으로 거절**하면 상태 코드와 JSON 본문을 **그대로** 프론트에 전달한다(§6).
 6. `IDENTITY_SERVICE_URL` 미설정 등 BFF 설정 오류·업스트림 연결 실패·업스트림 성공 응답이 계약과 맞지 않는 경우 등은 BFF가 `500`/`502` 등으로 처리할 수 있다. 프론트는 `success=false`와 `message`로 사용자 메시지를 구성한다.
 
-### 2.2 `POST /api/auth/external-keys` 동작
+### 2.2 `GET /api/auth/external-keys` 동작
+
+1. 브라우저 → BFF: `GET /api/auth/external-keys`
+2. **`access_token` 쿠키가 없거나 값이 비어 있으면** BFF는 Identity를 호출하지 않고 `401` + `ApiResponse<null>` (`success=false`, `data=null`)로 응답한다.
+3. BFF → Identity: `GET {IDENTITY_SERVICE_URL}/api/auth/external-keys`
+   - `Authorization: Bearer {access_token}`
+   - `Accept: application/json`
+4. **성공 시** Identity의 상태 코드/본문(`ApiResponse`)을 가능한 그대로 전달한다. 응답에는 `Cache-Control: no-store`를 적용한다.
+5. **Identity가 `401` 등으로 거절**하면 상태 코드와 JSON 본문을 **그대로** 프론트에 전달한다(§6).
+6. `IDENTITY_SERVICE_URL` 미설정, 업스트림 연결 실패, 업스트림 응답이 계약과 맞지 않는 경우 등은 BFF가 `500`/`502` 등으로 처리할 수 있다.
+
+### 2.3 `POST /api/auth/external-keys` 동작
 
 1. 브라우저 → BFF: `POST /api/auth/external-keys` (JSON body: `provider`, `externalKey`, `alias`)
 2. BFF: 입력 본문을 Zod로 검증한다(요청 본문이므로 검증 대상).
@@ -156,6 +168,7 @@
 ## 8. 캐시/보안 정책
 
 - 로그인/로그아웃/**`GET /api/auth/session`(세션 체크)** 응답에는 `Cache-Control: no-store`를 적용한다.
+- **`GET /api/auth/external-keys` / `POST /api/auth/external-keys`** 응답에도 `Cache-Control: no-store`를 적용한다.
 - MVP는 **Access Token only**(Refresh Token 미포함)로 운영하고, 만료 시 재로그인한다.
 - CSRF는 MVP에서 `SameSite=Lax + BFF 경유`를 기본으로 하고, **차기 스프린트에서 상태 변경 API는 BFF 경유에 더해 `Origin/Referer` 검증(또는 CSRF 토큰) 적용을 표준으로 한다.**
 
@@ -181,7 +194,7 @@
 - BFF 인증 라우트는 구현 파일 옆에 **Vitest** 스펙을 둔다. 예:
   - `apps/web/src/app/api/auth/session/route.test.ts` — 쿠키 없음·`IDENTITY_SERVICE_URL` 미설정·업스트림 프록시·401·형식 오류·연결 실패 등
   - `apps/web/src/app/api/auth/logout/route.test.ts` — 쿠키 삭제·선택적 업스트림 `POST /api/auth/logout`·업스트림 실패 시에도 쿠키 삭제
-  - `apps/web/src/app/api/auth/external-keys/route.test.ts` — 쿠키 없음·`IDENTITY_SERVICE_URL` 미설정·업스트림 프록시(201)·업스트림 400/409 전달·연결 실패(502)·JSON 파싱 실패 등
+  - `apps/web/src/app/api/auth/external-keys/route.test.ts` — 쿠키 없음·`IDENTITY_SERVICE_URL` 미설정·업스트림 프록시(`GET` 200 / `POST` 201)·업스트림 400/401/409 전달·연결 실패(502)·JSON 파싱 실패 등
   - `login`·`signup` Route Handler도 동일 패턴의 `route.test.ts`로 회귀 검증
   - `apps/web/src/app/api/identity/[[...path]]/route.test.ts` — §5.2 관리 API BFF(쿠키·`v1` 접두·업스트림 프록시)
 - 미들웨어·보호 경로 정합성은 **`apps/web/middleware.test.ts`**, **`apps/web/src/app/protected-routes.test.ts`** (§6.2 유지보수 문구와 동일).

--- a/docs/identity-auth-api-contract.md
+++ b/docs/identity-auth-api-contract.md
@@ -37,6 +37,7 @@
 | `POST` | `/api/auth/signup`  | 불필요 | 회원가입                     |
 | `POST` | `/api/auth/login`   | 불필요 | 로그인 및 액세스 토큰 발급          |
 | `GET`  | `/api/auth/session` | 필요  | 세션(인증 상태) 확인             |
+| `GET`  | `/api/auth/external-keys` | 필요  | 내 외부 AI API 키 목록 조회 (`id`, `provider`, `alias`, `createdAt`) |
 | `POST` | `/api/auth/external-keys` | 필요  | 외부 AI API 키 등록 (`provider`, `externalKey`, `alias`) |
 | `POST` | `/api/auth/logout`  | 불필요 | 로그아웃 신호 응답(BFF 쿠키 삭제 유도) |
 
@@ -92,11 +93,59 @@
 
 ---
 
-## 6. 외부 API 키 등록 계약
+## 6. 외부 API 키 조회 계약
+
+로그인 사용자가 등록한 외부 API 키 메타데이터 목록을 조회한다. 응답에는 **키 평문/암호문이 포함되지 않는다**.
+
+### 6.1 요청
+
+| 항목 | 값 |
+| --- | --- |
+| 메서드 | `GET` |
+| 경로 | `/api/auth/external-keys` |
+| 인증 | 필요 (액세스 토큰, 일반적으로 `Authorization: Bearer <jwt>`) |
+
+### 6.2 성공 응답 (`200 OK`)
+
+| 항목 | 값 |
+| --- | --- |
+| 상태 코드 | `200` |
+| `Cache-Control` | `no-store` (본 서비스는 API 응답 전반에 적용) |
+
+응답 본문 예시:
+
+```json
+{
+  "success": true,
+  "message": "외부 API 키 목록 조회에 성공했습니다",
+  "data": [
+    {
+      "id": 1,
+      "provider": "GEMINI",
+      "alias": "데모용 제미나이 키",
+      "createdAt": "2026-03-29T08:05:19.296098200Z"
+    }
+  ]
+}
+```
+
+오류 응답 예시 (`success=false`, `data=null`):
+
+| 상황 | 상태 코드 | 예시 JSON |
+| --- | --- | --- |
+| 보호 API 미인증 | `401` | `{"success":false,"message":"인증이 필요합니다","data":null}` |
+
+### 6.3 캐시 정책
+
+- identity-service는 HTTP 응답에 `Cache-Control: no-store`를 적용한다.
+
+---
+
+## 7. 외부 API 키 등록 계약
 
 클라이언트가 Gemini 등 **제3자에서 발급받은 API 키 평문**과 **제공자(`provider`)**, **별칭(`alias`)**을 전달하면, 서버는 키 평문을 **AES-256-GCM으로 암호화해 DB에 저장**하고, 응답 본문에는 **평문·암호문을 포함하지 않는다**. 동일 사용자가 동일 `provider`에 대해 동일 키 평문을 중복 등록하면 `409`를 반환한다.
 
-### 6.1 요청
+### 7.1 요청
 
 | 항목 | 값 |
 | --- | --- |
@@ -119,7 +168,7 @@
 | --- | --- |
 | Body | `{"provider":"GEMINI","externalKey":"<비밀키>","alias":"데모용 Gemini"}` |
 
-### 6.2 성공 응답 (`201 Created`)
+### 7.2 성공 응답 (`201 Created`)
 
 공통 래퍼 `ApiResponse`와 `data` 객체 형태는 아래와 같다. **`data`에 키 평문은 포함되지 않는다.**
 
@@ -165,13 +214,13 @@
 | 사용자당 외부 키 상한 초과 | `400` | `{"success":false,"message":"외부 API 키는 사용자당 최대 5개까지 등록할 수 있습니다","data":null}` |
 | 동일 provider·동일 키 재등록 | `409` | `{"success":false,"message":"이미 등록된 API 키입니다","data":null}` |
 
-### 6.3 캐시 정책
+### 7.3 캐시 정책
 
 - identity-service는 HTTP 응답에 `Cache-Control: no-store`를 적용한다.
 
 ---
 
-## 7. 로그아웃 계약
+## 8. 로그아웃 계약
 
 - `POST /api/auth/logout`은 Stateless 정책에 따라 서버 토큰 무효화를 수행하지 않는다.
 - 대신 BFF가 `access_token` 쿠키를 삭제할 수 있도록 성공 신호를 반환한다.
@@ -179,7 +228,7 @@
 
 ---
 
-## 8. 회원가입 입력 정책
+## 9. 회원가입 입력 정책
 
 - `passwordConfirm`은 필수이며 `password`와 일치해야 한다.
 - 비밀번호 정책:
@@ -190,7 +239,7 @@
 
 ---
 
-## 9. 오류 코드 기준
+## 10. 오류 코드 기준
 
 
 | 상황        | 상태 코드 | 설명                           |
@@ -198,7 +247,7 @@
 | 입력 검증 실패  | `400` | 필드 유효성/정책 위반 (`provider`·`externalKey`·`alias` 등) |
 | 외부 API 키 개수 초과 | `400` | 사용자당 최대 5개까지 등록 가능        |
 | 로그인 인증 실패 | `401` | 이메일/비밀번호 불일치                 |
-| 보호 API 미인증 | `401` | 액세스 토큰 없음/무효 (`POST /api/auth/external-keys` 등) |
+| 보호 API 미인증 | `401` | 액세스 토큰 없음/무효 (`GET/POST /api/auth/external-keys` 등) |
 | 외부 API 키 중복 등록 | `409` | 동일 사용자·동일 키 평문 재등록           |
 | 이메일 중복    | `409` | 회원가입 중복                      |
 | 인증 계약 위반  | `502` | 업스트림/내부 계약 위반(`tokenType` 등) |
@@ -206,7 +255,7 @@
 
 ---
 
-## 10. 구현 시 주의
+## 11. 구현 시 주의
 
 - 인증 관련 응답은 캐시 금지(`Cache-Control: no-store`)를 유지한다(identity-service는 필터로 API 응답 전반에 적용).
 - 인증 실패 응답은 프론트/BFF에서 공통 처리할 수 있도록 코드/본문 일관성을 유지한다.

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
@@ -10,10 +10,13 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /**
  * 외부 AI API 키 등록 HTTP API.
@@ -46,5 +49,20 @@ public class ExternalApiKeyController {
 				saved.getCreatedAt()
 		);
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok("외부 API 키가 등록되었습니다", data));
+	}
+
+	@GetMapping("/external-keys")
+	public ResponseEntity<ApiResponse<List<ExternalApiKeyRegisterResponse>>> getMyKeys(
+			@AuthenticationPrincipal IdentityUserPrincipal principal
+	) {
+		List<ExternalApiKeyRegisterResponse> data = externalApiKeyService.getMyKeys(principal.userId()).stream()
+				.map(key -> new ExternalApiKeyRegisterResponse(
+						key.getId(),
+						key.getProvider().name(),
+						key.getKeyAlias(),
+						key.getCreatedAt()
+				))
+				.toList();
+		return ResponseEntity.ok(ApiResponse.ok("외부 API 키 목록 조회에 성공했습니다", data));
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
@@ -12,4 +12,6 @@ public interface ExternalApiKeyRepository extends JpaRepository<ExternalApiKeyEn
 	boolean existsByUserIdAndProviderAndKeyHash(Long userId, ExternalApiKeyProvider provider, String keyHash);
 
 	long countByUserId(Long userId);
+
+	java.util.List<ExternalApiKeyEntity> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
@@ -79,4 +79,12 @@ public class ExternalApiKeyService {
 
 		return saved;
 	}
+
+	@Transactional(readOnly = true)
+	public java.util.List<ExternalApiKeyEntity> getMyKeys(Long userId) {
+		if (userId == null) {
+			throw new IllegalArgumentException("userId는 필수입니다");
+		}
+		return externalApiKeyRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Ref: (이슈 번호 미연결)
- 필요 시 `Related to: #<번호>` 추가 예정

## 작업 내용
- **해당 서비스**: Identity Service / Docs (BFF 계약 연동)
- 대시보드에서 사용자별 API 키 메타데이터를 조회할 수 있도록 `GET /api/auth/external-keys`를 추가했습니다.
- 기존 `POST /api/auth/external-keys`(등록)와 함께 조회/등록 계약이 문서 전반에서 일관되도록 연계 문서를 동기화했습니다.

## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`) (계약 문서 정합성 보강)

## 📝 상세 내용
- `identity-service` 조회 API 추가
  - `GET /api/auth/external-keys` (인증 필요)
  - 로그인 사용자 기준으로 외부 API 키 목록을 최신순 반환
  - 응답은 기존 공통 포맷 `ApiResponse` 사용
  - 반환 데이터는 메타데이터(`id`, `provider`, `alias`, `createdAt`)만 포함하며 키 평문/암호문은 미노출
- 코드 변경
  - `ExternalApiKeyController`: 조회 엔드포인트 추가
  - `ExternalApiKeyService`: `getMyKeys(userId)` 추가
  - `ExternalApiKeyRepository`: `findAllByUserIdOrderByCreatedAtDesc` 추가
- 문서 동기화
  - `docs/identity-auth-api-contract.md`
    - 조회 계약(`GET /api/auth/external-keys`) 추가
    - 등록/조회 섹션 재정렬 및 오류 코드 설명 보강
  - `docs/contracts/web-identity-bff.md`
    - BFF 엔드포인트 표에 조회 추가
    - 조회/등록 동작 섹션 분리
    - `no-store` 정책을 GET/POST external-keys까지 명시
  - `docs/c4-architecture-diagrams.md`
    - W2 시퀀스에 조회 흐름(`Browser -> BFF -> Identity`) 추가
    - W3 라벨을 `GET/POST external-keys`로 확장

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부 (없음)
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부 (없음)
- [x] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부
  - 신규 테이블/컬럼 변경은 없음
  - 기존 `external_api_keys` 읽기 조회 경로만 추가

## 📸 스크린샷 / 테스트 결과 (선택)
- 백엔드 테스트:
  - [x] `cd services/identity-service && ./gradlew test` 통과
- 수동 확인(권장):
  - [ ] 로그인 후 `GET /api/auth/external-keys`에서 목록 반환 확인
  - [ ] 토큰 없이 조회 시 `401` 및 공통 에러 응답 확인
  - [ ] `POST` 등록 후 `GET` 조회에서 동일 사용자 키 메타데이터 노출 확인

## 리뷰 요구사항
- `GET /api/auth/external-keys` 응답 스키마(`ApiResponse<List<ExternalApiKeyRegisterResponse>>`)가 프론트/BFF 소비 형태와 맞는지 확인 부탁드립니다.
- 조회 API에서 `createdAt` 정렬(최신순) 및 메시지 문구가 팀 컨벤션과 맞는지 확인 부탁드립니다.
- 문서 3종(`identity-auth-api-contract`, `web-identity-bff`, `c4-architecture-diagrams`) 간 링크/흐름 정합성 위주로 검토 부탁드립니다.