### PR TITLE
Fix: add external key update API and split duplicate errors

### DIFF
--- a/docs/contracts/web-identity-bff.md
+++ b/docs/contracts/web-identity-bff.md
@@ -1,6 +1,6 @@
 # Web(Next.js) ↔ Identity 인증 BFF 계약
 
-버전: 1.6  
+버전: 1.7  
 관련: [docs/architecture.md](../architecture.md) §1.3, §3.3, [Identity 인증 API 계약](../identity-auth-api-contract.md), [Web·Gateway Usage BFF](./web-gateway-bff.md)(`/api/usage/**` 호출 맵), [저장소 구조](../repository-structure.md) §6
 
 ---
@@ -20,6 +20,7 @@
 | 로그인 | `POST /api/auth/login` | `POST /api/auth/login` |
 | 외부 API 키 조회(개인) | `GET /api/auth/external-keys` | `GET /api/auth/external-keys` |
 | 외부 API 키 등록(개인) | `POST /api/auth/external-keys` | `POST /api/auth/external-keys` |
+| 외부 API 키 수정(개인) | 미지원 (현재 BFF 미구현) | `PUT /api/auth/external-keys/{id}` |
 | 세션(로그인 여부 단일 기준) | `GET /api/auth/session` | `GET /api/auth/session` (BFF가 쿠키 JWT를 Bearer로 전달해 프록시) |
 | 로그아웃 | `POST /api/auth/logout` | `POST /api/auth/logout` (선택 프록시; stateless이며 실질 로그아웃은 BFF의 쿠키 삭제) |
 
@@ -67,6 +68,13 @@
 5. **성공 시** Identity의 상태 코드/본문(`ApiResponse`)을 가능한 그대로 전달한다. 응답에는 `Cache-Control: no-store`를 적용한다.
 6. **Identity가 `400`/`401`/`409` 등으로 거절**하면 상태 코드와 JSON 본문을 **그대로** 프론트에 전달한다(§6).
 7. `IDENTITY_SERVICE_URL` 미설정, 업스트림 연결 실패, 업스트림 응답이 계약과 맞지 않는 경우 등은 BFF가 `500`/`502` 등으로 처리할 수 있다. 단, **외부 API 키 평문(`externalKey`)은 로그/에러 메시지에 포함하지 않는다.**
+
+### 2.4 `PUT /api/auth/external-keys/{id}` 지원 상태
+
+- Identity 백엔드는 `PUT /api/auth/external-keys/{id}`를 지원한다([Identity 인증 API 계약](../identity-auth-api-contract.md) §9).
+- 그러나 현재 `apps/web` BFF(`apps/web/src/app/api/auth/external-keys/route.ts`)는 `GET`/`POST`만 구현되어 있다.
+- 따라서 브라우저에서 BFF 경유로 외부 API 키 수정이 필요하면, BFF에 `PUT` 핸들러를 추가해 업스트림 `PUT` 프록시를 구현해야 한다.
+- 본 문서 버전에서는 Web BFF의 `PUT /api/auth/external-keys/{id}`를 **미지원**으로 정의한다.
 
 ---
 
@@ -169,6 +177,7 @@
 
 - 로그인/로그아웃/**`GET /api/auth/session`(세션 체크)** 응답에는 `Cache-Control: no-store`를 적용한다.
 - **`GET /api/auth/external-keys` / `POST /api/auth/external-keys`** 응답에도 `Cache-Control: no-store`를 적용한다.
+- 추후 BFF가 `PUT /api/auth/external-keys/{id}`를 지원하면 해당 응답에도 동일하게 `Cache-Control: no-store`를 적용한다.
 - MVP는 **Access Token only**(Refresh Token 미포함)로 운영하고, 만료 시 재로그인한다.
 - CSRF는 MVP에서 `SameSite=Lax + BFF 경유`를 기본으로 하고, **차기 스프린트에서 상태 변경 API는 BFF 경유에 더해 `Origin/Referer` 검증(또는 CSRF 토큰) 적용을 표준으로 한다.**
 

--- a/docs/identity-auth-api-contract.md
+++ b/docs/identity-auth-api-contract.md
@@ -212,7 +212,6 @@
 | `externalKey` 누락 | `400` | `{"success":false,"message":"externalKey는 필수입니다","data":null}` |
 | `alias` 누락 | `400` | `{"success":false,"message":"alias는 필수입니다","data":null}` |
 | `provider` 값 불가 | `400` | `{"success":false,"message":"provider 값이 올바르지 않습니다. 허용: GEMINI, OPENAI, ANTHROPIC","data":null}` (또는 본문 형식 오류 메시지) |
-| 사용자당 외부 키 상한 초과 | `400` | `{"success":false,"message":"외부 API 키는 사용자당 최대 5개까지 등록할 수 있습니다","data":null}` |
 | 동일 provider·동일 키 재등록 | `409` | `{"success":false,"message":"이미 등록된 API 키입니다","data":null}` |
 
 ### 7.3 캐시 정책
@@ -309,7 +308,6 @@
 | 상황        | 상태 코드 | 설명                           |
 | --------- | ----- | ---------------------------- |
 | 입력 검증 실패  | `400` | 필드 유효성/정책 위반 (`provider`·`externalKey`·`alias` 등) |
-| 외부 API 키 개수 초과 | `400` | 사용자당 최대 5개까지 등록 가능        |
 | 로그인 인증 실패 | `401` | 이메일/비밀번호 불일치                 |
 | 보호 API 미인증 | `401` | 액세스 토큰 없음/무효 (`GET/POST/PUT /api/auth/external-keys` 등) |
 | 외부 API 키 별칭 중복 | `409` | 동일 사용자 기준 별칭 재사용              |

--- a/docs/identity-auth-api-contract.md
+++ b/docs/identity-auth-api-contract.md
@@ -1,6 +1,6 @@
 # Identity 인증 API 계약 (백엔드)
 
-버전: 1.1  
+버전: 1.2  
 관련: [architecture.md](./architecture.md) §1.3, [contracts/web-identity-bff.md](./contracts/web-identity-bff.md)
 
 ---
@@ -39,6 +39,7 @@
 | `GET`  | `/api/auth/session` | 필요  | 세션(인증 상태) 확인             |
 | `GET`  | `/api/auth/external-keys` | 필요  | 내 외부 AI API 키 목록 조회 (`id`, `provider`, `alias`, `createdAt`) |
 | `POST` | `/api/auth/external-keys` | 필요  | 외부 AI API 키 등록 (`provider`, `externalKey`, `alias`) |
+| `PUT`  | `/api/auth/external-keys/{id}` | 필요  | 외부 AI API 키 수정 (`provider`, `externalKey`, `alias`) |
 | `POST` | `/api/auth/logout`  | 불필요 | 로그아웃 신호 응답(BFF 쿠키 삭제 유도) |
 
 
@@ -228,7 +229,70 @@
 
 ---
 
-## 9. 회원가입 입력 정책
+## 9. 외부 API 키 수정 계약
+
+외부 API 키 ID를 기준으로 `provider`/`externalKey`/`alias`를 수정한다. 응답 본문에는 **키 평문·암호문을 포함하지 않는다**.
+
+### 9.1 요청
+
+| 항목 | 값 |
+| --- | --- |
+| 메서드 | `PUT` |
+| 경로 | `/api/auth/external-keys/{id}` |
+| 인증 | 필요 (액세스 토큰, 일반적으로 `Authorization: Bearer <jwt>`) |
+| `Content-Type` | `application/json` |
+
+경로 파라미터:
+
+| 파라미터 | 타입 | 설명 |
+| --- | --- | --- |
+| `id` | number | 수정 대상 외부 API 키 ID |
+
+요청 본문 필드:
+
+| 필드 | 타입 | 필수 | 제약 | 예시 값 |
+| --- | --- | --- | --- | --- |
+| `provider` | string (enum) | 예 | `GEMINI`, `OPENAI`, `ANTHROPIC` 중 하나 | `"GEMINI"` |
+| `externalKey` | string | 예 | 공백만 불가, 최대 4096자 | 제3자가 발급한 비밀 키 |
+| `alias` | string | 예 | 공백만 불가, 최대 100자 | `"데모용 Gemini (수정)"` |
+
+### 9.2 성공 응답 (`200 OK`)
+
+| 항목 | 값 |
+| --- | --- |
+| 상태 코드 | `200` |
+| `Cache-Control` | `no-store` (본 서비스는 API 응답 전반에 적용) |
+
+응답 본문 예시:
+
+```json
+{
+  "success": true,
+  "message": "외부 API 키가 수정되었습니다",
+  "data": {
+    "id": 1,
+    "provider": "GEMINI",
+    "alias": "데모용 Gemini (수정)",
+    "createdAt": "2026-03-29T08:05:19.296098200Z"
+  }
+}
+```
+
+오류 응답 예시 (`success=false`, `data=null`):
+
+| 상황 | 상태 코드 | 예시 JSON |
+| --- | --- | --- |
+| 수정 대상 키 없음 | `404` | `{"success":false,"message":"등록된 API 키를 찾을 수 없습니다","data":null}` |
+| 별칭 중복 | `409` | `{"success":false,"message":"이미 사용 중인 별칭입니다","data":null}` |
+| 동일 provider·동일 키 중복 | `409` | `{"success":false,"message":"이미 등록된 API 키입니다","data":null}` |
+
+### 9.3 캐시 정책
+
+- identity-service는 HTTP 응답에 `Cache-Control: no-store`를 적용한다.
+
+---
+
+## 10. 회원가입 입력 정책
 
 - `passwordConfirm`은 필수이며 `password`와 일치해야 한다.
 - 비밀번호 정책:
@@ -239,7 +303,7 @@
 
 ---
 
-## 10. 오류 코드 기준
+## 11. 오류 코드 기준
 
 
 | 상황        | 상태 코드 | 설명                           |
@@ -247,15 +311,17 @@
 | 입력 검증 실패  | `400` | 필드 유효성/정책 위반 (`provider`·`externalKey`·`alias` 등) |
 | 외부 API 키 개수 초과 | `400` | 사용자당 최대 5개까지 등록 가능        |
 | 로그인 인증 실패 | `401` | 이메일/비밀번호 불일치                 |
-| 보호 API 미인증 | `401` | 액세스 토큰 없음/무효 (`GET/POST /api/auth/external-keys` 등) |
-| 외부 API 키 중복 등록 | `409` | 동일 사용자·동일 키 평문 재등록           |
+| 보호 API 미인증 | `401` | 액세스 토큰 없음/무효 (`GET/POST/PUT /api/auth/external-keys` 등) |
+| 외부 API 키 별칭 중복 | `409` | 동일 사용자 기준 별칭 재사용              |
+| 외부 API 키 중복 등록 | `409` | 동일 사용자·동일 provider·동일 키 평문 재등록 |
+| 외부 API 키 미존재 | `404` | 수정/조회 대상 외부 API 키를 찾을 수 없음    |
 | 이메일 중복    | `409` | 회원가입 중복                      |
 | 인증 계약 위반  | `502` | 업스트림/내부 계약 위반(`tokenType` 등) |
 
 
 ---
 
-## 11. 구현 시 주의
+## 12. 구현 시 주의
 
 - 인증 관련 응답은 캐시 금지(`Cache-Control: no-store`)를 유지한다(identity-service는 필터로 API 응답 전반에 적용).
 - 인증 실패 응답은 프론트/BFF에서 공통 처리할 수 있도록 코드/본문 일관성을 유지한다.

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
@@ -3,6 +3,7 @@ package com.zerobugfreinds.identity_service.controller;
 import com.zerobugfreinds.identity_service.common.ApiResponse;
 import com.zerobugfreinds.identity_service.dto.ExternalApiKeyRegisterRequest;
 import com.zerobugfreinds.identity_service.dto.ExternalApiKeyRegisterResponse;
+import com.zerobugfreinds.identity_service.dto.ExternalApiKeyUpdateRequest;
 import com.zerobugfreinds.identity_service.entity.ExternalApiKeyEntity;
 import com.zerobugfreinds.identity_service.security.IdentityUserPrincipal;
 import com.zerobugfreinds.identity_service.service.ExternalApiKeyService;
@@ -11,7 +12,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -64,5 +67,27 @@ public class ExternalApiKeyController {
 				))
 				.toList();
 		return ResponseEntity.ok(ApiResponse.ok("외부 API 키 목록 조회에 성공했습니다", data));
+	}
+
+	@PutMapping("/external-keys/{id}")
+	public ResponseEntity<ApiResponse<ExternalApiKeyRegisterResponse>> update(
+			@AuthenticationPrincipal IdentityUserPrincipal principal,
+			@PathVariable("id") Long id,
+			@Valid @RequestBody ExternalApiKeyUpdateRequest request
+	) {
+		ExternalApiKeyEntity saved = externalApiKeyService.update(
+				principal.userId(),
+				id,
+				request.provider(),
+				request.alias(),
+				request.externalKey()
+		);
+		ExternalApiKeyRegisterResponse data = new ExternalApiKeyRegisterResponse(
+				saved.getId(),
+				saved.getProvider().name(),
+				saved.getKeyAlias(),
+				saved.getCreatedAt()
+		);
+		return ResponseEntity.ok(ApiResponse.ok("외부 API 키가 수정되었습니다", data));
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.zerobugfreinds.identity_service.controller;
 import com.zerobugfreinds.identity_service.common.ApiResponse;
 import com.zerobugfreinds.identity_service.exception.ApiKeyLimitExceededException;
 import com.zerobugfreinds.identity_service.exception.AuthContractViolationException;
+import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyAliasException;
 import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyException;
 import com.zerobugfreinds.identity_service.exception.DuplicateEmailException;
 import com.zerobugfreinds.identity_service.exception.ExternalApiKeyNotFoundException;
@@ -54,6 +55,12 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(DuplicateExternalApiKeyException.class)
 	@ResponseStatus(HttpStatus.CONFLICT)
 	public ApiResponse<Void> handleDuplicateExternalApiKey(DuplicateExternalApiKeyException ex) {
+		return ApiResponse.fail(ex.getMessage());
+	}
+
+	@ExceptionHandler(DuplicateExternalApiKeyAliasException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ApiResponse<Void> handleDuplicateExternalApiKeyAlias(DuplicateExternalApiKeyAliasException ex) {
 		return ApiResponse.fail(ex.getMessage());
 	}
 

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ExternalApiKeyUpdateRequest.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ExternalApiKeyUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.zerobugfreinds.identity_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 외부 API 키 수정 요청. JSON 필드명은 {@code provider}, {@code externalKey}, {@code alias}.
+ */
+public record ExternalApiKeyUpdateRequest(
+		@NotNull(message = "provider는 필수입니다")
+		ExternalApiKeyProvider provider,
+
+		@NotBlank(message = "externalKey는 필수입니다")
+		@Size(max = 4096)
+		@JsonProperty("externalKey")
+		String externalKey,
+
+		@NotBlank(message = "alias는 필수입니다")
+		@Size(max = 100)
+		@JsonProperty("alias")
+		String alias
+) {
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/ExternalApiKeyEntity.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/ExternalApiKeyEntity.java
@@ -72,6 +72,18 @@ public class ExternalApiKeyEntity {
 		return entity;
 	}
 
+	public void updateCredential(
+			ExternalApiKeyProvider provider,
+			String keyAlias,
+			String keyHash,
+			String encryptedKey
+	) {
+		this.provider = provider;
+		this.keyAlias = keyAlias;
+		this.keyHash = keyHash;
+		this.encryptedKey = encryptedKey;
+	}
+
 	public Long getId() {
 		return id;
 	}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/exception/DuplicateExternalApiKeyAliasException.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/exception/DuplicateExternalApiKeyAliasException.java
@@ -1,0 +1,11 @@
+package com.zerobugfreinds.identity_service.exception;
+
+/**
+ * 동일 사용자의 외부 API 키 별칭이 중복될 때 발생한다.
+ */
+public class DuplicateExternalApiKeyAliasException extends RuntimeException {
+
+	public DuplicateExternalApiKeyAliasException(String message) {
+		super(message);
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
@@ -11,6 +11,17 @@ public interface ExternalApiKeyRepository extends JpaRepository<ExternalApiKeyEn
 
 	boolean existsByUserIdAndProviderAndKeyHash(Long userId, ExternalApiKeyProvider provider, String keyHash);
 
+	long countByUserIdAndProviderAndKeyHash(Long userId, ExternalApiKeyProvider provider, String keyHash);
+
+	boolean existsByUserIdAndKeyAlias(Long userId, String keyAlias);
+
+	boolean existsByUserIdAndProviderAndKeyHashAndIdNot(
+			Long userId,
+			ExternalApiKeyProvider provider,
+			String keyHash,
+			Long id
+	);
+
 	long countByUserId(Long userId);
 
 	java.util.List<ExternalApiKeyEntity> findAllByUserIdOrderByCreatedAtDesc(Long userId);
@@ -19,4 +30,6 @@ public interface ExternalApiKeyRepository extends JpaRepository<ExternalApiKeyEn
 			Long userId,
 			ExternalApiKeyProvider provider
 	);
+
+	java.util.Optional<ExternalApiKeyEntity> findByIdAndUserId(Long id, Long userId);
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
@@ -3,7 +3,6 @@ package com.zerobugfreinds.identity_service.service;
 import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
 import com.zerobugfreinds.identity_service.dto.InternalApiKeyResponse;
 import com.zerobugfreinds.identity_service.entity.ExternalApiKeyEntity;
-import com.zerobugfreinds.identity_service.exception.ApiKeyLimitExceededException;
 import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyAliasException;
 import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyException;
 import com.zerobugfreinds.identity_service.exception.ExternalApiKeyNotFoundException;
@@ -22,8 +21,6 @@ import org.springframework.util.StringUtils;
 public class ExternalApiKeyService {
 
 	private static final Logger log = LoggerFactory.getLogger(ExternalApiKeyService.class);
-
-	private static final int MAX_KEYS_PER_USER = 5;
 
 	private final ExternalApiKeyRepository externalApiKeyRepository;
 	private final EncryptionUtil encryptionUtil;
@@ -48,13 +45,6 @@ public class ExternalApiKeyService {
 		String normalizedKey = StringUtils.hasText(plainKey) ? plainKey.trim() : "";
 		if (!StringUtils.hasText(normalizedKey)) {
 			throw new IllegalArgumentException("externalKey는 필수입니다");
-		}
-
-		long count = externalApiKeyRepository.countByUserId(userId);
-		if (count >= MAX_KEYS_PER_USER) {
-			throw new ApiKeyLimitExceededException(
-					"외부 API 키는 사용자당 최대 " + MAX_KEYS_PER_USER + "개까지 등록할 수 있습니다"
-			);
 		}
 
 		if (externalApiKeyRepository.existsByUserIdAndKeyAlias(userId, trimmedAlias)) {

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
@@ -4,6 +4,7 @@ import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
 import com.zerobugfreinds.identity_service.dto.InternalApiKeyResponse;
 import com.zerobugfreinds.identity_service.entity.ExternalApiKeyEntity;
 import com.zerobugfreinds.identity_service.exception.ApiKeyLimitExceededException;
+import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyAliasException;
 import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyException;
 import com.zerobugfreinds.identity_service.exception.ExternalApiKeyNotFoundException;
 import com.zerobugfreinds.identity_service.repository.ExternalApiKeyRepository;
@@ -56,8 +57,21 @@ public class ExternalApiKeyService {
 			);
 		}
 
+		if (externalApiKeyRepository.existsByUserIdAndKeyAlias(userId, trimmedAlias)) {
+			throw new DuplicateExternalApiKeyAliasException("이미 사용 중인 별칭입니다");
+		}
+
 		String keyHash = encryptionUtil.sha256HexForUniqueness(provider.name(), normalizedKey);
-		if (externalApiKeyRepository.existsByUserIdAndProviderAndKeyHash(userId, provider, keyHash)) {
+		long duplicateCount = externalApiKeyRepository.countByUserIdAndProviderAndKeyHash(userId, provider, keyHash);
+		if (duplicateCount > 0) {
+			log.warn(
+					"[AUDIT] external_api_key_duplicate_detected userId={} provider={} alias={} hashPrefix={} duplicateCount={}",
+					userId,
+					provider.name(),
+					trimmedAlias,
+					keyHash.substring(0, 8),
+					duplicateCount
+			);
 			throw new DuplicateExternalApiKeyException("이미 등록된 API 키입니다");
 		}
 
@@ -88,6 +102,54 @@ public class ExternalApiKeyService {
 			throw new IllegalArgumentException("userId는 필수입니다");
 		}
 		return externalApiKeyRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+	}
+
+	@Transactional
+	public ExternalApiKeyEntity update(
+			Long userId,
+			Long externalKeyId,
+			ExternalApiKeyProvider provider,
+			String alias,
+			String plainKey
+	) {
+		if (userId == null) {
+			throw new IllegalArgumentException("userId는 필수입니다");
+		}
+		if (externalKeyId == null) {
+			throw new IllegalArgumentException("externalKeyId는 필수입니다");
+		}
+		if (provider == null) {
+			throw new IllegalArgumentException("provider는 필수입니다");
+		}
+		String trimmedAlias = StringUtils.hasText(alias) ? alias.trim() : "";
+		if (!StringUtils.hasText(trimmedAlias)) {
+			throw new IllegalArgumentException("alias는 필수입니다");
+		}
+		String normalizedKey = StringUtils.hasText(plainKey) ? plainKey.trim() : "";
+		if (!StringUtils.hasText(normalizedKey)) {
+			throw new IllegalArgumentException("externalKey는 필수입니다");
+		}
+
+		ExternalApiKeyEntity entity = externalApiKeyRepository.findByIdAndUserId(externalKeyId, userId)
+				.orElseThrow(() -> new ExternalApiKeyNotFoundException("등록된 API 키를 찾을 수 없습니다"));
+
+		String keyHash = encryptionUtil.sha256HexForUniqueness(provider.name(), normalizedKey);
+		if (externalApiKeyRepository.existsByUserIdAndProviderAndKeyHashAndIdNot(userId, provider, keyHash, externalKeyId)) {
+			throw new DuplicateExternalApiKeyException("이미 등록된 API 키입니다");
+		}
+
+		String encrypted = encryptionUtil.encryptAes256Gcm(normalizedKey);
+		entity.updateCredential(provider, trimmedAlias, keyHash, encrypted);
+
+		log.info(
+				"[AUDIT] external_api_key_updated userId={} provider={} alias={} keyId={}",
+				userId,
+				provider.name(),
+				trimmedAlias,
+				entity.getId()
+		);
+
+		return entity;
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 없음 (추가 예정)

## 작업 내용
- **해당 서비스**: Identity Service
- 외부 API 키 수정 엔드포인트 `PUT /api/auth/external-keys/{id}`를 추가했습니다.
- 등록 시 중복 검증을 분리해,
  - 별칭 중복: `이미 사용 중인 별칭입니다`
  - 키 중복: `이미 등록된 API 키입니다`
  로 각각 다른 `409` 메시지를 반환하도록 개선했습니다.
- 수정 로직에서 사용자 소유 키(`id + userId`) 검증 후 provider/alias/key(암호화/해시 포함) 갱신하도록 구현했습니다.

## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [x] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- `ExternalApiKeyController`
  - `PUT /api/auth/external-keys/{id}` 추가
- `ExternalApiKeyService`
  - `update(...)` 추가 (소유권 검증 + 중복 키 체크 + 암호화 갱신)
  - 등록 시 alias 중복 체크 추가
- `ExternalApiKeyRepository`
  - `findByIdAndUserId(...)`
  - `existsByUserIdAndKeyAlias(...)`
  - `existsByUserIdAndProviderAndKeyHashAndIdNot(...)` 추가
- `ExternalApiKeyEntity`
  - `updateCredential(...)` 추가
- `GlobalExceptionHandler`
  - `DuplicateExternalApiKeyAliasException` 처리 추가 (`409`)
- 신규 파일
  - `ExternalApiKeyUpdateRequest`
  - `DuplicateExternalApiKeyAliasException`
- docs/identity-auth-api-contract.md

버전 1.2로 업데이트
엔드포인트 표에 PUT /api/auth/external-keys/{id} 추가
새 섹션으로 외부 API 키 수정 계약(요청/응답/에러 404, 409) 추가
오류 코드 표에 별칭 중복/키 중복/미존재 케이스 반영
docs/contracts/web-identity-bff.md

버전 1.7로 업데이트
엔드포인트 표에 “외부 API 키 수정(개인): 미지원(현재 BFF 미구현)” 명시
2.4 섹션 추가해서 “Identity는 PUT 지원하지만 Web BFF는 아직 GET/POST만 지원”을 명확히 문서화
캐시 정책에도 추후 PUT 지원 시 no-store 적용 문구 추가

api key 등록 개수 제한 삭제

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [x] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부  
  (스키마 마이그레이션 파일 추가는 없고, JPA 엔티티/조회 로직 변경)

## 📸 스크린샷 / 테스트 결과 (선택)
- `services/identity-service`에서 `./gradlew.bat compileJava` 실행 성공

## 리뷰 요구사항
- 등록/수정 시 중복 검증 기준(userId/provider/keyHash, userId/alias)이 서비스 정책과 맞는지 확인 부탁드립니다.
- `PUT` API의 요청 필드(provider/alias/externalKey)를 모두 필수로 둔 설계가 UI/계약과 일치하는지 확인 부탁드립니다.