### PR TITLE
fix: 팀 예산 추가, 별명과 예산 수정 구현, api key 삭제 구현

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -415,8 +415,8 @@
 
 - **Identity 계열**: `services/identity-service` + `services/identity-service/web/` — 랜딩·인증·조직/팀 설정 UI, `/api/auth/**`·`/api/identity/**` BFF 등. 계약: `docs/contracts/web-identity-bff.md`.
 - **Usage·대시보드 계열**: `services/usage-service` + `services/usage-service/web/` — 사용량 대시보드, `/api/usage/**` BFF → 게이트웨이. 계약: `docs/contracts/web-gateway-bff.md`, `docs/contracts/gateway-proxy.md`.
-- **Team 계열**: `services/team-service` + `services/team-service/web/` — 팀 생성/조회/초대 및 팀 API Key 등록/조회 API, Team BFF. 브라우저 `/teams` UI는 Identity `web`가 소유하고 팀 API(`/api/team/v1/**`)만 Team BFF로 연동. 계약: `docs/contracts/web-team-bff.md`.
-- **`/teams` 진입 방식:** **단일 도메인 `web-edge`** 를 쓰면 브라우저의 `/teams/*` 요청은 Nginx가 **team `web`** 으로 넘긴다. **Identity `web`만 호스트 오리진(엣지 없이 예: `localhost:3000`)으로 띄우는 경우**에는 Identity 앱의 `/teams` 페이지와 Next rewrite로 `/api/team/v1/**` 만 team `web` BFF(및 `team-service`)로 연동될 수 있다. 위 두 방식은 저장소 설정에 따라 병행 정의된다.
+- **Team 계열**: `services/team-service` + `services/team-service/web/` — 팀 도메인 REST·Team BFF. 팀 API Key·월 예산(USD)은 **Identity `web`의 `/teams`** 에서도 계정 설정의 개인 외부 키와 유사한 UX로 제공할 수 있으며, 동일 API는 **team `web`**(`basePath=/teams`)에서도 사용 가능하다. 브라우저 → `/api/team/v1/**` → Team BFF → `team-service`. 계약: `docs/contracts/web-team-bff.md`.
+- **`/teams` 진입 방식:** **단일 도메인 `web-edge`** 를 쓰면 `/teams/*` 를 **team `web`** 으로 넘길 수 있다. **Identity `web`만** 띄울 때는 `/teams` 페이지에서 팀·키·예산을 다루고 Next rewrite로 `/api/team/v1/**` 를 team `web` BFF(및 `team-service`)로 넘긴다.
 - **웹 경계**: `docs/contracts/web-split-boundary.md` — 경로·BFF·미들웨어 변경 시 **본 문서·계약 문서**를 코드와 같이 갱신한다.
 - **Proxy·API Gateway**: 공개 AI·Usage HTTP 진입·신뢰 헤더 — 게이트웨이·프록시 구현 팀과 **HTTP 계약**만 맞춘다.
 

--- a/docs/contracts/web-team-bff.md
+++ b/docs/contracts/web-team-bff.md
@@ -21,8 +21,10 @@
 | `POST /api/team/v1/teams/{id}/members` | Team BFF `POST /api/team/v1/teams/{id}/members` → Team Service `POST /api/v1/teams/{id}/members` |
 | `GET /api/team/v1/teams/{id}/api-keys` | Team BFF `GET /api/team/v1/teams/{id}/api-keys` → Team Service `GET /api/v1/teams/{id}/api-keys` |
 | `POST /api/team/v1/teams/{id}/api-keys` | Team BFF `POST /api/team/v1/teams/{id}/api-keys` → Team Service `POST /api/v1/teams/{id}/api-keys` |
+| `PUT /api/team/v1/teams/{teamId}/api-keys/{keyId}` | Team BFF `PUT ...` → Team Service `PUT /api/v1/teams/{teamId}/api-keys/{keyId}` |
+| `DELETE /api/team/v1/teams/{teamId}/api-keys/{keyId}` | Team BFF `DELETE ...` → Team Service `DELETE /api/v1/teams/{teamId}/api-keys/{keyId}` |
 
-- Identity `web`는 `/teams` UI를 직접 렌더링하고, Next rewrite로 `GET/POST /api/team/v1/*`를 Team BFF(`team-web`)로 전달한다.
+- Identity `web`는 `/teams` UI(팀·멤버·팀 API Key·예산)를 렌더링하고, Next rewrite로 `GET/POST/PUT/DELETE /api/team/v1/*`를 Team BFF(`team-web`)로 전달한다.
 - Team BFF는 `TEAM_SERVICE_URL` 환경 변수로 Team Service를 프록시한다.
 - Team BFF는 `IDENTITY_SERVICE_URL`로 세션 확인(`GET /api/auth/session`)을 프록시한다.
 
@@ -38,7 +40,7 @@
 
 ## 4. 보안/권한
 
-- 팀 생성/조회/초대/팀 API Key 등록·조회는 모두 인증 필요다.
+- 팀 생성/조회/초대/팀 API Key 등록·조회·수정·삭제는 모두 인증 필요다.
 - 권한 검증(팀 멤버만 초대 가능 등)은 Team Service가 최종 책임을 가진다.
 - 팀원 초대 시 Team Service는 Identity 내부 API(`GET /internal/users/exists?email=...`)로
   사용자 존재 여부를 확인한 뒤, **실제로 존재하는 아이디(이메일)만** 초대를 허용한다.
@@ -60,18 +62,27 @@
   - `403` (`success=false`): 요청자가 해당 팀의 초대 권한이 없는 경우
   - `404` (`success=false`): 대상 팀이 존재하지 않는 경우
 
-### 5.2 팀 API Key 등록/조회
+### 5.2 팀 API Key 등록/조회/수정
 
 - `POST /api/team/v1/teams/{id}/api-keys`
-  - 요청 본문: `provider` (`OPENAI`/`GEMINI`/`CLAUDE`), `alias`, `externalKey`
-  - 성공: `201`, `data`에 등록된 키 요약(`id`, `provider`, `alias`, `keyPreview`, `createdAt`)
+  - 요청 본문: `provider` (`OPENAI`/`GEMINI`/`CLAUDE`), `alias`, `externalKey`, `monthlyBudgetUsd` (0 이상, USD 월 예산 한도 — identity-service 외부 키와 동일 개념)
+  - 성공: `201`, `data`에 등록된 키 요약(`id`, `provider`, `alias`, `keyPreview`, `monthlyBudgetUsd`, `createdAt`)
   - 실패:
     - `400` (`success=false`): 필수값 누락, alias 중복, 동일 provider+key 중복
     - `403` (`success=false`): 팀 멤버가 아닌 사용자의 등록 시도
     - `404` (`success=false`): 대상 팀이 존재하지 않는 경우
 
+- `PUT /api/team/v1/teams/{teamId}/api-keys/{keyId}`
+  - 요청 본문: `alias`, `monthlyBudgetUsd` (필수). Identity `/teams`·team `web` UI는 별칭·예산만 보낸다. 서버는 `externalKey`가 비어 있지 않을 때에만 키 값·provider 갱신을 허용한다(내부·다른 클라이언트용).
+  - 성공: `200`, 수정된 키 요약
+  - 실패: `400` (검증/중복/대상 없음), `403`, `404`
+
+- `DELETE /api/team/v1/teams/{teamId}/api-keys/{keyId}`
+  - 성공: `200`, 해당 키 행을 DB에서 제거(영구 삭제). Identity 개인 키의 「삭제 예약」과는 별도 정책이다.
+  - 실패: `400` (대상 없음 등), `403`, `404`
+
 - `GET /api/team/v1/teams/{id}/api-keys`
-  - 성공: `200`, 팀 API Key 목록(요약 정보만 반환)
+  - 성공: `200`, 팀 API Key 목록(요약 정보만 반환, `monthlyBudgetUsd` 포함)
   - 실패:
     - `403` (`success=false`): 팀 멤버가 아닌 사용자의 조회 시도
     - `404` (`success=false`): 대상 팀이 존재하지 않는 경우

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       '@ai-usage/ui':
         specifier: workspace:*
         version: link:../../../packages/ui
+      lucide-react:
+        specifier: ^1.6.0
+        version: 1.7.0(react@19.2.4)
       next:
         specifier: 16.2.1
         version: 16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/services/identity-service/web/src/components/account/teams-view.tsx
+++ b/services/identity-service/web/src/components/account/teams-view.tsx
@@ -1,12 +1,10 @@
 "use client"
 
 import * as React from "react"
+import { Eye, EyeOff } from "lucide-react"
 
-type ApiResponse<T> = {
-  success: boolean
-  message: string
-  data: T | null
-}
+import { apiFetch } from "@/lib/api/client-fetch"
+import type { ApiResponse } from "@/lib/api/identity/types"
 
 type TeamSummary = {
   id: string
@@ -18,17 +16,20 @@ type TeamSummaryLike = {
   name: string
 }
 
+type TeamKeyProvider = "OPENAI" | "GEMINI" | "CLAUDE"
+
 type TeamApiKeySummary = {
   id: number
   provider: string
   alias: string
   keyPreview: string
+  monthlyBudgetUsd: number | null
   createdAt: string
 }
 
-function asApiResponse(value: unknown): ApiResponse<unknown> | null {
-  if (!value || typeof value !== "object") return null
-  const r = value as Record<string, unknown>
+function asApiResponse(json: unknown): ApiResponse<unknown> | null {
+  if (!json || typeof json !== "object") return null
+  const r = json as Record<string, unknown>
   if (typeof r.success !== "boolean") return null
   if (typeof r.message !== "string") return null
   if (!("data" in r)) return null
@@ -50,13 +51,61 @@ function normalizeTeamApiKeySummary(item: unknown): TeamApiKeySummary | null {
   if (typeof v.alias !== "string") return null
   if (typeof v.keyPreview !== "string") return null
   if (typeof v.createdAt !== "string") return null
+  const b = v.monthlyBudgetUsd
+  let monthlyBudgetUsd: number | null = null
+  if (typeof b === "number" && Number.isFinite(b)) {
+    monthlyBudgetUsd = b
+  } else if (typeof b === "string" && b.trim() !== "") {
+    const n = Number(b)
+    if (Number.isFinite(n)) monthlyBudgetUsd = n
+  }
   return {
     id: v.id,
     provider: v.provider,
     alias: v.alias,
     keyPreview: v.keyPreview,
+    monthlyBudgetUsd,
     createdAt: v.createdAt,
   }
+}
+
+function providerLabel(provider: string) {
+  if (provider === "OPENAI") return "OpenAI"
+  if (provider === "GEMINI") return "Gemini"
+  if (provider === "CLAUDE") return "Claude"
+  return provider
+}
+
+function defaultAlias(provider: TeamKeyProvider) {
+  return `${providerLabel(provider)} 팀 키 1`
+}
+
+function formatCreatedAt(iso: string) {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString("ko-KR", { timeZone: "Asia/Seoul" })
+}
+
+function formatBudgetUsd(value: number | null | undefined) {
+  if (value === null || value === undefined) return null
+  return new Intl.NumberFormat("ko-KR", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+const BUDGET_STEP = 0.01
+
+/** blur 또는 스피너 조정 후 소수 둘째 자리·0.01 단위로 맞춤 */
+function normalizeBudgetNumericString(raw: string): string {
+  const t = raw.trim()
+  if (t === "") return ""
+  const n = Number(t)
+  if (!Number.isFinite(n) || n < 0) return ""
+  const rounded = Math.round(n / BUDGET_STEP) * BUDGET_STEP
+  return Number(rounded.toFixed(2)).toString()
 }
 
 export function TeamsView() {
@@ -70,12 +119,28 @@ export function TeamsView() {
   const [createLoading, setCreateLoading] = React.useState(false)
   const [inviteInputByTeamId, setInviteInputByTeamId] = React.useState<Record<string, string>>({})
   const [inviteLoadingTeamId, setInviteLoadingTeamId] = React.useState<string | null>(null)
+  const [message, setMessage] = React.useState<{ kind: "success" | "error"; text: string } | null>(null)
+
   const [teamApiKeysByTeamId, setTeamApiKeysByTeamId] = React.useState<Record<string, TeamApiKeySummary[]>>({})
+  /** 목록 로드 실패(팀별). 수정·삭제 검증 오류는 `keysError`. */
+  const [apiKeysListErrorByTeamId, setApiKeysListErrorByTeamId] = React.useState<Record<string, string | null>>({})
+  const [keysError, setKeysError] = React.useState<string | null>(null)
   const [apiKeyAliasByTeamId, setApiKeyAliasByTeamId] = React.useState<Record<string, string>>({})
   const [apiKeyValueByTeamId, setApiKeyValueByTeamId] = React.useState<Record<string, string>>({})
-  const [apiKeyProviderByTeamId, setApiKeyProviderByTeamId] = React.useState<Record<string, string>>({})
-  const [apiKeyLoadingTeamId, setApiKeyLoadingTeamId] = React.useState<string | null>(null)
-  const [message, setMessage] = React.useState<{ kind: "success" | "error"; text: string } | null>(null)
+  const [apiKeyProviderByTeamId, setApiKeyProviderByTeamId] = React.useState<Record<string, TeamKeyProvider>>({})
+  const [apiKeyMonthlyBudgetByTeamId, setApiKeyMonthlyBudgetByTeamId] = React.useState<Record<string, string>>({})
+  const [apiKeyAliasTouchedByTeamId, setApiKeyAliasTouchedByTeamId] = React.useState<Record<string, boolean>>({})
+  const [apiKeyRegisterLoadingTeamId, setApiKeyRegisterLoadingTeamId] = React.useState<string | null>(null)
+  const [apiKeyRegisterMessageByTeamId, setApiKeyRegisterMessageByTeamId] = React.useState<
+    Record<string, { kind: "success" | "error"; text: string }>
+  >({})
+  const [apiKeyRevealByTeamId, setApiKeyRevealByTeamId] = React.useState<Record<string, boolean>>({})
+
+  const [editingKey, setEditingKey] = React.useState<{ teamId: string; row: TeamApiKeySummary } | null>(null)
+  const [editAlias, setEditAlias] = React.useState("")
+  const [editBudget, setEditBudget] = React.useState("")
+  const [saveEditLoading, setSaveEditLoading] = React.useState(false)
+  const [deleteLoadingKey, setDeleteLoadingKey] = React.useState<string | null>(null)
 
   function normalizeInviteUserIds(values: string[]): string[] {
     return Array.from(
@@ -91,33 +156,25 @@ export function TeamsView() {
     setLoading(true)
     setError(null)
     try {
-      const res = await fetch("/api/team/v1/me/teams", {
-        method: "GET",
-        credentials: "include",
-        headers: { Accept: "application/json" },
-        cache: "no-store",
-      })
-      const json = (await res.json()) as unknown
+      const { response, json } = await apiFetch<unknown>(
+        "/api/team/v1/me/teams",
+        { method: "GET", credentials: "include", headers: { Accept: "application/json" }, cache: "no-store" },
+        { authRequired: true }
+      )
       const body = asApiResponse(json)
 
-      if (res.status === 404) {
+      if (response.status === 404) {
         setTeams([])
         return
       }
 
-      if (!res.ok || !body?.success) {
+      if (!response.ok || !body?.success) {
         setError(body?.message ?? "팀 목록을 불러오지 못했습니다")
         setTeams([])
         return
       }
 
-      if (body.data === null) {
-        setTeams([])
-        return
-      }
-
-      if (!Array.isArray(body.data)) {
-        setError("팀 목록을 불러오지 못했습니다")
+      if (body.data === null || !Array.isArray(body.data)) {
         setTeams([])
         return
       }
@@ -137,15 +194,13 @@ export function TeamsView() {
 
   const loadTeamMembers = React.useCallback(async (teamId: string) => {
     try {
-      const res = await fetch(`/api/team/v1/teams/${encodeURIComponent(teamId)}/members`, {
-        method: "GET",
-        credentials: "include",
-        headers: { Accept: "application/json" },
-        cache: "no-store",
-      })
-      const json = (await res.json()) as unknown
+      const { response, json } = await apiFetch<unknown>(
+        `/api/team/v1/teams/${encodeURIComponent(teamId)}/members`,
+        { method: "GET", credentials: "include", headers: { Accept: "application/json" }, cache: "no-store" },
+        { authRequired: true }
+      )
       const body = asApiResponse(json)
-      if (!res.ok || !body?.success || !Array.isArray(body.data)) {
+      if (!response.ok || !body?.success || !Array.isArray(body.data)) {
         setTeamMemberIdsByTeamId((prev) => ({ ...prev, [teamId]: [] }))
         return
       }
@@ -158,27 +213,35 @@ export function TeamsView() {
 
   const loadTeamApiKeys = React.useCallback(async (teamId: string) => {
     try {
-      const res = await fetch(`/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys`, {
-        method: "GET",
-        credentials: "include",
-        headers: { Accept: "application/json" },
-        cache: "no-store",
-      })
-      const json = (await res.json()) as unknown
+      const { response, json } = await apiFetch<unknown>(
+        `/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys`,
+        { method: "GET", credentials: "include", headers: { Accept: "application/json" }, cache: "no-store" },
+        { authRequired: true }
+      )
       const body = asApiResponse(json)
-      if (!res.ok || !body?.success || !Array.isArray(body.data)) {
+      if (!response.ok || !body?.success || !Array.isArray(body.data)) {
         setTeamApiKeysByTeamId((prev) => ({ ...prev, [teamId]: [] }))
+        const msg =
+          json && typeof json === "object" && "message" in json
+            ? String((json as { message: string }).message)
+            : "팀 API Key 목록을 불러오지 못했습니다"
+        setApiKeysListErrorByTeamId((prev) => ({ ...prev, [teamId]: msg }))
         return
       }
-      const apiKeyItems = body.data as unknown[]
+      const items = body.data as unknown[]
       setTeamApiKeysByTeamId((prev) => ({
         ...prev,
-        [teamId]: apiKeyItems
+        [teamId]: items
           .map((item) => normalizeTeamApiKeySummary(item))
           .filter((item): item is TeamApiKeySummary => item !== null),
       }))
+      setApiKeysListErrorByTeamId((prev) => ({ ...prev, [teamId]: null }))
     } catch {
       setTeamApiKeysByTeamId((prev) => ({ ...prev, [teamId]: [] }))
+      setApiKeysListErrorByTeamId((prev) => ({
+        ...prev,
+        [teamId]: "팀 API Key 목록을 불러오지 못했습니다",
+      }))
     }
   }, [])
 
@@ -190,6 +253,7 @@ export function TeamsView() {
     if (teams.length === 0) {
       setTeamMemberIdsByTeamId({})
       setTeamApiKeysByTeamId({})
+      setApiKeysListErrorByTeamId({})
       return
     }
     for (const team of teams) {
@@ -197,6 +261,20 @@ export function TeamsView() {
       void loadTeamApiKeys(team.id)
     }
   }, [teams, loadTeamMembers, loadTeamApiKeys])
+
+  React.useEffect(() => {
+    setApiKeyAliasByTeamId((prev) => {
+      let changed = false
+      const next = { ...prev }
+      for (const team of teams) {
+        if (next[team.id] === undefined) {
+          next[team.id] = defaultAlias("OPENAI")
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [teams])
 
   async function createTeam(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -210,15 +288,18 @@ export function TeamsView() {
     setCreateLoading(true)
     setMessage(null)
     try {
-      const res = await fetch("/api/team/v1/teams", {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json", Accept: "application/json" },
-        body: JSON.stringify({ name }),
-      })
-      const json = (await res.json()) as unknown
+      const { response, json } = await apiFetch<unknown>(
+        "/api/team/v1/teams",
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify({ name }),
+        },
+        { authRequired: true }
+      )
       const body = asApiResponse(json)
-      if (!res.ok || !body?.success) {
+      if (!response.ok || !body?.success) {
         setMessage({ kind: "error", text: body?.message ?? "팀 생성에 실패했습니다" })
         return
       }
@@ -235,25 +316,24 @@ export function TeamsView() {
       if (inviteUserIdsToSend.length > 0 && createdTeamId) {
         let invitedCount = 0
         let failedCount = 0
-
         for (const userId of inviteUserIdsToSend) {
           try {
-            const inviteRes = await fetch(`/api/team/v1/teams/${encodeURIComponent(createdTeamId)}/members`, {
-              method: "POST",
-              credentials: "include",
-              headers: { "Content-Type": "application/json", Accept: "application/json" },
-              body: JSON.stringify({ userId }),
-            })
-            if (inviteRes.ok) {
-              invitedCount += 1
-            } else {
-              failedCount += 1
-            }
+            const inviteRes = await apiFetch<unknown>(
+              `/api/team/v1/teams/${encodeURIComponent(createdTeamId)}/members`,
+              {
+                method: "POST",
+                credentials: "include",
+                headers: { "Content-Type": "application/json", Accept: "application/json" },
+                body: JSON.stringify({ userId }),
+              },
+              { authRequired: true }
+            )
+            if (inviteRes.response.ok) invitedCount += 1
+            else failedCount += 1
           } catch {
             failedCount += 1
           }
         }
-
         if (failedCount > 0) {
           setMessage({
             kind: "error",
@@ -316,15 +396,18 @@ export function TeamsView() {
     setInviteLoadingTeamId(teamId)
     setMessage(null)
     try {
-      const res = await fetch(`/api/team/v1/teams/${encodeURIComponent(teamId)}/members`, {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json", Accept: "application/json" },
-        body: JSON.stringify({ userId }),
-      })
-      const json = (await res.json()) as unknown
+      const { response, json } = await apiFetch<unknown>(
+        `/api/team/v1/teams/${encodeURIComponent(teamId)}/members`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify({ userId }),
+        },
+        { authRequired: true }
+      )
       const body = asApiResponse(json)
-      if (!res.ok || !body?.success) {
+      if (!response.ok || !body?.success) {
         setMessage({ kind: "error", text: body?.message ?? "초대에 실패했습니다" })
         return
       }
@@ -337,58 +420,214 @@ export function TeamsView() {
     }
   }
 
-  async function registerTeamApiKey(teamId: string) {
-    if (apiKeyLoadingTeamId) return
-    const provider = (apiKeyProviderByTeamId[teamId] ?? "OPENAI").trim()
-    const alias = (apiKeyAliasByTeamId[teamId] ?? "").trim()
-    const externalKey = (apiKeyValueByTeamId[teamId] ?? "").trim()
-    if (!alias) {
-      setMessage({ kind: "error", text: "API Key 별칭을 입력해 주세요" })
+  function cancelEditKey() {
+    setEditingKey(null)
+    setEditAlias("")
+    setEditBudget("")
+    setSaveEditLoading(false)
+  }
+
+  function startEditKey(teamId: string, row: TeamApiKeySummary) {
+    setKeysError(null)
+    setEditingKey({ teamId, row })
+    setEditAlias(row.alias)
+    setEditBudget(
+      row.monthlyBudgetUsd !== null && row.monthlyBudgetUsd !== undefined ? String(row.monthlyBudgetUsd) : "",
+    )
+  }
+
+  async function saveEditKey() {
+    if (!editingKey) return
+    const { teamId, row } = editingKey
+    const aliasTrimmed = editAlias.trim()
+    const budgetTrimmed = editBudget.trim()
+    if (!aliasTrimmed) {
+      setKeysError("별칭은 필수입니다")
       return
     }
-    if (!externalKey) {
-      setMessage({ kind: "error", text: "API Key 값을 입력해 주세요" })
+    if (!budgetTrimmed) {
+      setKeysError("월 예산은 필수입니다")
+      return
+    }
+    const fracPart = budgetTrimmed.includes(".") ? (budgetTrimmed.split(".")[1] ?? "") : ""
+    if (fracPart.length > 2) {
+      setKeysError("월 예산은 소수점 둘째 자리까지만 입력할 수 있습니다")
+      return
+    }
+    const parsedBudget = Number(budgetTrimmed)
+    if (!Number.isFinite(parsedBudget) || parsedBudget < 0) {
+      setKeysError("예산은 0 이상의 숫자로 입력해 주세요")
+      return
+    }
+    const monthlyBudgetUsd = Number(parsedBudget.toFixed(2))
+    const normalizedCurrentBudget =
+      row.monthlyBudgetUsd === null || row.monthlyBudgetUsd === undefined
+        ? null
+        : Number(row.monthlyBudgetUsd.toFixed(2))
+    if (aliasTrimmed === row.alias && monthlyBudgetUsd === normalizedCurrentBudget) {
+      cancelEditKey()
       return
     }
 
-    setApiKeyLoadingTeamId(teamId)
-    setMessage(null)
+    const body = { alias: aliasTrimmed, monthlyBudgetUsd }
+
+    setSaveEditLoading(true)
+    setKeysError(null)
     try {
-      const res = await fetch(`/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys`, {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json", Accept: "application/json" },
-        body: JSON.stringify({ provider, alias, externalKey }),
-      })
-      const json = (await res.json()) as unknown
-      const body = asApiResponse(json)
-      if (!res.ok || !body?.success) {
-        setMessage({ kind: "error", text: body?.message ?? "팀 API Key 등록에 실패했습니다" })
-        return
+      const { response, json } = await apiFetch<unknown>(
+        `/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys/${encodeURIComponent(String(row.id))}`,
+        {
+          method: "PUT",
+          credentials: "include",
+          cache: "no-store",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify(body),
+        },
+        { authRequired: true }
+      )
+      const apiResponse = asApiResponse(json)
+      if (response.ok && apiResponse?.success) {
+        cancelEditKey()
+        await loadTeamApiKeys(teamId)
+      } else {
+        setKeysError(apiResponse?.message ?? "팀 API Key 수정에 실패했습니다")
       }
-      setMessage({ kind: "success", text: "팀 API Key가 등록되었습니다" })
-      setApiKeyAliasByTeamId((prev) => ({ ...prev, [teamId]: "" }))
-      setApiKeyValueByTeamId((prev) => ({ ...prev, [teamId]: "" }))
-      await loadTeamApiKeys(teamId)
     } catch {
-      setMessage({ kind: "error", text: "팀 API Key 등록에 실패했습니다" })
+      setKeysError("팀 API Key 수정에 실패했습니다")
     } finally {
-      setApiKeyLoadingTeamId(null)
+      setSaveEditLoading(false)
+    }
+  }
+
+  async function deleteTeamKey(teamId: string, keyId: number) {
+    const ok = window.confirm(
+      "이 팀 API 키를 즉시 삭제합니다.\n\nDB에서 영구 삭제되며 복구할 수 없습니다. 과거 사용량 로그는 다른 서비스 기록에 남을 수 있습니다.",
+    )
+    if (!ok) return
+    const loadingKey = `${teamId}:${keyId}`
+    setDeleteLoadingKey(loadingKey)
+    setKeysError(null)
+    try {
+      const { response, json } = await apiFetch<unknown>(
+        `/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys/${encodeURIComponent(String(keyId))}`,
+        { method: "DELETE", credentials: "include", cache: "no-store", headers: { Accept: "application/json" } },
+        { authRequired: true }
+      )
+      const apiResponse = asApiResponse(json)
+      if (response.ok && apiResponse?.success) {
+        if (editingKey?.teamId === teamId && editingKey.row.id === keyId) cancelEditKey()
+        await loadTeamApiKeys(teamId)
+      } else {
+        setKeysError(apiResponse?.message ?? "삭제에 실패했습니다")
+      }
+    } catch {
+      setKeysError("삭제에 실패했습니다")
+    } finally {
+      setDeleteLoadingKey(null)
+    }
+  }
+
+  async function registerTeamApiKey(teamId: string) {
+    if (apiKeyRegisterLoadingTeamId) return
+    const provider = apiKeyProviderByTeamId[teamId] ?? "OPENAI"
+    const alias = (apiKeyAliasByTeamId[teamId] ?? "").trim()
+    const externalKey = (apiKeyValueByTeamId[teamId] ?? "").trim()
+    const budgetTrimmed = (apiKeyMonthlyBudgetByTeamId[teamId] ?? "").trim()
+
+    if (!alias) {
+      setApiKeyRegisterMessageByTeamId((prev) => ({
+        ...prev,
+        [teamId]: { kind: "error", text: "API Key 별칭을 입력해 주세요" },
+      }))
+      return
+    }
+    if (!externalKey) {
+      setApiKeyRegisterMessageByTeamId((prev) => ({
+        ...prev,
+        [teamId]: { kind: "error", text: "API Key 값을 입력해 주세요" },
+      }))
+      return
+    }
+    if (!budgetTrimmed) {
+      setApiKeyRegisterMessageByTeamId((prev) => ({
+        ...prev,
+        [teamId]: { kind: "error", text: "월 예산은 필수입니다" },
+      }))
+      return
+    }
+    const fracRegister = budgetTrimmed.includes(".") ? (budgetTrimmed.split(".")[1] ?? "") : ""
+    if (fracRegister.length > 2) {
+      setApiKeyRegisterMessageByTeamId((prev) => ({
+        ...prev,
+        [teamId]: { kind: "error", text: "월 예산은 소수점 둘째 자리까지만 입력할 수 있습니다" },
+      }))
+      return
+    }
+    const parsedBudget = Number(budgetTrimmed)
+    if (!Number.isFinite(parsedBudget) || parsedBudget < 0) {
+      setApiKeyRegisterMessageByTeamId((prev) => ({
+        ...prev,
+        [teamId]: { kind: "error", text: "예산은 0 이상의 숫자로 입력해 주세요" },
+      }))
+      return
+    }
+    const monthlyBudgetUsd = Number(parsedBudget.toFixed(2))
+
+    setApiKeyRegisterLoadingTeamId(teamId)
+    try {
+      const { response, json } = await apiFetch<unknown>(
+        `/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys`,
+        {
+          method: "POST",
+          credentials: "include",
+          cache: "no-store",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify({ provider, alias, externalKey, monthlyBudgetUsd }),
+        },
+        { authRequired: true }
+      )
+      const apiResponse = asApiResponse(json)
+      if (response.ok && apiResponse?.success) {
+        setApiKeyRegisterMessageByTeamId((prev) => ({
+          ...prev,
+          [teamId]: { kind: "success", text: apiResponse.message || "등록되었습니다" },
+        }))
+        setApiKeyAliasTouchedByTeamId((prev) => ({ ...prev, [teamId]: false }))
+        setApiKeyAliasByTeamId((prev) => ({ ...prev, [teamId]: defaultAlias(provider) }))
+        setApiKeyValueByTeamId((prev) => ({ ...prev, [teamId]: "" }))
+        setApiKeyMonthlyBudgetByTeamId((prev) => ({ ...prev, [teamId]: "" }))
+        setApiKeyRevealByTeamId((prev) => ({ ...prev, [teamId]: false }))
+        await loadTeamApiKeys(teamId)
+      } else {
+        setApiKeyRegisterMessageByTeamId((prev) => ({
+          ...prev,
+          [teamId]: { kind: "error", text: apiResponse?.message ?? "등록에 실패했습니다" },
+        }))
+      }
+    } catch {
+      setApiKeyRegisterMessageByTeamId((prev) => ({
+        ...prev,
+        [teamId]: { kind: "error", text: "등록에 실패했습니다" },
+      }))
+    } finally {
+      setApiKeyRegisterLoadingTeamId(null)
     }
   }
 
   return (
     <div className="flex min-h-[40vh] flex-col gap-8 py-4">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">팀 관리</h1>
-        <p className="text-sm text-zinc-600">팀 생성 후 멤버 초대와 팀 API Key 등록/조회가 가능합니다.</p>
+        <h1 className="text-2xl font-semibold tracking-tight">팀 관리</h1>
+        <p className="text-sm text-muted-foreground">
+          팀을 만든 뒤 멤버를 초대하고, 팀 단위 공급사 API 키와 월 예산(USD)을 등록·수정·삭제할 수 있습니다. (계정 설정의 개인 외부 키와 같은 사용 흐름입니다.)
+        </p>
       </header>
 
-      <section className="max-w-lg space-y-3 rounded-lg border border-zinc-200 bg-white p-4">
+      <section className="max-w-lg space-y-3 rounded-lg border border-border bg-card p-5 shadow-sm">
         {!showCreateForm ? (
           <button
             type="button"
-            className="h-10 rounded-md bg-black px-4 text-sm font-medium text-white disabled:opacity-60"
+            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-60"
             onClick={openCreateForm}
             disabled={createLoading}
           >
@@ -397,12 +636,12 @@ export function TeamsView() {
         ) : (
           <form className="space-y-3" onSubmit={createTeam}>
             <div className="space-y-1">
-              <label htmlFor="team-name" className="text-xs font-medium text-zinc-700">
+              <label htmlFor="team-name" className="text-sm font-medium">
                 팀 이름 (필수)
               </label>
               <input
                 id="team-name"
-                className="h-10 w-full rounded-md border border-zinc-300 bg-white px-3 text-sm"
+                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
                 value={teamName}
                 onChange={(e) => setTeamName(e.target.value)}
                 placeholder="예: 플랫폼팀"
@@ -413,11 +652,11 @@ export function TeamsView() {
             </div>
 
             <div className="space-y-2">
-              <p className="text-xs font-medium text-zinc-700">팀원 초대 (선택)</p>
+              <p className="text-sm font-medium">팀원 초대 (선택)</p>
               {inviteUserIds.map((value, index) => (
                 <div key={`invite-${index}`} className="flex items-center gap-2">
                   <input
-                    className="h-10 flex-1 rounded-md border border-zinc-300 bg-white px-3 text-sm"
+                    className="h-10 flex-1 rounded-md border border-input bg-background px-3 text-sm"
                     value={value}
                     onChange={(e) => updateInviteInput(index, e.target.value)}
                     placeholder="팀원 이메일(아이디) 입력"
@@ -426,7 +665,7 @@ export function TeamsView() {
                   />
                   <button
                     type="button"
-                    className="h-10 rounded-md border border-zinc-300 bg-white px-3 text-sm font-medium"
+                    className="h-10 rounded-md border border-border bg-background px-3 text-sm font-medium"
                     onClick={() => removeInviteInput(index)}
                     disabled={createLoading}
                     aria-label={`팀원 입력창 ${index + 1} 삭제`}
@@ -437,7 +676,7 @@ export function TeamsView() {
               ))}
               <button
                 type="button"
-                className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-sm font-medium"
+                className="h-9 rounded-md border border-border bg-background px-3 text-sm font-medium"
                 onClick={addInviteInput}
                 disabled={createLoading}
               >
@@ -448,14 +687,14 @@ export function TeamsView() {
             <div className="flex gap-2">
               <button
                 type="submit"
-                className="h-10 rounded-md bg-black px-4 text-sm font-medium text-white disabled:opacity-60"
+                className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-60"
                 disabled={createLoading}
               >
-                {createLoading ? "생성 중..." : "생성"}
+                {createLoading ? "생성 중…" : "생성"}
               </button>
               <button
                 type="button"
-                className="h-10 rounded-md border border-zinc-300 bg-white px-4 text-sm font-medium"
+                className="h-10 rounded-md border border-border bg-background px-4 text-sm font-medium"
                 onClick={closeCreateForm}
                 disabled={createLoading}
               >
@@ -466,97 +705,291 @@ export function TeamsView() {
         )}
       </section>
 
-      {message ? <p className={message.kind === "success" ? "text-sm text-emerald-600" : "text-sm text-red-600"}>{message.text}</p> : null}
-      {loading ? <p className="text-sm text-zinc-500">불러오는 중...</p> : null}
-      {error && !loading ? <p className="text-sm text-red-600">{error}</p> : null}
+      {message ? (
+        <p className={message.kind === "success" ? "text-sm text-emerald-600" : "text-sm text-destructive"}>{message.text}</p>
+      ) : null}
+      {loading ? <p className="text-sm text-muted-foreground">불러오는 중…</p> : null}
+      {error && !loading ? <p className="text-sm text-destructive">{error}</p> : null}
 
-      {!loading && !error && teams.length === 0 ? <p className="text-sm text-zinc-500">아직 팀이 구성되지 않았습니다.</p> : null}
+      {!loading && !error && teams.length === 0 ? (
+        <p className="text-sm text-muted-foreground">아직 팀이 구성되지 않았습니다.</p>
+      ) : null}
+
+      {keysError ? <p className="text-sm text-destructive">{keysError}</p> : null}
 
       {!loading && teams.length > 0 ? (
-        <ul className="max-w-lg divide-y divide-zinc-200 rounded-lg border border-zinc-200 bg-white">
+        <ul className="max-w-lg divide-y divide-border rounded-lg border border-border bg-card shadow-sm">
           {teams.map((team) => (
-            <li key={team.id} className="space-y-2 px-4 py-3">
-              <p className="font-medium">{team.name}</p>
-              <p className="text-xs text-zinc-500">id: {team.id}</p>
-              <p className="text-xs text-zinc-600">멤버 수: {(teamMemberIdsByTeamId[team.id] ?? []).length}명</p>
-              {(teamMemberIdsByTeamId[team.id] ?? []).length > 0 ? (
-                <ul className="list-disc pl-5 text-xs text-zinc-700">
-                  {(teamMemberIdsByTeamId[team.id] ?? []).map((memberId) => (
-                    <li key={`${team.id}-${memberId}`}>{memberId}</li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="text-xs text-zinc-500">초대된 멤버가 없습니다.</p>
-              )}
-              <div className="flex flex-col gap-2 sm:flex-row">
-                <input
-                  className="h-9 flex-1 rounded-md border border-zinc-300 bg-white px-3 text-sm"
-                  value={inviteInputByTeamId[team.id] ?? ""}
-                  onChange={(e) => setInviteInputByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
-                  placeholder="초대할 사용자 이메일(아이디)"
-                  autoComplete="off"
-                  disabled={inviteLoadingTeamId === team.id}
-                />
-                <button
-                  type="button"
-                  className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium disabled:opacity-60"
-                  disabled={inviteLoadingTeamId === team.id}
-                  onClick={() => void invite(team.id)}
-                >
-                  {inviteLoadingTeamId === team.id ? "초대 중..." : "아이디로 초대"}
-                </button>
+            <li key={team.id} className="space-y-4 px-4 py-4">
+              <div>
+                <p className="font-medium">{team.name}</p>
+                <p className="text-xs text-muted-foreground">id: {team.id}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  멤버 {(teamMemberIdsByTeamId[team.id] ?? []).length}명
+                </p>
+                {(teamMemberIdsByTeamId[team.id] ?? []).length > 0 ? (
+                  <ul className="mt-1 list-disc pl-5 text-xs text-muted-foreground">
+                    {(teamMemberIdsByTeamId[team.id] ?? []).map((memberId) => (
+                      <li key={`${team.id}-${memberId}`}>{memberId}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mt-1 text-xs text-muted-foreground">초대된 멤버가 없습니다.</p>
+                )}
+                <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+                  <input
+                    className="h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm"
+                    value={inviteInputByTeamId[team.id] ?? ""}
+                    onChange={(e) => setInviteInputByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
+                    placeholder="초대할 사용자 이메일(아이디)"
+                    autoComplete="off"
+                    disabled={inviteLoadingTeamId === team.id}
+                  />
+                  <button
+                    type="button"
+                    className="h-9 shrink-0 rounded-md border border-border bg-background px-3 text-xs font-medium disabled:opacity-60"
+                    disabled={inviteLoadingTeamId === team.id}
+                    onClick={() => void invite(team.id)}
+                  >
+                    {inviteLoadingTeamId === team.id ? "초대 중…" : "아이디로 초대"}
+                  </button>
+                </div>
               </div>
-              <div className="space-y-2 rounded-md border border-zinc-200 bg-zinc-50 p-3">
-                <p className="text-xs font-medium text-zinc-700">팀 API Key 등록</p>
-                <div className="flex flex-col gap-2">
+
+              <div className="space-y-2 rounded-md border border-border bg-muted/20 p-3">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold">등록된 팀 API Key</p>
+                  <p className="text-xs text-muted-foreground">
+                    Provider·별칭·미리보기·월 예산만 표시됩니다. 수정 시에는 별칭과 월 예산만 바꿀 수 있고, 키 값은 등록 시에만 설정됩니다.
+                  </p>
+                </div>
+                {apiKeysListErrorByTeamId[team.id] ? (
+                  <p className="text-xs text-destructive">{apiKeysListErrorByTeamId[team.id]}</p>
+                ) : null}
+
+                {(teamApiKeysByTeamId[team.id] ?? []).length > 0 ? (
+                  <ul className="divide-y divide-border rounded-md border border-border bg-background">
+                    {(teamApiKeysByTeamId[team.id] ?? []).map((apiKey) => {
+                      const isEditing = editingKey?.teamId === team.id && editingKey.row.id === apiKey.id
+                      const delKey = `${team.id}:${apiKey.id}`
+                      const deleting = deleteLoadingKey === delKey
+                      return (
+                        <li key={`${team.id}-key-${apiKey.id}`} className="flex flex-col gap-2 px-3 py-3 text-sm sm:flex-row sm:items-start sm:justify-between">
+                          <div className="min-w-0 space-y-1">
+                            <div className="font-medium">
+                              <span>{providerLabel(apiKey.provider)}</span>
+                              <span className="mx-2 text-muted-foreground">·</span>
+                              {isEditing ? (
+                                <span className="inline-flex flex-col gap-2 align-middle">
+                                  <input
+                                    className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+                                    value={editAlias}
+                                    onChange={(e) => setEditAlias(e.target.value)}
+                                    disabled={saveEditLoading}
+                                    autoComplete="off"
+                                  />
+                                  <input
+                                    type="number"
+                                    step={0.01}
+                                    min={0}
+                                    className="h-8 w-full max-w-[12rem] rounded-md border border-input bg-background px-2 text-sm"
+                                    inputMode="decimal"
+                                    value={editBudget}
+                                    onChange={(e) => {
+                                      const v = e.target.value
+                                      if (v === "") {
+                                        setEditBudget("")
+                                        return
+                                      }
+                                      const n = Number(v)
+                                      if (!Number.isFinite(n) || n < 0) return
+                                      setEditBudget(v)
+                                    }}
+                                    onBlur={() =>
+                                      setEditBudget((prev) =>
+                                        prev.trim() === "" ? prev : normalizeBudgetNumericString(prev),
+                                      )
+                                    }
+                                    placeholder="월 예산 USD"
+                                    disabled={saveEditLoading}
+                                  />
+                                </span>
+                              ) : (
+                                <span>{apiKey.alias}</span>
+                              )}
+                            </div>
+                            <p className="text-xs text-muted-foreground">{apiKey.keyPreview}</p>
+                            <p className="text-xs text-muted-foreground">
+                              월 예산:{" "}
+                              {formatBudgetUsd(apiKey.monthlyBudgetUsd ?? undefined) ?? "— (미설정·기존 데이터)"}
+                            </p>
+                          </div>
+                          <div className="flex shrink-0 flex-col items-stretch gap-2 sm:items-end">
+                            <div className="text-xs text-muted-foreground tabular-nums sm:text-right">
+                              {formatCreatedAt(apiKey.createdAt)}
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                              {isEditing ? (
+                                <>
+                                  <button
+                                    type="button"
+                                    className="rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                                    disabled={saveEditLoading}
+                                    onClick={() => void saveEditKey()}
+                                  >
+                                    {saveEditLoading ? "저장 중…" : "저장"}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                                    disabled={saveEditLoading}
+                                    onClick={cancelEditKey}
+                                  >
+                                    취소
+                                  </button>
+                                </>
+                              ) : (
+                                <button
+                                  type="button"
+                                  className="rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                                  disabled={deleting || saveEditLoading}
+                                  onClick={() => startEditKey(team.id, apiKey)}
+                                >
+                                  수정
+                                </button>
+                              )}
+                              {!isEditing ? (
+                                <button
+                                  type="button"
+                                  className="rounded-md border border-destructive/40 bg-background px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                                  disabled={deleting}
+                                  onClick={() => void deleteTeamKey(team.id, apiKey.id)}
+                                >
+                                  {deleting ? "삭제 중…" : "삭제"}
+                                </button>
+                              ) : null}
+                            </div>
+                          </div>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                ) : (
+                  <p className="rounded-md border border-dashed border-border bg-background px-4 py-4 text-center text-xs text-muted-foreground">
+                    등록된 팀 API Key가 없습니다. 아래에서 추가할 수 있습니다.
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-3 rounded-md border border-border bg-muted/10 p-3">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold">팀 API Key 등록</p>
+                  <p className="text-xs text-muted-foreground">제출 후 입력한 키 값은 보안을 위해 비웁니다.</p>
+                </div>
+                <div className="grid gap-2">
                   <select
-                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs"
+                    className="h-9 rounded-md border border-input bg-background px-3 text-sm"
                     value={apiKeyProviderByTeamId[team.id] ?? "OPENAI"}
-                    onChange={(e) => setApiKeyProviderByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
-                    disabled={apiKeyLoadingTeamId === team.id}
+                    onChange={(e) => {
+                      const p = e.target.value as TeamKeyProvider
+                      setApiKeyProviderByTeamId((prev) => ({ ...prev, [team.id]: p }))
+                      if (!apiKeyAliasTouchedByTeamId[team.id]) {
+                        setApiKeyAliasByTeamId((prev) => ({ ...prev, [team.id]: defaultAlias(p) }))
+                      }
+                    }}
+                    disabled={apiKeyRegisterLoadingTeamId === team.id}
                   >
                     <option value="OPENAI">OPENAI</option>
                     <option value="GEMINI">GEMINI</option>
                     <option value="CLAUDE">CLAUDE</option>
                   </select>
                   <input
-                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs"
+                    className="h-9 rounded-md border border-input bg-background px-3 text-sm"
                     value={apiKeyAliasByTeamId[team.id] ?? ""}
-                    onChange={(e) => setApiKeyAliasByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
-                    placeholder="API Key 별칭"
+                    onChange={(e) => {
+                      setApiKeyAliasTouchedByTeamId((prev) => ({ ...prev, [team.id]: true }))
+                      setApiKeyAliasByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))
+                    }}
+                    placeholder="별칭"
                     autoComplete="off"
-                    disabled={apiKeyLoadingTeamId === team.id}
+                    disabled={apiKeyRegisterLoadingTeamId === team.id}
                   />
+                  <div className="flex gap-1">
+                    <input
+                      type={apiKeyRevealByTeamId[team.id] ? "text" : "password"}
+                      className="h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-3 text-sm"
+                      value={apiKeyValueByTeamId[team.id] ?? ""}
+                      onChange={(e) => setApiKeyValueByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
+                      placeholder="API Key 값"
+                      autoComplete="new-password"
+                      disabled={apiKeyRegisterLoadingTeamId === team.id}
+                    />
+                    <button
+                      type="button"
+                      className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-input bg-background text-muted-foreground hover:bg-muted disabled:opacity-50"
+                      aria-label={apiKeyRevealByTeamId[team.id] ? "API Key 숨기기" : "API Key 보기"}
+                      disabled={apiKeyRegisterLoadingTeamId === team.id}
+                      onClick={() =>
+                        setApiKeyRevealByTeamId((prev) => ({ ...prev, [team.id]: !prev[team.id] }))
+                      }
+                    >
+                      {apiKeyRevealByTeamId[team.id] ? (
+                        <EyeOff className="h-4 w-4" aria-hidden />
+                      ) : (
+                        <Eye className="h-4 w-4" aria-hidden />
+                      )}
+                    </button>
+                  </div>
                   <input
-                    type="password"
-                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs"
-                    value={apiKeyValueByTeamId[team.id] ?? ""}
-                    onChange={(e) => setApiKeyValueByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
-                    placeholder="API Key 값"
-                    autoComplete="new-password"
-                    disabled={apiKeyLoadingTeamId === team.id}
+                    type="number"
+                    step={0.01}
+                    min={0}
+                    className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                    inputMode="decimal"
+                    value={apiKeyMonthlyBudgetByTeamId[team.id] ?? ""}
+                    onChange={(e) => {
+                      const v = e.target.value
+                      if (v === "") {
+                        setApiKeyMonthlyBudgetByTeamId((prev) => ({ ...prev, [team.id]: "" }))
+                        return
+                      }
+                      const n = Number(v)
+                      if (!Number.isFinite(n) || n < 0) return
+                      setApiKeyMonthlyBudgetByTeamId((prev) => ({ ...prev, [team.id]: v }))
+                    }}
+                    onBlur={() =>
+                      setApiKeyMonthlyBudgetByTeamId((prev) => {
+                        const cur = prev[team.id] ?? ""
+                        if (cur.trim() === "") return prev
+                        const next = normalizeBudgetNumericString(cur)
+                        if (next === cur) return prev
+                        return { ...prev, [team.id]: next }
+                      })
+                    }
+                    placeholder="월 예산 USD (스피너 ±0.01)"
+                    autoComplete="off"
+                    disabled={apiKeyRegisterLoadingTeamId === team.id}
                   />
+                  {apiKeyRegisterMessageByTeamId[team.id] ? (
+                    <p
+                      className={
+                        apiKeyRegisterMessageByTeamId[team.id]?.kind === "success"
+                          ? "text-xs text-emerald-600"
+                          : "text-xs text-destructive"
+                      }
+                    >
+                      {apiKeyRegisterMessageByTeamId[team.id]?.text}
+                    </p>
+                  ) : null}
                   <button
                     type="button"
-                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium disabled:opacity-60"
-                    disabled={apiKeyLoadingTeamId === team.id}
+                    className="inline-flex h-9 items-center rounded-md border border-border bg-background px-3 text-sm font-medium hover:bg-muted disabled:opacity-60"
+                    disabled={apiKeyRegisterLoadingTeamId === team.id}
                     onClick={() => void registerTeamApiKey(team.id)}
                   >
-                    {apiKeyLoadingTeamId === team.id ? "등록 중..." : "팀 API Key 등록"}
+                    {apiKeyRegisterLoadingTeamId === team.id ? "등록 중…" : "등록"}
                   </button>
                 </div>
-
-                {(teamApiKeysByTeamId[team.id] ?? []).length > 0 ? (
-                  <ul className="space-y-1 text-xs text-zinc-700">
-                    {(teamApiKeysByTeamId[team.id] ?? []).map((apiKey) => (
-                      <li key={`${team.id}-api-key-${apiKey.id}`} className="rounded border border-zinc-200 bg-white px-2 py-1">
-                        {apiKey.provider} / {apiKey.alias} / {apiKey.keyPreview}
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="text-xs text-zinc-500">등록된 팀 API Key가 없습니다.</p>
-                )}
               </div>
             </li>
           ))}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/TeamController.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/TeamController.java
@@ -5,6 +5,7 @@ import com.zerobugfreinds.team_service.dto.CreateTeamRequest;
 import com.zerobugfreinds.team_service.dto.InviteTeamMemberRequest;
 import com.zerobugfreinds.team_service.dto.RegisterTeamApiKeyRequest;
 import com.zerobugfreinds.team_service.dto.TeamApiKeySummaryResponse;
+import com.zerobugfreinds.team_service.dto.UpdateTeamApiKeyRequest;
 import com.zerobugfreinds.team_service.dto.TeamSummaryResponse;
 import com.zerobugfreinds.team_service.security.TeamUserPrincipal;
 import com.zerobugfreinds.team_service.service.TeamApiKeyService;
@@ -13,9 +14,11 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -80,9 +83,39 @@ public class TeamController {
 				teamId,
 				request.provider(),
 				request.alias(),
-				request.externalKey()
+				request.externalKey(),
+				request.monthlyBudgetUsd()
 		);
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok("팀 API 키가 등록되었습니다", created));
+	}
+
+	@PutMapping("/teams/{teamId}/api-keys/{keyId}")
+	public ResponseEntity<ApiResponse<TeamApiKeySummaryResponse>> updateTeamApiKey(
+			@AuthenticationPrincipal TeamUserPrincipal principal,
+			@PathVariable("teamId") Long teamId,
+			@PathVariable("keyId") Long keyId,
+			@Valid @RequestBody UpdateTeamApiKeyRequest request
+	) {
+		TeamApiKeySummaryResponse updated = teamApiKeyService.update(
+				principal.userId(),
+				teamId,
+				keyId,
+				request.provider(),
+				request.alias(),
+				request.externalKey(),
+				request.monthlyBudgetUsd()
+		);
+		return ResponseEntity.ok(ApiResponse.ok("팀 API 키가 수정되었습니다", updated));
+	}
+
+	@DeleteMapping("/teams/{teamId}/api-keys/{keyId}")
+	public ResponseEntity<ApiResponse<Void>> deleteTeamApiKey(
+			@AuthenticationPrincipal TeamUserPrincipal principal,
+			@PathVariable("teamId") Long teamId,
+			@PathVariable("keyId") Long keyId
+	) {
+		teamApiKeyService.delete(principal.userId(), teamId, keyId);
+		return ResponseEntity.ok(ApiResponse.ok("팀 API 키가 삭제되었습니다", null));
 	}
 
 	@GetMapping("/teams/{id}/api-keys")

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/TeamApiKeySummaryResponse.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/TeamApiKeySummaryResponse.java
@@ -1,5 +1,8 @@
 package com.zerobugfreinds.team_service.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
 import java.time.Instant;
 
 public record TeamApiKeySummaryResponse(
@@ -7,6 +10,7 @@ public record TeamApiKeySummaryResponse(
         String provider,
         String alias,
         String keyPreview,
+        @JsonProperty("monthlyBudgetUsd") BigDecimal monthlyBudgetUsd,
         Instant createdAt
 ) {
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/UpdateTeamApiKeyRequest.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/UpdateTeamApiKeyRequest.java
@@ -10,11 +10,12 @@ import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
 
-public record RegisterTeamApiKeyRequest(
-        @NotNull(message = "provider는 필수입니다")
+/**
+ * 팀 API 키 수정. {@code externalKey}가 비어 있으면 키 값은 유지하고 별칭·예산만 갱신한다.
+ */
+public record UpdateTeamApiKeyRequest(
         TeamApiKeyProvider provider,
 
-        @NotBlank(message = "externalKey는 필수입니다")
         @Size(max = 4096)
         @JsonProperty("externalKey")
         String externalKey,

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/entity/TeamApiKeyEntity.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/entity/TeamApiKeyEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 
 @Entity
@@ -51,6 +52,9 @@ public class TeamApiKeyEntity {
     @Column(name = "encrypted_key", nullable = false)
     private String encryptedKey;
 
+    @Column(name = "monthly_budget_usd", precision = 12, scale = 2)
+    private BigDecimal monthlyBudgetUsd;
+
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
@@ -62,7 +66,8 @@ public class TeamApiKeyEntity {
             TeamApiKeyProvider provider,
             String keyAlias,
             String keyHash,
-            String encryptedKey
+            String encryptedKey,
+            BigDecimal monthlyBudgetUsd
     ) {
         TeamApiKeyEntity entity = new TeamApiKeyEntity();
         entity.teamId = teamId;
@@ -70,8 +75,28 @@ public class TeamApiKeyEntity {
         entity.keyAlias = keyAlias;
         entity.keyHash = keyHash;
         entity.encryptedKey = encryptedKey;
+        entity.monthlyBudgetUsd = monthlyBudgetUsd;
         entity.createdAt = Instant.now();
         return entity;
+    }
+
+    public void updateCredential(
+            TeamApiKeyProvider provider,
+            String keyAlias,
+            String keyHash,
+            String encryptedKey,
+            BigDecimal monthlyBudgetUsd
+    ) {
+        this.provider = provider;
+        this.keyAlias = keyAlias;
+        this.keyHash = keyHash;
+        this.encryptedKey = encryptedKey;
+        this.monthlyBudgetUsd = monthlyBudgetUsd;
+    }
+
+    public void updateAliasAndBudget(String keyAlias, BigDecimal monthlyBudgetUsd) {
+        this.keyAlias = keyAlias;
+        this.monthlyBudgetUsd = monthlyBudgetUsd;
     }
 
     public Long getId() {
@@ -96,6 +121,10 @@ public class TeamApiKeyEntity {
 
     public String getEncryptedKey() {
         return encryptedKey;
+    }
+
+    public BigDecimal getMonthlyBudgetUsd() {
+        return monthlyBudgetUsd;
     }
 
     public Instant getCreatedAt() {

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamApiKeyRepository.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamApiKeyRepository.java
@@ -5,11 +5,23 @@ import com.zerobugfreinds.team_service.entity.TeamApiKeyEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TeamApiKeyRepository extends JpaRepository<TeamApiKeyEntity, Long> {
     List<TeamApiKeyEntity> findAllByTeamIdOrderByCreatedAtDesc(Long teamId);
 
+    Optional<TeamApiKeyEntity> findByIdAndTeamId(Long id, Long teamId);
+
     boolean existsByTeamIdAndProviderAndKeyHash(Long teamId, TeamApiKeyProvider provider, String keyHash);
 
     boolean existsByTeamIdAndKeyAlias(Long teamId, String keyAlias);
+
+    boolean existsByTeamIdAndKeyAliasAndIdNot(Long teamId, String keyAlias, Long id);
+
+    boolean existsByTeamIdAndProviderAndKeyHashAndIdNot(
+            Long teamId,
+            TeamApiKeyProvider provider,
+            String keyHash,
+            Long id
+    );
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Service
@@ -41,11 +42,15 @@ public class TeamApiKeyService {
             Long teamId,
             TeamApiKeyProvider provider,
             String alias,
-            String externalKey
+            String externalKey,
+            BigDecimal monthlyBudgetUsd
     ) {
         validateTeamAccess(actorUserId, teamId);
         if (provider == null) {
             throw new IllegalArgumentException("provider는 필수입니다");
+        }
+        if (monthlyBudgetUsd == null) {
+            throw new IllegalArgumentException("monthlyBudgetUsd는 필수입니다");
         }
 
         String normalizedAlias = normalizeAlias(alias);
@@ -61,9 +66,70 @@ public class TeamApiKeyService {
 
         String encrypted = encryptionUtil.encryptAes256Gcm(normalizedExternalKey);
         TeamApiKeyEntity saved = teamApiKeyRepository.save(
-                TeamApiKeyEntity.register(teamId, provider, normalizedAlias, keyHash, encrypted)
+                TeamApiKeyEntity.register(teamId, provider, normalizedAlias, keyHash, encrypted, monthlyBudgetUsd)
         );
         return toSummary(saved);
+    }
+
+    @Transactional
+    public TeamApiKeySummaryResponse update(
+            String actorUserId,
+            Long teamId,
+            Long apiKeyId,
+            TeamApiKeyProvider provider,
+            String alias,
+            String externalKey,
+            BigDecimal monthlyBudgetUsd
+    ) {
+        validateTeamAccess(actorUserId, teamId);
+        if (apiKeyId == null) {
+            throw new IllegalArgumentException("apiKeyId는 필수입니다");
+        }
+        if (monthlyBudgetUsd == null) {
+            throw new IllegalArgumentException("monthlyBudgetUsd는 필수입니다");
+        }
+
+        String normalizedAlias = normalizeAlias(alias);
+        String normalizedExternalKey = StringUtils.hasText(externalKey) ? externalKey.trim() : "";
+
+        TeamApiKeyEntity entity = teamApiKeyRepository.findByIdAndTeamId(apiKeyId, teamId)
+                .orElseThrow(() -> new IllegalArgumentException("팀 API 키를 찾을 수 없습니다"));
+
+        if (teamApiKeyRepository.existsByTeamIdAndKeyAliasAndIdNot(teamId, normalizedAlias, apiKeyId)) {
+            throw new IllegalArgumentException("이미 사용 중인 API Key 별칭입니다");
+        }
+
+        if (StringUtils.hasText(normalizedExternalKey)) {
+            if (provider == null) {
+                throw new IllegalArgumentException("externalKey를 변경할 때 provider는 필수입니다");
+            }
+            if (normalizedExternalKey.length() > 4096) {
+                throw new IllegalArgumentException("externalKey 길이가 너무 깁니다");
+            }
+            String keyHash = encryptionUtil.sha256HexForUniqueness(provider.name(), normalizedExternalKey);
+            if (teamApiKeyRepository.existsByTeamIdAndProviderAndKeyHashAndIdNot(
+                    teamId, provider, keyHash, apiKeyId
+            )) {
+                throw new IllegalArgumentException("이미 등록된 API Key입니다");
+            }
+            String encrypted = encryptionUtil.encryptAes256Gcm(normalizedExternalKey);
+            entity.updateCredential(provider, normalizedAlias, keyHash, encrypted, monthlyBudgetUsd);
+        } else {
+            entity.updateAliasAndBudget(normalizedAlias, monthlyBudgetUsd);
+        }
+
+        return toSummary(entity);
+    }
+
+    @Transactional
+    public void delete(String actorUserId, Long teamId, Long apiKeyId) {
+        validateTeamAccess(actorUserId, teamId);
+        if (apiKeyId == null) {
+            throw new IllegalArgumentException("apiKeyId는 필수입니다");
+        }
+        TeamApiKeyEntity entity = teamApiKeyRepository.findByIdAndTeamId(apiKeyId, teamId)
+                .orElseThrow(() -> new IllegalArgumentException("팀 API 키를 찾을 수 없습니다"));
+        teamApiKeyRepository.delete(entity);
     }
 
     @Transactional(readOnly = true)
@@ -113,6 +179,7 @@ public class TeamApiKeyService {
                 entity.getProvider().name(),
                 entity.getKeyAlias(),
                 maskedKeyPreview(entity.getProvider().name(), entity.getKeyHash()),
+                entity.getMonthlyBudgetUsd(),
                 entity.getCreatedAt()
         );
     }

--- a/services/team-service/web/package.json
+++ b/services/team-service/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@ai-usage/ui": "workspace:*",
+    "lucide-react": "^1.6.0",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/services/team-service/web/src/components/team/team-management-view.tsx
+++ b/services/team-service/web/src/components/team/team-management-view.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { Eye, EyeOff } from "lucide-react"
 
 type ApiResponse<T> = {
   success: boolean
@@ -13,6 +14,20 @@ type TeamSummary = {
   name: string
 }
 
+type TeamSummaryLike = {
+  id: string | number
+  name: string
+}
+
+type TeamApiKeySummary = {
+  id: number
+  provider: string
+  alias: string
+  keyPreview: string
+  monthlyBudgetUsd: number | null
+  createdAt: string
+}
+
 function asApiResponse(value: unknown): ApiResponse<unknown> | null {
   if (!value || typeof value !== "object") return null
   const r = value as Record<string, unknown>
@@ -20,6 +35,60 @@ function asApiResponse(value: unknown): ApiResponse<unknown> | null {
   if (typeof r.message !== "string") return null
   if (!("data" in r)) return null
   return r as ApiResponse<unknown>
+}
+
+function normalizeTeamSummary(item: unknown): TeamSummary | null {
+  if (!item || typeof item !== "object") return null
+  const v = item as TeamSummaryLike
+  if ((typeof v.id !== "string" && typeof v.id !== "number") || typeof v.name !== "string") return null
+  return { id: String(v.id), name: v.name }
+}
+
+function normalizeTeamApiKeySummary(item: unknown): TeamApiKeySummary | null {
+  if (!item || typeof item !== "object") return null
+  const v = item as Record<string, unknown>
+  if (typeof v.id !== "number") return null
+  if (typeof v.provider !== "string") return null
+  if (typeof v.alias !== "string") return null
+  if (typeof v.keyPreview !== "string") return null
+  if (typeof v.createdAt !== "string") return null
+  const b = v.monthlyBudgetUsd
+  let monthlyBudgetUsd: number | null = null
+  if (typeof b === "number" && Number.isFinite(b)) {
+    monthlyBudgetUsd = b
+  } else if (typeof b === "string" && b.trim() !== "") {
+    const n = Number(b)
+    if (Number.isFinite(n)) monthlyBudgetUsd = n
+  }
+  return {
+    id: v.id,
+    provider: v.provider,
+    alias: v.alias,
+    keyPreview: v.keyPreview,
+    monthlyBudgetUsd,
+    createdAt: v.createdAt,
+  }
+}
+
+function formatBudgetUsd(value: number | null | undefined) {
+  if (value === null || value === undefined) return null
+  return new Intl.NumberFormat("ko-KR", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+const BUDGET_STEP = 0.01
+
+function normalizeBudgetNumericString(raw: string): string {
+  const t = raw.trim()
+  if (t === "") return ""
+  const n = Number(t)
+  if (!Number.isFinite(n) || n < 0) return ""
+  const rounded = Math.round(n / BUDGET_STEP) * BUDGET_STEP
+  return Number(rounded.toFixed(2)).toString()
 }
 
 export function TeamManagementView() {
@@ -31,6 +100,18 @@ export function TeamManagementView() {
   const [inviteInputByTeamId, setInviteInputByTeamId] = React.useState<Record<string, string>>({})
   const [inviteLoadingTeamId, setInviteLoadingTeamId] = React.useState<string | null>(null)
   const [message, setMessage] = React.useState<{ kind: "success" | "error"; text: string } | null>(null)
+
+  const [teamApiKeysByTeamId, setTeamApiKeysByTeamId] = React.useState<Record<string, TeamApiKeySummary[]>>({})
+  const [apiKeyAliasByTeamId, setApiKeyAliasByTeamId] = React.useState<Record<string, string>>({})
+  const [apiKeyValueByTeamId, setApiKeyValueByTeamId] = React.useState<Record<string, string>>({})
+  const [apiKeyProviderByTeamId, setApiKeyProviderByTeamId] = React.useState<Record<string, string>>({})
+  const [apiKeyMonthlyBudgetByTeamId, setApiKeyMonthlyBudgetByTeamId] = React.useState<Record<string, string>>({})
+  const [apiKeyRevealByTeamId, setApiKeyRevealByTeamId] = React.useState<Record<string, boolean>>({})
+  const [apiKeyLoadingTeamId, setApiKeyLoadingTeamId] = React.useState<string | null>(null)
+  const [editingTeamApiKey, setEditingTeamApiKey] = React.useState<{ teamId: string; keyId: number } | null>(null)
+  const [editTeamApiKeyAlias, setEditTeamApiKeyAlias] = React.useState("")
+  const [editTeamApiKeyBudget, setEditTeamApiKeyBudget] = React.useState("")
+  const [teamApiKeyUpdateLoading, setTeamApiKeyUpdateLoading] = React.useState<string | null>(null)
 
   const loadTeams = React.useCallback(async () => {
     setLoading(true)
@@ -51,9 +132,8 @@ export function TeamManagementView() {
       }
       setTeams(
         body.data
-          .filter((item) => typeof item === "object" && item !== null)
-          .map((item) => item as TeamSummary)
-          .filter((item) => typeof item.id === "string" && typeof item.name === "string")
+          .map((item) => normalizeTeamSummary(item))
+          .filter((item): item is TeamSummary => item !== null)
       )
     } catch {
       setError("팀 목록을 불러오지 못했습니다")
@@ -63,9 +143,45 @@ export function TeamManagementView() {
     }
   }, [])
 
+  const loadTeamApiKeys = React.useCallback(async (teamId: string) => {
+    try {
+      const res = await fetch(`/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys`, {
+        method: "GET",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+      })
+      const json = (await res.json()) as unknown
+      const body = asApiResponse(json)
+      if (!res.ok || !body?.success || !Array.isArray(body.data)) {
+        setTeamApiKeysByTeamId((prev) => ({ ...prev, [teamId]: [] }))
+        return
+      }
+      const apiKeyItems = body.data as unknown[]
+      setTeamApiKeysByTeamId((prev) => ({
+        ...prev,
+        [teamId]: apiKeyItems
+          .map((item) => normalizeTeamApiKeySummary(item))
+          .filter((item): item is TeamApiKeySummary => item !== null),
+      }))
+    } catch {
+      setTeamApiKeysByTeamId((prev) => ({ ...prev, [teamId]: [] }))
+    }
+  }, [])
+
   React.useEffect(() => {
     void loadTeams()
   }, [loadTeams])
+
+  React.useEffect(() => {
+    if (teams.length === 0) {
+      setTeamApiKeysByTeamId({})
+      return
+    }
+    for (const team of teams) {
+      void loadTeamApiKeys(team.id)
+    }
+  }, [teams, loadTeamApiKeys])
 
   async function createTeam(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -131,11 +247,153 @@ export function TeamManagementView() {
     }
   }
 
+  function cancelEditTeamApiKey() {
+    setEditingTeamApiKey(null)
+    setEditTeamApiKeyAlias("")
+    setEditTeamApiKeyBudget("")
+    setTeamApiKeyUpdateLoading(null)
+  }
+
+  function startEditTeamApiKey(teamId: string, row: TeamApiKeySummary) {
+    setEditingTeamApiKey({ teamId, keyId: row.id })
+    setEditTeamApiKeyAlias(row.alias)
+    setEditTeamApiKeyBudget(
+      row.monthlyBudgetUsd !== null && row.monthlyBudgetUsd !== undefined ? String(row.monthlyBudgetUsd) : "",
+    )
+    setMessage(null)
+  }
+
+  async function saveEditTeamApiKey(teamId: string) {
+    if (!editingTeamApiKey || editingTeamApiKey.teamId !== teamId || teamApiKeyUpdateLoading) return
+    const aliasTrimmed = editTeamApiKeyAlias.trim()
+    const budgetTrimmed = editTeamApiKeyBudget.trim()
+    if (!aliasTrimmed) {
+      setMessage({ kind: "error", text: "API Key 별칭을 입력해 주세요" })
+      return
+    }
+    if (!budgetTrimmed) {
+      setMessage({ kind: "error", text: "월 예산은 필수입니다" })
+      return
+    }
+    const fracEdit = budgetTrimmed.includes(".") ? (budgetTrimmed.split(".")[1] ?? "") : ""
+    if (fracEdit.length > 2) {
+      setMessage({ kind: "error", text: "월 예산은 소수점 둘째 자리까지만 입력할 수 있습니다" })
+      return
+    }
+    const parsedBudget = Number(budgetTrimmed)
+    if (!Number.isFinite(parsedBudget) || parsedBudget < 0) {
+      setMessage({ kind: "error", text: "예산은 0 이상의 숫자로 입력해 주세요" })
+      return
+    }
+    const monthlyBudgetUsd = Number(parsedBudget.toFixed(2))
+
+    const keyId = editingTeamApiKey.keyId
+    const row = (teamApiKeysByTeamId[teamId] ?? []).find((k) => k.id === keyId)
+    if (row) {
+      const normalizedCurrentBudget =
+        row.monthlyBudgetUsd === null || row.monthlyBudgetUsd === undefined
+          ? null
+          : Number(row.monthlyBudgetUsd.toFixed(2))
+      if (aliasTrimmed === row.alias && monthlyBudgetUsd === normalizedCurrentBudget) {
+        cancelEditTeamApiKey()
+        return
+      }
+    }
+
+    setTeamApiKeyUpdateLoading(`${teamId}:${keyId}`)
+    setMessage(null)
+    try {
+      const body = { alias: aliasTrimmed, monthlyBudgetUsd }
+      const res = await fetch(
+        `/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys/${encodeURIComponent(String(keyId))}`,
+        {
+          method: "PUT",
+          credentials: "include",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify(body),
+        },
+      )
+      const json = (await res.json()) as unknown
+      const bodyRes = asApiResponse(json)
+      if (!res.ok || !bodyRes?.success) {
+        setMessage({ kind: "error", text: bodyRes?.message ?? "팀 API Key 수정에 실패했습니다" })
+        return
+      }
+      setMessage({ kind: "success", text: "팀 API Key가 수정되었습니다" })
+      cancelEditTeamApiKey()
+      await loadTeamApiKeys(teamId)
+    } catch {
+      setMessage({ kind: "error", text: "팀 API Key 수정에 실패했습니다" })
+    } finally {
+      setTeamApiKeyUpdateLoading(null)
+    }
+  }
+
+  async function registerTeamApiKey(teamId: string) {
+    if (apiKeyLoadingTeamId) return
+    const provider = (apiKeyProviderByTeamId[teamId] ?? "OPENAI").trim()
+    const alias = (apiKeyAliasByTeamId[teamId] ?? "").trim()
+    const externalKey = (apiKeyValueByTeamId[teamId] ?? "").trim()
+    const budgetTrimmed = (apiKeyMonthlyBudgetByTeamId[teamId] ?? "").trim()
+    if (!alias) {
+      setMessage({ kind: "error", text: "API Key 별칭을 입력해 주세요" })
+      return
+    }
+    if (!externalKey) {
+      setMessage({ kind: "error", text: "API Key 값을 입력해 주세요" })
+      return
+    }
+    if (!budgetTrimmed) {
+      setMessage({ kind: "error", text: "월 예산은 필수입니다" })
+      return
+    }
+    const fracReg = budgetTrimmed.includes(".") ? (budgetTrimmed.split(".")[1] ?? "") : ""
+    if (fracReg.length > 2) {
+      setMessage({ kind: "error", text: "월 예산은 소수점 둘째 자리까지만 입력할 수 있습니다" })
+      return
+    }
+    const parsedBudget = Number(budgetTrimmed)
+    if (!Number.isFinite(parsedBudget) || parsedBudget < 0) {
+      setMessage({ kind: "error", text: "예산은 0 이상의 숫자로 입력해 주세요" })
+      return
+    }
+    const monthlyBudgetUsd = Number(parsedBudget.toFixed(2))
+
+    setApiKeyLoadingTeamId(teamId)
+    setMessage(null)
+    try {
+      const res = await fetch(`/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ provider, alias, externalKey, monthlyBudgetUsd }),
+      })
+      const json = (await res.json()) as unknown
+      const body = asApiResponse(json)
+      if (!res.ok || !body?.success) {
+        setMessage({ kind: "error", text: body?.message ?? "팀 API Key 등록에 실패했습니다" })
+        return
+      }
+      setMessage({ kind: "success", text: "팀 API Key가 등록되었습니다" })
+      setApiKeyAliasByTeamId((prev) => ({ ...prev, [teamId]: "" }))
+      setApiKeyValueByTeamId((prev) => ({ ...prev, [teamId]: "" }))
+      setApiKeyMonthlyBudgetByTeamId((prev) => ({ ...prev, [teamId]: "" }))
+      setApiKeyRevealByTeamId((prev) => ({ ...prev, [teamId]: false }))
+      await loadTeamApiKeys(teamId)
+    } catch {
+      setMessage({ kind: "error", text: "팀 API Key 등록에 실패했습니다" })
+    } finally {
+      setApiKeyLoadingTeamId(null)
+    }
+  }
+
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-6 px-4 py-8">
       <header className="space-y-2">
         <h1 className="text-2xl font-semibold">팀 관리</h1>
-        <p className="text-sm text-zinc-600">팀 생성 후 사용자 아이디로 팀원을 초대할 수 있습니다.</p>
+        <p className="text-sm text-zinc-600">
+          팀 생성 후 사용자 아이디로 팀원을 초대할 수 있으며, 팀 API Key를 등록하고 월 예산(USD)을 설정할 수 있습니다.
+        </p>
       </header>
 
       <section className="space-y-3 rounded-lg border border-zinc-200 bg-white p-4">
@@ -189,6 +447,187 @@ export function TeamManagementView() {
                 >
                   {inviteLoadingTeamId === team.id ? "초대 중…" : "아이디로 초대"}
                 </button>
+              </div>
+
+              <div className="space-y-2 rounded-md border border-zinc-200 bg-zinc-50 p-3">
+                <p className="text-xs font-medium text-zinc-700">팀 API Key 등록</p>
+                <div className="flex flex-col gap-2">
+                  <select
+                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs"
+                    value={apiKeyProviderByTeamId[team.id] ?? "OPENAI"}
+                    onChange={(e) => setApiKeyProviderByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
+                    disabled={apiKeyLoadingTeamId === team.id}
+                  >
+                    <option value="OPENAI">OPENAI</option>
+                    <option value="GEMINI">GEMINI</option>
+                    <option value="CLAUDE">CLAUDE</option>
+                  </select>
+                  <input
+                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs"
+                    value={apiKeyAliasByTeamId[team.id] ?? ""}
+                    onChange={(e) => setApiKeyAliasByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
+                    placeholder="API Key 별칭"
+                    autoComplete="off"
+                    disabled={apiKeyLoadingTeamId === team.id}
+                  />
+                  <div className="flex gap-1">
+                    <input
+                      type={apiKeyRevealByTeamId[team.id] ? "text" : "password"}
+                      className="h-9 min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-3 text-xs"
+                      value={apiKeyValueByTeamId[team.id] ?? ""}
+                      onChange={(e) => setApiKeyValueByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
+                      placeholder="API Key 값"
+                      autoComplete="new-password"
+                      disabled={apiKeyLoadingTeamId === team.id}
+                    />
+                    <button
+                      type="button"
+                      className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-zinc-300 bg-white text-zinc-600 hover:bg-zinc-50 disabled:opacity-50"
+                      aria-label={apiKeyRevealByTeamId[team.id] ? "API Key 숨기기" : "API Key 보기"}
+                      disabled={apiKeyLoadingTeamId === team.id}
+                      onClick={() =>
+                        setApiKeyRevealByTeamId((prev) => ({ ...prev, [team.id]: !prev[team.id] }))
+                      }
+                    >
+                      {apiKeyRevealByTeamId[team.id] ? (
+                        <EyeOff className="h-4 w-4" aria-hidden />
+                      ) : (
+                        <Eye className="h-4 w-4" aria-hidden />
+                      )}
+                    </button>
+                  </div>
+                  <input
+                    type="number"
+                    step={0.01}
+                    min={0}
+                    className="h-9 w-full rounded-md border border-zinc-300 bg-white px-3 text-xs"
+                    value={apiKeyMonthlyBudgetByTeamId[team.id] ?? ""}
+                    onChange={(e) => {
+                      const v = e.target.value
+                      if (v === "") {
+                        setApiKeyMonthlyBudgetByTeamId((prev) => ({ ...prev, [team.id]: "" }))
+                        return
+                      }
+                      const n = Number(v)
+                      if (!Number.isFinite(n) || n < 0) return
+                      setApiKeyMonthlyBudgetByTeamId((prev) => ({ ...prev, [team.id]: v }))
+                    }}
+                    onBlur={() =>
+                      setApiKeyMonthlyBudgetByTeamId((prev) => {
+                        const cur = prev[team.id] ?? ""
+                        if (cur.trim() === "") return prev
+                        const next = normalizeBudgetNumericString(cur)
+                        if (next === cur) return prev
+                        return { ...prev, [team.id]: next }
+                      })
+                    }
+                    placeholder="월 예산 USD (스피너 ±0.01)"
+                    inputMode="decimal"
+                    autoComplete="off"
+                    disabled={apiKeyLoadingTeamId === team.id}
+                  />
+                  <button
+                    type="button"
+                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium disabled:opacity-60"
+                    disabled={apiKeyLoadingTeamId === team.id}
+                    onClick={() => void registerTeamApiKey(team.id)}
+                  >
+                    {apiKeyLoadingTeamId === team.id ? "등록 중…" : "팀 API Key 등록"}
+                  </button>
+                </div>
+
+                {(teamApiKeysByTeamId[team.id] ?? []).length > 0 ? (
+                  <ul className="space-y-2 text-xs text-zinc-700">
+                    {(teamApiKeysByTeamId[team.id] ?? []).map((apiKey) => {
+                      const isEditing =
+                        editingTeamApiKey?.teamId === team.id && editingTeamApiKey?.keyId === apiKey.id
+                      const updateKey = `${team.id}:${apiKey.id}`
+                      const updating = teamApiKeyUpdateLoading === updateKey
+                      return (
+                        <li
+                          key={`${team.id}-api-key-${apiKey.id}`}
+                          className="rounded border border-zinc-200 bg-white px-2 py-2"
+                        >
+                          {!isEditing ? (
+                            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                              <div>
+                                <p>
+                                  {apiKey.provider} / {apiKey.alias} / {apiKey.keyPreview}
+                                </p>
+                                <p className="text-[11px] text-zinc-500">
+                                  월 예산:{" "}
+                                  {formatBudgetUsd(apiKey.monthlyBudgetUsd ?? undefined) ?? "— (기존 데이터)"}
+                                </p>
+                              </div>
+                              <button
+                                type="button"
+                                className="h-8 shrink-0 rounded-md border border-zinc-300 bg-white px-2 text-[11px] font-medium"
+                                onClick={() => startEditTeamApiKey(team.id, apiKey)}
+                              >
+                                수정
+                              </button>
+                            </div>
+                          ) : (
+                            <div className="flex flex-col gap-2">
+                              <input
+                                className="h-8 rounded-md border border-zinc-300 bg-white px-2 text-xs"
+                                value={editTeamApiKeyAlias}
+                                onChange={(e) => setEditTeamApiKeyAlias(e.target.value)}
+                                placeholder="별칭"
+                                disabled={updating}
+                              />
+                              <input
+                                type="number"
+                                step={0.01}
+                                min={0}
+                                className="h-8 w-full max-w-[12rem] rounded-md border border-zinc-300 bg-white px-2 text-xs"
+                                value={editTeamApiKeyBudget}
+                                onChange={(e) => {
+                                  const v = e.target.value
+                                  if (v === "") {
+                                    setEditTeamApiKeyBudget("")
+                                    return
+                                  }
+                                  const n = Number(v)
+                                  if (!Number.isFinite(n) || n < 0) return
+                                  setEditTeamApiKeyBudget(v)
+                                }}
+                                onBlur={() =>
+                                  setEditTeamApiKeyBudget((prev) =>
+                                    prev.trim() === "" ? prev : normalizeBudgetNumericString(prev),
+                                  )
+                                }
+                                placeholder="월 예산 USD"
+                                inputMode="decimal"
+                                disabled={updating}
+                              />
+                              <div className="flex gap-2">
+                                <button
+                                  type="button"
+                                  className="h-8 rounded-md bg-black px-3 text-[11px] font-medium text-white disabled:opacity-60"
+                                  disabled={updating}
+                                  onClick={() => void saveEditTeamApiKey(team.id)}
+                                >
+                                  {updating ? "저장 중…" : "저장"}
+                                </button>
+                                <button
+                                  type="button"
+                                  className="h-8 rounded-md border border-zinc-300 bg-white px-3 text-[11px] font-medium"
+                                  disabled={updating}
+                                  onClick={cancelEditTeamApiKey}
+                                >
+                                  취소
+                                </button>
+                              </div>
+                            </div>
+                          )}
+                        </li>
+                      )
+                    })}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-zinc-500">등록된 팀 API Key가 없습니다.</p>
+                )}
               </div>
             </li>
           ))}


### PR DESCRIPTION
## 연관된 이슈
> # (해당 이슈 번호가 있으면 기입)

## 작업 내용
- **해당 서비스**: **Identity (Next.js web)**, **Team Service (Spring Boot)**, **Team BFF (Next.js web)**, **문서**

이번 PR에서는 팀·팀 API Key 흐름을 맞추고 UX를 정리했습니다.

- **팀 월 예산(USD)**: 팀 생성·수정·팀 API Key 등록·수정에서 예산을 다루고, **소수 둘째 자리·0.01 단위**로 입력·검증합니다. Identity 팀 화면과 Team 웹 모두 **`type="number"`, `step={0.01}`** 로 스피너(화살표)로 ±0.01 조정이 가능하며, `onBlur` 시 `normalizeBudgetNumericString`으로 정규화합니다.
- **팀 API Key 수정**: 웹 UI는 **별칭(`alias`)·월 예산(`monthlyBudgetUsd`)만** 수정 요청으로 보냅니다. 서버는 `externalKey`가 비어 있지 않을 때만 키 값·provider 갱신을 허용하도록 계약을 문서에 반영했습니다 (`docs/contracts/web-team-bff.md`).
- **팀 API Key 삭제**: 삭제 API 및 UI 연동.
- **팀 API Key 등록 UX**: 등록 폼의 키 입력 오른쪽에 **눈 아이콘**으로 평문 표시 ↔ 마스킹(`password`) 토글 (Identity `teams-view`, Team `team-management-view`). 등록 성공 시 입력값·표시 상태 초기화.
- **Team 웹**: `lucide-react` 의존성 추가, 루트 `pnpm-lock.yaml` 갱신.
- **백엔드(Team Service)**: 팀 API Key DTO/엔티티/저장소/서비스/컨트롤러에 예산·수정·삭제 관련 변경 반영.
- **아키텍처 문서**: `docs/architecture.md`에 이번 경계/흐름 정리 반영.

## 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`) — `package.json` / lockfile, 문서

## 상세 내용
- **`services/identity-service/web/src/components/account/teams-view.tsx`**: 팀 예산 number 입력·0.01 스텝·blur 정규화, 팀 API Key 등록 시 키 필드 show/hide 토글.
- **`services/team-service/web/src/components/team/team-management-view.tsx`**: 동일 예산 UX, 팀 API Key 등록 키 필드 show/hide 토글.
- **`services/team-service/web/package.json`**: `lucide-react` 추가.
- **`services/team-service/src/main/java/...`**: `TeamController`, `TeamApiKeyService`, `TeamApiKeyRepository`, `TeamApiKeyEntity`, `RegisterTeamApiKeyRequest`, `UpdateTeamApiKeyRequest`, `TeamApiKeySummaryResponse` 등 팀 API Key 예산·수정·삭제 처리.
- **`docs/contracts/web-team-bff.md`**: PUT 본문(별칭·예산 중심 UI) 및 키 갱신 조건, DELETE 설명 등 계약 정리.
- **`docs/architecture.md`**: 관련 아키텍처 설명 보강.
- **`pnpm-lock.yaml`**: 의존성 lock 반영.

## 인프라 및 통신 체크
- [ ] **Redis**: 해당 없음 (이번 변경에 캐시/Quota 로직 없음)
- [ ] **RabbitMQ**: 해당 없음 (발행/소비 로직 없음)
- [x] **DB**: 팀 API Key 쪽 **엔티티/스키마(예: `monthlyBudgetUsd` 등)** 반영 — 마이그레이션 전략이 별도로 있다면 PR/배포 노트에 명시 권장

## 스크린샷 / 테스트 결과 (선택)
- (선택) 팀 예산 스피너·키 필드 눈 버튼 동작 캡처
- 로컬에서 `identity-service/web`, `team-service/web` 각각 `npm run lint` 통과 권장

## 리뷰 요구사항
- 팀 API Key **PUT**이 웹에서는 alias·budget만 보내는지, 서버 검증·중복 규칙이 의도와 맞는지 확인 부탁드립니다.
- **DB 마이그레이션**이 수동/자동 중 어떤 방식인지, 운영 DB에 컬럼 추가가 필요하면 배포 순서를 한 번 짚어 주시면 좋겠습니다.