### PR TITLE
fix/팀 api key 노출 제거, 예산 설명 수정, 팀 목록 ui 수정

### DIFF
--- a/docs/contracts/web-team-bff.md
+++ b/docs/contracts/web-team-bff.md
@@ -1,7 +1,7 @@
 # Web(Next.js) ↔ Team Service BFF 계약
 
-버전: 0.1  
-관련: [web-split-boundary.md](./web-split-boundary.md), [web-identity-bff.md](./web-identity-bff.md)
+버전: 0.2  
+관련: [web-split-boundary.md](./web-split-boundary.md), [web-identity-bff.md](./web-identity-bff.md) — `/teams` UI 소유·경로: §2.3
 
 ---
 
@@ -45,7 +45,7 @@
 - 팀원 초대 시 Team Service는 Identity 내부 API(`GET /internal/users/exists?email=...`)로
   사용자 존재 여부를 확인한 뒤, **실제로 존재하는 아이디(이메일)만** 초대를 허용한다.
 - 팀 API Key는 Team Service DB에 **평문 저장하지 않고 암호화 저장**한다.
-- 팀 API Key 조회 응답에는 `keyPreview`(마스킹된 미리보기)만 제공하고, 원문 키는 반환하지 않는다.
+- 팀 API Key 조회·등록·수정 응답에는 **원문 키를 포함하지 않는다**(미리보기 필드 없음). 저장은 DB에 암호화된다.
 
 ---
 
@@ -66,7 +66,7 @@
 
 - `POST /api/team/v1/teams/{id}/api-keys`
   - 요청 본문: `provider` (`OPENAI`/`GEMINI`/`CLAUDE`), `alias`, `externalKey`, `monthlyBudgetUsd` (0 이상, USD 월 예산 한도 — identity-service 외부 키와 동일 개념)
-  - 성공: `201`, `data`에 등록된 키 요약(`id`, `provider`, `alias`, `keyPreview`, `monthlyBudgetUsd`, `createdAt`)
+  - 성공: `201`, `data`에 등록된 키 요약(`id`, `provider`, `alias`, `monthlyBudgetUsd`, `createdAt`)
   - 실패:
     - `400` (`success=false`): 필수값 누락, alias 중복, 동일 provider+key 중복
     - `403` (`success=false`): 팀 멤버가 아닌 사용자의 등록 시도
@@ -86,3 +86,36 @@
   - 실패:
     - `403` (`success=false`): 팀 멤버가 아닌 사용자의 조회 시도
     - `404` (`success=false`): 대상 팀이 존재하지 않는 경우
+
+---
+
+## 6. Identity `web` `/teams` 화면·데모 순서 (현행 구현)
+
+구현 정본: `services/identity-service/web/src/components/account/teams-view.tsx`, `services/identity-service/web/src/app/teams/[[...path]]/page.tsx`. 팀 백엔드: `services/team-service/` (`TeamService.createTeam` 등).
+
+### 6.1 내비게이션
+
+- 좌측 대시보드 셸에서 **`팀`** → 브라우저 경로 **`/teams`** (Identity `web`이 페이지를 소유한다).
+- **`조직`** (`/organizations`)과는 **별도** 상위 메뉴이며, **「조직 설정 > 팀 관리」** 같은 중첩 메뉴는 없다.
+- 조직 맥락 뱃지·우측 상단 **「+ 새 팀 추가」** 전용 버튼·중앙 **데이터 테이블** 형태의 팀 그리드는 **본 저장소 UI에 없다** (데모 시나리오 작성 시 혼동하지 말 것).
+
+### 6.2 팀 만들기
+
+1. **`팀 만들기`**를 누르면 같은 카드 영역에 **인라인 폼**이 열린다(별도 중앙 모달 전용 컴포넌트가 아니다).
+2. **팀 이름 (필수)** 입력.
+3. **팀원 초대 (선택)** — 이메일(아이디) 입력란을 여러 개 둘 수 있다. 비우면 생성자만 멤버가 된다.
+4. **`생성`** — `POST /api/team/v1/teams` 본문은 **`{ "name": "…" }` 만** 보낸다. 생성이 성공한 뒤, 초대 이메일이 있으면 **팀별로** `POST /api/team/v1/teams/{id}/members` 를 연속 호출한다.
+5. **`취소`** — 폼을 닫는다.
+
+**팀 리더 지정 UI는 없다.** Team Service는 팀 생성 요청을 보낸 사용자를 멤버로 넣고 **OWNER** 역할을 부여한다.
+
+### 6.3 팀 목록 표시
+
+- 목록은 **데이터 테이블(컬럼: 리더·인원·생성일 등)** 이 아니라, **접이식(아코디언) 목록**이다.
+- 접힌 행에는 **팀 이름**만 보인다.
+- 행을 눌러 펼치면 팀 `id`, 멤버 수·이메일 목록, 초대 입력, 팀 API Key 등록·목록·수정·삭제 영역이 나온다. 펼친 팀에 대해서만 멤버/API Key 목록 API를 호출한다.
+- `GET /api/team/v1/me/teams` 응답의 팀 요약은 **`id`, `name`** 수준이며, **리더·인원 수·생성일**을 한 줄로 주지 않는다. 검증은 **이름이 목록에 나타나는지**, 펼쳤을 때 **멤버·초대·키** 동작이 보이는지로 맞춘다.
+
+### 6.4 Team `web` (`services/team-service/web/`)
+
+- 동일 도메인 로직을 **Team 전용 Next**에서도 볼 수 있다. UI 패턴(팀 만들기·접이식 목록 등)은 `team-management-view.tsx`가 대응한다. 브라우저 진입점으로는 보통 Identity의 **`/teams`** 를 쓴다([web-split-boundary.md](./web-split-boundary.md) §2.3).

--- a/docs/contracts/web-team-bff.md
+++ b/docs/contracts/web-team-bff.md
@@ -1,6 +1,6 @@
 # Web(Next.js) ↔ Team Service BFF 계약
 
-버전: 0.2  
+버전: 0.4  
 관련: [web-split-boundary.md](./web-split-boundary.md), [web-identity-bff.md](./web-identity-bff.md) — `/teams` UI 소유·경로: §2.3
 
 ---
@@ -22,9 +22,10 @@
 | `GET /api/team/v1/teams/{id}/api-keys` | Team BFF `GET /api/team/v1/teams/{id}/api-keys` → Team Service `GET /api/v1/teams/{id}/api-keys` |
 | `POST /api/team/v1/teams/{id}/api-keys` | Team BFF `POST /api/team/v1/teams/{id}/api-keys` → Team Service `POST /api/v1/teams/{id}/api-keys` |
 | `PUT /api/team/v1/teams/{teamId}/api-keys/{keyId}` | Team BFF `PUT ...` → Team Service `PUT /api/v1/teams/{teamId}/api-keys/{keyId}` |
-| `DELETE /api/team/v1/teams/{teamId}/api-keys/{keyId}` | Team BFF `DELETE ...` → Team Service `DELETE /api/v1/teams/{teamId}/api-keys/{keyId}` |
+| `DELETE /api/team/v1/teams/{teamId}/api-keys/{keyId}` | Team BFF `DELETE ...` → Team Service `DELETE /api/v1/teams/{teamId}/api-keys/{keyId}` (선택 쿼리 `gracePeriodDays`) |
+| `POST /api/team/v1/teams/{teamId}/api-keys/{keyId}/deletion/cancel` | Team BFF `POST ...` → Team Service `POST /api/v1/teams/{teamId}/api-keys/{keyId}/deletion/cancel` |
 
-- Identity `web`는 `/teams` UI(팀·멤버·팀 API Key·예산)를 렌더링하고, Next rewrite로 `GET/POST/PUT/DELETE /api/team/v1/*`를 Team BFF(`team-web`)로 전달한다.
+- Identity `web`는 `/teams` UI(팀·멤버·팀 API Key·예산)를 렌더링하고, Next rewrite로 `GET/POST/PUT/DELETE /api/team/v1/*`를 Team BFF(`team-web`)로 전달한다(삭제 예정 해제용 `POST .../deletion/cancel` 포함).
 - Team BFF는 `TEAM_SERVICE_URL` 환경 변수로 Team Service를 프록시한다.
 - Team BFF는 `IDENTITY_SERVICE_URL`로 세션 확인(`GET /api/auth/session`)을 프록시한다.
 
@@ -40,7 +41,7 @@
 
 ## 4. 보안/권한
 
-- 팀 생성/조회/초대/팀 API Key 등록·조회·수정·삭제는 모두 인증 필요다.
+- 팀 생성/조회/초대/팀 API Key 등록·조회·수정·삭제 예정 등록·삭제 예정 해제는 모두 인증 필요다.
 - 권한 검증(팀 멤버만 초대 가능 등)은 Team Service가 최종 책임을 가진다.
 - 팀원 초대 시 Team Service는 Identity 내부 API(`GET /internal/users/exists?email=...`)로
   사용자 존재 여부를 확인한 뒤, **실제로 존재하는 아이디(이메일)만** 초대를 허용한다.
@@ -62,27 +63,47 @@
   - `403` (`success=false`): 요청자가 해당 팀의 초대 권한이 없는 경우
   - `404` (`success=false`): 대상 팀이 존재하지 않는 경우
 
-### 5.2 팀 API Key 등록/조회/수정
+### 5.2 팀 API Key 등록/조회/수정·삭제 예정
+
+#### 팀 API Key 요약 객체 (`data` 및 목록 항목)
+
+| 필드 | 설명 |
+|---|---|
+| `id` | 키 행 ID |
+| `provider` | `OPENAI` / `GEMINI` / `CLAUDE` |
+| `alias` | 별칭 |
+| `monthlyBudgetUsd` | 월 예산(USD), 숫자 |
+| `createdAt` | 생성 시각(ISO-8601) |
+| `deletionRequestedAt` | 삭제 예정 요청 시각. 삭제 예정이 아니면 보통 응답에 포함되지 않음(null 생략). |
+| `permanentDeletionAt` | 유예 종료·영구 삭제 예정 시각. 삭제 예정이 아니면 생략. |
+| `deletionGraceDays` | 삭제 요청 시 선택한 유예 기간(일). 생략 시 서버 기본은 7일. 삭제 예정이 아니면 생략. |
 
 - `POST /api/team/v1/teams/{id}/api-keys`
   - 요청 본문: `provider` (`OPENAI`/`GEMINI`/`CLAUDE`), `alias`, `externalKey`, `monthlyBudgetUsd` (0 이상, USD 월 예산 한도 — identity-service 외부 키와 동일 개념)
-  - 성공: `201`, `data`에 등록된 키 요약(`id`, `provider`, `alias`, `monthlyBudgetUsd`, `createdAt`)
+  - 성공: `201`, `data`에 등록된 키 요약(위 표의 활성 키에 해당하는 필드)
   - 실패:
-    - `400` (`success=false`): 필수값 누락, alias 중복, 동일 provider+key 중복
+    - `400` (`success=false`): 필수값 누락, alias 중복, 동일 provider+키 값(해시)이 **이미 활성**인 경우 `이미 등록된 API Key입니다`, 동일 해시가 **삭제 예정** 행에 있으면 `삭제 예정키와 중복입니다`
     - `403` (`success=false`): 팀 멤버가 아닌 사용자의 등록 시도
     - `404` (`success=false`): 대상 팀이 존재하지 않는 경우
 
 - `PUT /api/team/v1/teams/{teamId}/api-keys/{keyId}`
   - 요청 본문: `alias`, `monthlyBudgetUsd` (필수). Identity `/teams`·team `web` UI는 별칭·예산만 보낸다. 서버는 `externalKey`가 비어 있지 않을 때에만 키 값·provider 갱신을 허용한다(내부·다른 클라이언트용).
   - 성공: `200`, 수정된 키 요약
-  - 실패: `400` (검증/중복/대상 없음), `403`, `404`
+  - 실패: `400` (검증/중복/대상 없음, **삭제 예정인 키는 수정 불가**), `403`, `404`
 
 - `DELETE /api/team/v1/teams/{teamId}/api-keys/{keyId}`
-  - 성공: `200`, 해당 키 행을 DB에서 제거(영구 삭제). Identity 개인 키의 「삭제 예약」과는 별도 정책이다.
-  - 실패: `400` (대상 없음 등), `403`, `404`
+  - 선택 쿼리: `gracePeriodDays` (정수, 생략 시 **기본 7일**). `deletionRequestedAt`을 현재 시각으로, `permanentDeletionAt`을 그 시각 + `gracePeriodDays`일 후로 둔다. 허용 범위는 Team Service 구현상 **1~365일**.
+  - 동작: **소프트 삭제(삭제 예정)**. 유예 기간이 끝난 뒤 DB에서 행을 제거하는 **배치/스케줄러는 별도 구현**일 수 있다(계약만으로 보장하지 않음).
+  - 성공: `200`, `message` 예: `팀 API 키가 삭제 예정으로 등록되었습니다`, `data`에 해당 키 요약(삭제 예정 필드 포함)
+  - 실패: `400` (대상 없음·유예 일수 범위 밖·이미 삭제 예정 등), `403`, `404`
+
+- `POST /api/team/v1/teams/{teamId}/api-keys/{keyId}/deletion/cancel`
+  - 본문 없음. 삭제 예정이었던 키를 다시 활성 상태로 되돌린다(`deletionRequestedAt` / `permanentDeletionAt` / `deletionGraceDays` 해제).
+  - 성공: `200`, `message` 예: `삭제 예정이 해제되었습니다`, `data`에 활성 키 요약
+  - 실패: `400` (삭제 예정이 아님 등), `403`, `404`
 
 - `GET /api/team/v1/teams/{id}/api-keys`
-  - 성공: `200`, 팀 API Key 목록(요약 정보만 반환, `monthlyBudgetUsd` 포함)
+  - 성공: `200`, 팀 API Key 목록(요약만, `monthlyBudgetUsd` 포함). 삭제 예정 행은 `deletionRequestedAt`, `permanentDeletionAt`, `deletionGraceDays`가 채워진다.
   - 실패:
     - `403` (`success=false`): 팀 멤버가 아닌 사용자의 조회 시도
     - `404` (`success=false`): 대상 팀이 존재하지 않는 경우
@@ -116,6 +137,16 @@
 - 행을 눌러 펼치면 팀 `id`, 멤버 수·이메일 목록, 초대 입력, 팀 API Key 등록·목록·수정·삭제 영역이 나온다. 펼친 팀에 대해서만 멤버/API Key 목록 API를 호출한다.
 - `GET /api/team/v1/me/teams` 응답의 팀 요약은 **`id`, `name`** 수준이며, **리더·인원 수·생성일**을 한 줄로 주지 않는다. 검증은 **이름이 목록에 나타나는지**, 펼쳤을 때 **멤버·초대·키** 동작이 보이는지로 맞춘다.
 
-### 6.4 Team `web` (`services/team-service/web/`)
+### 6.4 팀 API Key 삭제 예정·유예·취소 (Identity `/teams`)
+
+구현: `teams-view.tsx`. 서버 기본 유예 **7일**, 요청 시 **1~365일**(`gracePeriodDays`).
+
+1. **삭제 예정 등록** — 활성 키 행에서 **`삭제`** → 확인 대화상자 → 브라우저 **`prompt`로 유예 기간(일)** 입력(비우면 7일). `DELETE .../api-keys/{keyId}?gracePeriodDays=...` 호출.
+2. **삭제 예정 표시** — 해당 행에 `(삭제 예정)` 안내, **영구 삭제 예정 시각**·유예 일수 표시, **`수정` 비활성**.
+3. **삭제 취소** — **`삭제 취소`** → 확인 후 `POST .../api-keys/{keyId}/deletion/cancel`. 성공 시 다시 활성 키로 표시.
+4. **동일 키 재등록** — 삭제 예정 중인 키와 같은 provider+키 값으로 등록 시 서버 메시지 `삭제 예정키와 중복입니다`.
+
+### 6.5 Team `web` (`services/team-service/web/`)
 
 - 동일 도메인 로직을 **Team 전용 Next**에서도 볼 수 있다. UI 패턴(팀 만들기·접이식 목록 등)은 `team-management-view.tsx`가 대응한다. 브라우저 진입점으로는 보통 Identity의 **`/teams`** 를 쓴다([web-split-boundary.md](./web-split-boundary.md) §2.3).
+- `team-management-view`는 팀 API Key **목록·삭제 예정 안내(영구 삭제 예정 시각 등)** 를 볼 수 있으나, **삭제 예정 등록·삭제 취소** 전용 버튼은 Identity `/teams`와 다를 수 있다(필요 시 동일 API로 확장 가능).

--- a/services/identity-service/web/src/components/account/teams-view.tsx
+++ b/services/identity-service/web/src/components/account/teams-view.tsx
@@ -24,6 +24,9 @@ type TeamApiKeySummary = {
   alias: string
   monthlyBudgetUsd: number | null
   createdAt: string
+  deletionRequestedAt?: string | null
+  permanentDeletionAt?: string | null
+  deletionGraceDays?: number | null
 }
 
 function asApiResponse(json: unknown): ApiResponse<unknown> | null {
@@ -57,12 +60,22 @@ function normalizeTeamApiKeySummary(item: unknown): TeamApiKeySummary | null {
     const n = Number(b)
     if (Number.isFinite(n)) monthlyBudgetUsd = n
   }
+  const delReq = v.deletionRequestedAt
+  const delPerm = v.permanentDeletionAt
+  const gd = v.deletionGraceDays
+  let deletionGraceDays: number | null = null
+  if (typeof gd === "number" && Number.isFinite(gd)) {
+    deletionGraceDays = gd
+  }
   return {
     id: v.id,
     provider: v.provider,
     alias: v.alias,
     monthlyBudgetUsd,
     createdAt: v.createdAt,
+    deletionRequestedAt: typeof delReq === "string" ? delReq : null,
+    permanentDeletionAt: typeof delPerm === "string" ? delPerm : null,
+    deletionGraceDays,
   }
 }
 
@@ -94,6 +107,10 @@ function formatBudgetUsd(value: number | null | undefined) {
 }
 
 const BUDGET_STEP = 0.01
+
+const DEFAULT_DELETION_GRACE_DAYS = 7
+const MIN_DELETION_GRACE_DAYS = 1
+const MAX_DELETION_GRACE_DAYS = 365
 
 /** blur 또는 스피너 조정 후 소수 둘째 자리·0.01 단위로 맞춤 */
 function normalizeBudgetNumericString(raw: string): string {
@@ -138,6 +155,7 @@ export function TeamsView() {
   const [editBudget, setEditBudget] = React.useState("")
   const [saveEditLoading, setSaveEditLoading] = React.useState(false)
   const [deleteLoadingKey, setDeleteLoadingKey] = React.useState<string | null>(null)
+  const [cancelDeleteLoadingKey, setCancelDeleteLoadingKey] = React.useState<string | null>(null)
   /** 목록에서는 이름만 보이고, 펼친 팀만 상세·API 조회 */
   const [openTeamId, setOpenTeamId] = React.useState<string | null>(null)
 
@@ -509,15 +527,31 @@ export function TeamsView() {
 
   async function deleteTeamKey(teamId: string, keyId: number) {
     const ok = window.confirm(
-      "이 팀 API 키를 즉시 삭제합니다.\n\nDB에서 영구 삭제되며 복구할 수 없습니다. 과거 사용량 로그는 다른 서비스 기록에 남을 수 있습니다.",
+      `이 팀 API 키를 삭제 예정으로 등록합니다.\n\n유예 기간이 지나면 영구 삭제되며, 유예 중에는 언제든 삭제를 취소할 수 있습니다.\n유예 중에는 동일 키 값으로 재등록할 수 없습니다.\n\n다음 단계에서 유예 기간(일)을 입력합니다. (기본 ${DEFAULT_DELETION_GRACE_DAYS}일)`,
     )
     if (!ok) return
+    const raw = window.prompt(
+      `유예 기간(일) (${MIN_DELETION_GRACE_DAYS}~${MAX_DELETION_GRACE_DAYS}, 비우면 ${DEFAULT_DELETION_GRACE_DAYS}일)`,
+      String(DEFAULT_DELETION_GRACE_DAYS),
+    )
+    if (raw === null) return
+    const trimmed = raw.trim()
+    let graceDays = DEFAULT_DELETION_GRACE_DAYS
+    if (trimmed !== "") {
+      const n = Number.parseInt(trimmed, 10)
+      if (!Number.isFinite(n) || n < MIN_DELETION_GRACE_DAYS || n > MAX_DELETION_GRACE_DAYS) {
+        setKeysError(`유예 기간은 ${MIN_DELETION_GRACE_DAYS}~${MAX_DELETION_GRACE_DAYS}일 사이의 정수로 입력해 주세요`)
+        return
+      }
+      graceDays = n
+    }
     const loadingKey = `${teamId}:${keyId}`
     setDeleteLoadingKey(loadingKey)
     setKeysError(null)
     try {
+      const q = new URLSearchParams({ gracePeriodDays: String(graceDays) })
       const { response, json } = await apiFetch<unknown>(
-        `/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys/${encodeURIComponent(String(keyId))}`,
+        `/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys/${encodeURIComponent(String(keyId))}?${q.toString()}`,
         { method: "DELETE", credentials: "include", cache: "no-store", headers: { Accept: "application/json" } },
         { authRequired: true }
       )
@@ -532,6 +566,32 @@ export function TeamsView() {
       setKeysError("삭제에 실패했습니다")
     } finally {
       setDeleteLoadingKey(null)
+    }
+  }
+
+  async function cancelTeamKeyDeletion(teamId: string, keyId: number) {
+    const ok = window.confirm("삭제 예정을 해제하고 이 키를 계속 사용하시겠습니까?")
+    if (!ok) return
+    const loadingKey = `${teamId}:${keyId}`
+    setCancelDeleteLoadingKey(loadingKey)
+    setKeysError(null)
+    try {
+      const { response, json } = await apiFetch<unknown>(
+        `/api/team/v1/teams/${encodeURIComponent(teamId)}/api-keys/${encodeURIComponent(String(keyId))}/deletion/cancel`,
+        { method: "POST", credentials: "include", cache: "no-store", headers: { Accept: "application/json" } },
+        { authRequired: true },
+      )
+      const apiResponse = asApiResponse(json)
+      if (response.ok && apiResponse?.success) {
+        if (editingKey?.teamId === teamId && editingKey.row.id === keyId) cancelEditKey()
+        await loadTeamApiKeys(teamId)
+      } else {
+        setKeysError(apiResponse?.message ?? "삭제 예정 해제에 실패했습니다")
+      }
+    } catch {
+      setKeysError("삭제 예정 해제에 실패했습니다")
+    } finally {
+      setCancelDeleteLoadingKey(null)
     }
   }
 
@@ -807,6 +867,8 @@ export function TeamsView() {
                       const isEditing = editingKey?.teamId === team.id && editingKey.row.id === apiKey.id
                       const delKey = `${team.id}:${apiKey.id}`
                       const deleting = deleteLoadingKey === delKey
+                      const canceling = cancelDeleteLoadingKey === delKey
+                      const keyPendingDeletion = Boolean(apiKey.deletionRequestedAt)
                       return (
                         <li key={`${team.id}-key-${apiKey.id}`} className="flex flex-col gap-2 px-3 py-3 text-sm sm:flex-row sm:items-start sm:justify-between">
                           <div className="min-w-0 space-y-1">
@@ -849,13 +911,26 @@ export function TeamsView() {
                                   />
                                 </span>
                               ) : (
-                                <span>{apiKey.alias}</span>
+                                <span>
+                                  {apiKey.alias}
+                                  {keyPendingDeletion ? (
+                                    <span className="ml-1.5 text-amber-700 dark:text-amber-500">(삭제 예정)</span>
+                                  ) : null}
+                                </span>
                               )}
                             </div>
                             <p className="text-xs text-muted-foreground">
                               월 예산:{" "}
                               {formatBudgetUsd(apiKey.monthlyBudgetUsd ?? undefined) ?? "— (미설정·기존 데이터)"}
                             </p>
+                            {keyPendingDeletion && apiKey.permanentDeletionAt ? (
+                              <p className="text-xs text-amber-800 dark:text-amber-300">
+                                영구 삭제 예정: {formatCreatedAt(apiKey.permanentDeletionAt)}
+                                {typeof apiKey.deletionGraceDays === "number"
+                                  ? ` (${apiKey.deletionGraceDays}일 유예)`
+                                  : ""}
+                              </p>
+                            ) : null}
                           </div>
                           <div className="flex shrink-0 flex-col items-stretch gap-2 sm:items-end">
                             <div className="text-xs text-muted-foreground tabular-nums sm:text-right">
@@ -885,21 +960,32 @@ export function TeamsView() {
                                 <button
                                   type="button"
                                   className="rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
-                                  disabled={deleting || saveEditLoading}
+                                  disabled={keyPendingDeletion || deleting || canceling || saveEditLoading}
                                   onClick={() => startEditKey(team.id, apiKey)}
                                 >
                                   수정
                                 </button>
                               )}
                               {!isEditing ? (
-                                <button
-                                  type="button"
-                                  className="rounded-md border border-destructive/40 bg-background px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-                                  disabled={deleting}
-                                  onClick={() => void deleteTeamKey(team.id, apiKey.id)}
-                                >
-                                  {deleting ? "삭제 중…" : "삭제"}
-                                </button>
+                                keyPendingDeletion ? (
+                                  <button
+                                    type="button"
+                                    className="rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                                    disabled={canceling || deleting}
+                                    onClick={() => void cancelTeamKeyDeletion(team.id, apiKey.id)}
+                                  >
+                                    {canceling ? "처리 중…" : "삭제 취소"}
+                                  </button>
+                                ) : (
+                                  <button
+                                    type="button"
+                                    className="rounded-md border border-destructive/40 bg-background px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                                    disabled={deleting}
+                                    onClick={() => void deleteTeamKey(team.id, apiKey.id)}
+                                  >
+                                    {deleting ? "처리 중…" : "삭제"}
+                                  </button>
+                                )
                               ) : null}
                             </div>
                           </div>

--- a/services/identity-service/web/src/components/account/teams-view.tsx
+++ b/services/identity-service/web/src/components/account/teams-view.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Eye, EyeOff } from "lucide-react"
+import { ChevronDown, ChevronRight, Eye, EyeOff } from "lucide-react"
 
 import { apiFetch } from "@/lib/api/client-fetch"
 import type { ApiResponse } from "@/lib/api/identity/types"
@@ -22,7 +22,6 @@ type TeamApiKeySummary = {
   id: number
   provider: string
   alias: string
-  keyPreview: string
   monthlyBudgetUsd: number | null
   createdAt: string
 }
@@ -49,7 +48,6 @@ function normalizeTeamApiKeySummary(item: unknown): TeamApiKeySummary | null {
   if (typeof v.id !== "number") return null
   if (typeof v.provider !== "string") return null
   if (typeof v.alias !== "string") return null
-  if (typeof v.keyPreview !== "string") return null
   if (typeof v.createdAt !== "string") return null
   const b = v.monthlyBudgetUsd
   let monthlyBudgetUsd: number | null = null
@@ -63,7 +61,6 @@ function normalizeTeamApiKeySummary(item: unknown): TeamApiKeySummary | null {
     id: v.id,
     provider: v.provider,
     alias: v.alias,
-    keyPreview: v.keyPreview,
     monthlyBudgetUsd,
     createdAt: v.createdAt,
   }
@@ -141,6 +138,8 @@ export function TeamsView() {
   const [editBudget, setEditBudget] = React.useState("")
   const [saveEditLoading, setSaveEditLoading] = React.useState(false)
   const [deleteLoadingKey, setDeleteLoadingKey] = React.useState<string | null>(null)
+  /** 목록에서는 이름만 보이고, 펼친 팀만 상세·API 조회 */
+  const [openTeamId, setOpenTeamId] = React.useState<string | null>(null)
 
   function normalizeInviteUserIds(values: string[]): string[] {
     return Array.from(
@@ -254,13 +253,22 @@ export function TeamsView() {
       setTeamMemberIdsByTeamId({})
       setTeamApiKeysByTeamId({})
       setApiKeysListErrorByTeamId({})
-      return
+      setOpenTeamId(null)
     }
-    for (const team of teams) {
-      void loadTeamMembers(team.id)
-      void loadTeamApiKeys(team.id)
+  }, [teams.length])
+
+  React.useEffect(() => {
+    if (openTeamId && !teams.some((t) => t.id === openTeamId)) {
+      setOpenTeamId(null)
     }
-  }, [teams, loadTeamMembers, loadTeamApiKeys])
+  }, [teams, openTeamId])
+
+  React.useEffect(() => {
+    if (!openTeamId) return
+    if (!teams.some((t) => t.id === openTeamId)) return
+    void loadTeamMembers(openTeamId)
+    void loadTeamApiKeys(openTeamId)
+  }, [openTeamId, teams, loadTeamMembers, loadTeamApiKeys])
 
   React.useEffect(() => {
     setApiKeyAliasByTeamId((prev) => {
@@ -719,10 +727,36 @@ export function TeamsView() {
 
       {!loading && teams.length > 0 ? (
         <ul className="max-w-lg divide-y divide-border rounded-lg border border-border bg-card shadow-sm">
-          {teams.map((team) => (
-            <li key={team.id} className="space-y-4 px-4 py-4">
+          {teams.map((team) => {
+            const isOpen = openTeamId === team.id
+            return (
+            <li key={team.id} className="overflow-hidden">
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-muted/60"
+                aria-expanded={isOpen}
+                onClick={() => {
+                  setOpenTeamId((prev) => {
+                    if (prev === team.id) {
+                      cancelEditKey()
+                      return null
+                    }
+                    cancelEditKey()
+                    return team.id
+                  })
+                }}
+              >
+                {isOpen ? (
+                  <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+                ) : (
+                  <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+                )}
+                <span className="min-w-0 flex-1 font-medium">{team.name}</span>
+              </button>
+
+              {isOpen ? (
+              <div className="space-y-4 border-t border-border bg-muted/5 px-4 pb-4 pt-2">
               <div>
-                <p className="font-medium">{team.name}</p>
                 <p className="text-xs text-muted-foreground">id: {team.id}</p>
                 <p className="mt-1 text-xs text-muted-foreground">
                   멤버 {(teamMemberIdsByTeamId[team.id] ?? []).length}명
@@ -760,7 +794,7 @@ export function TeamsView() {
                 <div className="space-y-1">
                   <p className="text-sm font-semibold">등록된 팀 API Key</p>
                   <p className="text-xs text-muted-foreground">
-                    Provider·별칭·미리보기·월 예산만 표시됩니다. 수정 시에는 별칭과 월 예산만 바꿀 수 있고, 키 값은 등록 시에만 설정됩니다.
+                    Provider·별칭·월 예산을 표시합니다. 수정 시에는 별칭과 월 예산만 바꿀 수 있고, 키 값은 등록 시에만 설정됩니다.
                   </p>
                 </div>
                 {apiKeysListErrorByTeamId[team.id] ? (
@@ -818,7 +852,6 @@ export function TeamsView() {
                                 <span>{apiKey.alias}</span>
                               )}
                             </div>
-                            <p className="text-xs text-muted-foreground">{apiKey.keyPreview}</p>
                             <p className="text-xs text-muted-foreground">
                               월 예산:{" "}
                               {formatBudgetUsd(apiKey.monthlyBudgetUsd ?? undefined) ?? "— (미설정·기존 데이터)"}
@@ -966,7 +999,7 @@ export function TeamsView() {
                         return { ...prev, [team.id]: next }
                       })
                     }
-                    placeholder="월 예산 USD (스피너 ±0.01)"
+                    placeholder="월 예산 USD"
                     autoComplete="off"
                     disabled={apiKeyRegisterLoadingTeamId === team.id}
                   />
@@ -991,8 +1024,11 @@ export function TeamsView() {
                   </button>
                 </div>
               </div>
+              </div>
+              ) : null}
             </li>
-          ))}
+            )
+          })}
         </ul>
       ) : null}
     </div>

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/TeamController.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/TeamController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -109,13 +110,25 @@ public class TeamController {
 	}
 
 	@DeleteMapping("/teams/{teamId}/api-keys/{keyId}")
-	public ResponseEntity<ApiResponse<Void>> deleteTeamApiKey(
+	public ResponseEntity<ApiResponse<TeamApiKeySummaryResponse>> deleteTeamApiKey(
+			@AuthenticationPrincipal TeamUserPrincipal principal,
+			@PathVariable("teamId") Long teamId,
+			@PathVariable("keyId") Long keyId,
+			@RequestParam(name = "gracePeriodDays", required = false) Integer gracePeriodDays
+	) {
+		TeamApiKeySummaryResponse updated =
+				teamApiKeyService.delete(principal.userId(), teamId, keyId, gracePeriodDays);
+		return ResponseEntity.ok(ApiResponse.ok("팀 API 키가 삭제 예정으로 등록되었습니다", updated));
+	}
+
+	@PostMapping("/teams/{teamId}/api-keys/{keyId}/deletion/cancel")
+	public ResponseEntity<ApiResponse<TeamApiKeySummaryResponse>> cancelTeamApiKeyDeletion(
 			@AuthenticationPrincipal TeamUserPrincipal principal,
 			@PathVariable("teamId") Long teamId,
 			@PathVariable("keyId") Long keyId
 	) {
-		teamApiKeyService.delete(principal.userId(), teamId, keyId);
-		return ResponseEntity.ok(ApiResponse.ok("팀 API 키가 삭제되었습니다", null));
+		TeamApiKeySummaryResponse updated = teamApiKeyService.cancelDeletion(principal.userId(), teamId, keyId);
+		return ResponseEntity.ok(ApiResponse.ok("삭제 예정이 해제되었습니다", updated));
 	}
 
 	@GetMapping("/teams/{id}/api-keys")

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/TeamApiKeySummaryResponse.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/TeamApiKeySummaryResponse.java
@@ -9,7 +9,6 @@ public record TeamApiKeySummaryResponse(
         Long id,
         String provider,
         String alias,
-        String keyPreview,
         @JsonProperty("monthlyBudgetUsd") BigDecimal monthlyBudgetUsd,
         Instant createdAt
 ) {

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/TeamApiKeySummaryResponse.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/TeamApiKeySummaryResponse.java
@@ -1,15 +1,20 @@
 package com.zerobugfreinds.team_service.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigDecimal;
 import java.time.Instant;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TeamApiKeySummaryResponse(
         Long id,
         String provider,
         String alias,
         @JsonProperty("monthlyBudgetUsd") BigDecimal monthlyBudgetUsd,
-        Instant createdAt
+        Instant createdAt,
+        Instant deletionRequestedAt,
+        Instant permanentDeletionAt,
+        Integer deletionGraceDays
 ) {
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/entity/TeamApiKeyEntity.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/entity/TeamApiKeyEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.Instant;
 
 @Entity
@@ -58,6 +59,18 @@ public class TeamApiKeyEntity {
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
+    /** 비어 있지 않으면 삭제 예정(유예 중). */
+    @Column(name = "deletion_requested_at")
+    private Instant deletionRequestedAt;
+
+    /** 유예 종료 후 물리 삭제 예정 시각. 삭제 예정이 아니면 null. */
+    @Column(name = "permanent_deletion_at")
+    private Instant permanentDeletionAt;
+
+    /** 삭제 요청 시 사용자가 선택한 유예 기간(일). 삭제 예정이 아니면 null. */
+    @Column(name = "deletion_grace_days")
+    private Integer deletionGraceDays;
+
     protected TeamApiKeyEntity() {
     }
 
@@ -99,6 +112,22 @@ public class TeamApiKeyEntity {
         this.monthlyBudgetUsd = monthlyBudgetUsd;
     }
 
+    public boolean isDeletionPending() {
+        return deletionRequestedAt != null;
+    }
+
+    public void markDeletionRequested(Instant now, int gracePeriodDays) {
+        this.deletionRequestedAt = now;
+        this.deletionGraceDays = gracePeriodDays;
+        this.permanentDeletionAt = now.plus(Duration.ofDays(gracePeriodDays));
+    }
+
+    public void clearDeletionRequest() {
+        this.deletionRequestedAt = null;
+        this.permanentDeletionAt = null;
+        this.deletionGraceDays = null;
+    }
+
     public Long getId() {
         return id;
     }
@@ -129,5 +158,17 @@ public class TeamApiKeyEntity {
 
     public Instant getCreatedAt() {
         return createdAt;
+    }
+
+    public Instant getDeletionRequestedAt() {
+        return deletionRequestedAt;
+    }
+
+    public Instant getPermanentDeletionAt() {
+        return permanentDeletionAt;
+    }
+
+    public Integer getDeletionGraceDays() {
+        return deletionGraceDays;
     }
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamApiKeyRepository.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamApiKeyRepository.java
@@ -12,6 +12,19 @@ public interface TeamApiKeyRepository extends JpaRepository<TeamApiKeyEntity, Lo
 
     Optional<TeamApiKeyEntity> findByIdAndTeamId(Long id, Long teamId);
 
+    Optional<TeamApiKeyEntity> findByTeamIdAndProviderAndKeyHash(
+            Long teamId,
+            TeamApiKeyProvider provider,
+            String keyHash
+    );
+
+    Optional<TeamApiKeyEntity> findByTeamIdAndProviderAndKeyHashAndIdNot(
+            Long teamId,
+            TeamApiKeyProvider provider,
+            String keyHash,
+            Long id
+    );
+
     boolean existsByTeamIdAndProviderAndKeyHash(Long teamId, TeamApiKeyProvider provider, String keyHash);
 
     boolean existsByTeamIdAndKeyAlias(Long teamId, String keyAlias);

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java
@@ -15,10 +15,17 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class TeamApiKeyService {
+    /** 삭제 예정 등록 시 유예 기간 기본값(일). */
+    public static final int DEFAULT_DELETION_GRACE_DAYS = 7;
+    private static final int MIN_DELETION_GRACE_DAYS = 1;
+    private static final int MAX_DELETION_GRACE_DAYS = 365;
+
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final TeamApiKeyRepository teamApiKeyRepository;
@@ -60,7 +67,12 @@ public class TeamApiKeyService {
         if (teamApiKeyRepository.existsByTeamIdAndKeyAlias(teamId, normalizedAlias)) {
             throw new IllegalArgumentException("이미 사용 중인 API Key 별칭입니다");
         }
-        if (teamApiKeyRepository.existsByTeamIdAndProviderAndKeyHash(teamId, provider, keyHash)) {
+        Optional<TeamApiKeyEntity> sameKeyHash =
+                teamApiKeyRepository.findByTeamIdAndProviderAndKeyHash(teamId, provider, keyHash);
+        if (sameKeyHash.isPresent()) {
+            if (sameKeyHash.get().isDeletionPending()) {
+                throw new IllegalArgumentException("삭제 예정키와 중복입니다");
+            }
             throw new IllegalArgumentException("이미 등록된 API Key입니다");
         }
 
@@ -94,6 +106,9 @@ public class TeamApiKeyService {
 
         TeamApiKeyEntity entity = teamApiKeyRepository.findByIdAndTeamId(apiKeyId, teamId)
                 .orElseThrow(() -> new IllegalArgumentException("팀 API 키를 찾을 수 없습니다"));
+        if (entity.isDeletionPending()) {
+            throw new IllegalArgumentException("삭제 예정인 키는 수정할 수 없습니다");
+        }
 
         if (teamApiKeyRepository.existsByTeamIdAndKeyAliasAndIdNot(teamId, normalizedAlias, apiKeyId)) {
             throw new IllegalArgumentException("이미 사용 중인 API Key 별칭입니다");
@@ -107,9 +122,12 @@ public class TeamApiKeyService {
                 throw new IllegalArgumentException("externalKey 길이가 너무 깁니다");
             }
             String keyHash = encryptionUtil.sha256HexForUniqueness(provider.name(), normalizedExternalKey);
-            if (teamApiKeyRepository.existsByTeamIdAndProviderAndKeyHashAndIdNot(
-                    teamId, provider, keyHash, apiKeyId
-            )) {
+            Optional<TeamApiKeyEntity> sameKeyHashElsewhere = teamApiKeyRepository
+                    .findByTeamIdAndProviderAndKeyHashAndIdNot(teamId, provider, keyHash, apiKeyId);
+            if (sameKeyHashElsewhere.isPresent()) {
+                if (sameKeyHashElsewhere.get().isDeletionPending()) {
+                    throw new IllegalArgumentException("삭제 예정키와 중복입니다");
+                }
                 throw new IllegalArgumentException("이미 등록된 API Key입니다");
             }
             String encrypted = encryptionUtil.encryptAes256Gcm(normalizedExternalKey);
@@ -122,14 +140,36 @@ public class TeamApiKeyService {
     }
 
     @Transactional
-    public void delete(String actorUserId, Long teamId, Long apiKeyId) {
+    public TeamApiKeySummaryResponse delete(String actorUserId, Long teamId, Long apiKeyId, Integer gracePeriodDays) {
         validateTeamAccess(actorUserId, teamId);
         if (apiKeyId == null) {
             throw new IllegalArgumentException("apiKeyId는 필수입니다");
         }
         TeamApiKeyEntity entity = teamApiKeyRepository.findByIdAndTeamId(apiKeyId, teamId)
                 .orElseThrow(() -> new IllegalArgumentException("팀 API 키를 찾을 수 없습니다"));
-        teamApiKeyRepository.delete(entity);
+        if (entity.isDeletionPending()) {
+            throw new IllegalArgumentException("이미 삭제 예정인 키입니다");
+        }
+        int days = resolveGracePeriodDays(gracePeriodDays);
+        entity.markDeletionRequested(Instant.now(), days);
+        teamApiKeyRepository.save(entity);
+        return toSummary(entity);
+    }
+
+    @Transactional
+    public TeamApiKeySummaryResponse cancelDeletion(String actorUserId, Long teamId, Long apiKeyId) {
+        validateTeamAccess(actorUserId, teamId);
+        if (apiKeyId == null) {
+            throw new IllegalArgumentException("apiKeyId는 필수입니다");
+        }
+        TeamApiKeyEntity entity = teamApiKeyRepository.findByIdAndTeamId(apiKeyId, teamId)
+                .orElseThrow(() -> new IllegalArgumentException("팀 API 키를 찾을 수 없습니다"));
+        if (!entity.isDeletionPending()) {
+            throw new IllegalArgumentException("삭제 예정 상태가 아닙니다");
+        }
+        entity.clearDeletionRequest();
+        teamApiKeyRepository.save(entity);
+        return toSummary(entity);
     }
 
     @Transactional(readOnly = true)
@@ -173,13 +213,26 @@ public class TeamApiKeyService {
         return normalized;
     }
 
+    private static int resolveGracePeriodDays(Integer requested) {
+        int days = requested != null ? requested : DEFAULT_DELETION_GRACE_DAYS;
+        if (days < MIN_DELETION_GRACE_DAYS || days > MAX_DELETION_GRACE_DAYS) {
+            throw new IllegalArgumentException(
+                    "유예 기간은 " + MIN_DELETION_GRACE_DAYS + "일 이상 " + MAX_DELETION_GRACE_DAYS + "일 이하로 설정할 수 있습니다"
+            );
+        }
+        return days;
+    }
+
     private static TeamApiKeySummaryResponse toSummary(TeamApiKeyEntity entity) {
         return new TeamApiKeySummaryResponse(
                 entity.getId(),
                 entity.getProvider().name(),
                 entity.getKeyAlias(),
                 entity.getMonthlyBudgetUsd(),
-                entity.getCreatedAt()
+                entity.getCreatedAt(),
+                entity.getDeletionRequestedAt(),
+                entity.getPermanentDeletionAt(),
+                entity.getDeletionGraceDays()
         );
     }
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java
@@ -178,14 +178,8 @@ public class TeamApiKeyService {
                 entity.getId(),
                 entity.getProvider().name(),
                 entity.getKeyAlias(),
-                maskedKeyPreview(entity.getProvider().name(), entity.getKeyHash()),
                 entity.getMonthlyBudgetUsd(),
                 entity.getCreatedAt()
         );
-    }
-
-    private static String maskedKeyPreview(String provider, String keyHash) {
-        String last4 = keyHash.length() >= 4 ? keyHash.substring(keyHash.length() - 4) : keyHash;
-        return provider + "-****" + last4;
     }
 }

--- a/services/team-service/web/src/components/team/team-management-view.tsx
+++ b/services/team-service/web/src/components/team/team-management-view.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Eye, EyeOff } from "lucide-react"
+import { ChevronDown, ChevronRight, Eye, EyeOff } from "lucide-react"
 
 type ApiResponse<T> = {
   success: boolean
@@ -23,7 +23,6 @@ type TeamApiKeySummary = {
   id: number
   provider: string
   alias: string
-  keyPreview: string
   monthlyBudgetUsd: number | null
   createdAt: string
 }
@@ -50,7 +49,6 @@ function normalizeTeamApiKeySummary(item: unknown): TeamApiKeySummary | null {
   if (typeof v.id !== "number") return null
   if (typeof v.provider !== "string") return null
   if (typeof v.alias !== "string") return null
-  if (typeof v.keyPreview !== "string") return null
   if (typeof v.createdAt !== "string") return null
   const b = v.monthlyBudgetUsd
   let monthlyBudgetUsd: number | null = null
@@ -64,7 +62,6 @@ function normalizeTeamApiKeySummary(item: unknown): TeamApiKeySummary | null {
     id: v.id,
     provider: v.provider,
     alias: v.alias,
-    keyPreview: v.keyPreview,
     monthlyBudgetUsd,
     createdAt: v.createdAt,
   }
@@ -112,6 +109,7 @@ export function TeamManagementView() {
   const [editTeamApiKeyAlias, setEditTeamApiKeyAlias] = React.useState("")
   const [editTeamApiKeyBudget, setEditTeamApiKeyBudget] = React.useState("")
   const [teamApiKeyUpdateLoading, setTeamApiKeyUpdateLoading] = React.useState<string | null>(null)
+  const [openTeamId, setOpenTeamId] = React.useState<string | null>(null)
 
   const loadTeams = React.useCallback(async () => {
     setLoading(true)
@@ -176,12 +174,21 @@ export function TeamManagementView() {
   React.useEffect(() => {
     if (teams.length === 0) {
       setTeamApiKeysByTeamId({})
-      return
+      setOpenTeamId(null)
     }
-    for (const team of teams) {
-      void loadTeamApiKeys(team.id)
+  }, [teams.length])
+
+  React.useEffect(() => {
+    if (openTeamId && !teams.some((t) => t.id === openTeamId)) {
+      setOpenTeamId(null)
     }
-  }, [teams, loadTeamApiKeys])
+  }, [teams, openTeamId])
+
+  React.useEffect(() => {
+    if (!openTeamId) return
+    if (!teams.some((t) => t.id === openTeamId)) return
+    void loadTeamApiKeys(openTeamId)
+  }, [openTeamId, teams, loadTeamApiKeys])
 
   async function createTeam(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -426,9 +433,35 @@ export function TeamManagementView() {
 
       {!loading && teams.length > 0 ? (
         <ul className="divide-y divide-zinc-200 rounded-lg border border-zinc-200 bg-white">
-          {teams.map((team) => (
-            <li key={team.id} className="space-y-2 px-4 py-3">
-              <p className="font-medium">{team.name}</p>
+          {teams.map((team) => {
+            const isOpen = openTeamId === team.id
+            return (
+            <li key={team.id} className="overflow-hidden">
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-zinc-50"
+                aria-expanded={isOpen}
+                onClick={() => {
+                  setOpenTeamId((prev) => {
+                    if (prev === team.id) {
+                      cancelEditTeamApiKey()
+                      return null
+                    }
+                    cancelEditTeamApiKey()
+                    return team.id
+                  })
+                }}
+              >
+                {isOpen ? (
+                  <ChevronDown className="h-4 w-4 shrink-0 text-zinc-500" aria-hidden />
+                ) : (
+                  <ChevronRight className="h-4 w-4 shrink-0 text-zinc-500" aria-hidden />
+                )}
+                <span className="min-w-0 flex-1 font-medium">{team.name}</span>
+              </button>
+
+              {isOpen ? (
+              <div className="space-y-2 border-t border-zinc-200 bg-zinc-50/50 px-4 pb-4 pt-2">
               <p className="text-xs text-zinc-500">id: {team.id}</p>
               <div className="flex flex-col gap-2 sm:flex-row">
                 <input
@@ -552,7 +585,7 @@ export function TeamManagementView() {
                             <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                               <div>
                                 <p>
-                                  {apiKey.provider} / {apiKey.alias} / {apiKey.keyPreview}
+                                  {apiKey.provider} · {apiKey.alias}
                                 </p>
                                 <p className="text-[11px] text-zinc-500">
                                   월 예산:{" "}
@@ -629,8 +662,11 @@ export function TeamManagementView() {
                   <p className="text-xs text-zinc-500">등록된 팀 API Key가 없습니다.</p>
                 )}
               </div>
+              </div>
+              ) : null}
             </li>
-          ))}
+            )
+          })}
         </ul>
       ) : null}
     </main>

--- a/services/team-service/web/src/components/team/team-management-view.tsx
+++ b/services/team-service/web/src/components/team/team-management-view.tsx
@@ -25,6 +25,9 @@ type TeamApiKeySummary = {
   alias: string
   monthlyBudgetUsd: number | null
   createdAt: string
+  deletionRequestedAt?: string | null
+  permanentDeletionAt?: string | null
+  deletionGraceDays?: number | null
 }
 
 function asApiResponse(value: unknown): ApiResponse<unknown> | null {
@@ -58,12 +61,22 @@ function normalizeTeamApiKeySummary(item: unknown): TeamApiKeySummary | null {
     const n = Number(b)
     if (Number.isFinite(n)) monthlyBudgetUsd = n
   }
+  const delReq = v.deletionRequestedAt
+  const delPerm = v.permanentDeletionAt
+  const gd = v.deletionGraceDays
+  let deletionGraceDays: number | null = null
+  if (typeof gd === "number" && Number.isFinite(gd)) {
+    deletionGraceDays = gd
+  }
   return {
     id: v.id,
     provider: v.provider,
     alias: v.alias,
     monthlyBudgetUsd,
     createdAt: v.createdAt,
+    deletionRequestedAt: typeof delReq === "string" ? delReq : null,
+    permanentDeletionAt: typeof delPerm === "string" ? delPerm : null,
+    deletionGraceDays,
   }
 }
 
@@ -75,6 +88,12 @@ function formatBudgetUsd(value: number | null | undefined) {
     minimumFractionDigits: 0,
     maximumFractionDigits: 2,
   }).format(value)
+}
+
+function formatDeletionDeadline(iso: string) {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString("ko-KR", { timeZone: "Asia/Seoul" })
 }
 
 const BUDGET_STEP = 0.01
@@ -576,6 +595,7 @@ export function TeamManagementView() {
                         editingTeamApiKey?.teamId === team.id && editingTeamApiKey?.keyId === apiKey.id
                       const updateKey = `${team.id}:${apiKey.id}`
                       const updating = teamApiKeyUpdateLoading === updateKey
+                      const keyPendingDeletion = Boolean(apiKey.deletionRequestedAt)
                       return (
                         <li
                           key={`${team.id}-api-key-${apiKey.id}`}
@@ -586,15 +606,30 @@ export function TeamManagementView() {
                               <div>
                                 <p>
                                   {apiKey.provider} · {apiKey.alias}
+                                  {keyPendingDeletion ? (
+                                    <span className="ml-1.5 rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium text-zinc-700">
+                                      삭제 예정
+                                    </span>
+                                  ) : null}
                                 </p>
                                 <p className="text-[11px] text-zinc-500">
                                   월 예산:{" "}
                                   {formatBudgetUsd(apiKey.monthlyBudgetUsd ?? undefined) ?? "— (기존 데이터)"}
                                 </p>
+                                {keyPendingDeletion && apiKey.permanentDeletionAt ? (
+                                  <p className="text-[11px] text-amber-800">
+                                    영구 삭제 예정: {formatDeletionDeadline(apiKey.permanentDeletionAt)}
+                                    {typeof apiKey.deletionGraceDays === "number"
+                                      ? ` (${apiKey.deletionGraceDays}일 유예)`
+                                      : ""}
+                                  </p>
+                                ) : null}
                               </div>
                               <button
                                 type="button"
-                                className="h-8 shrink-0 rounded-md border border-zinc-300 bg-white px-2 text-[11px] font-medium"
+                                className="h-8 shrink-0 rounded-md border border-zinc-300 bg-white px-2 text-[11px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
+                                disabled={keyPendingDeletion}
+                                title={keyPendingDeletion ? "삭제 예정인 키는 수정할 수 없습니다" : undefined}
                                 onClick={() => startEditTeamApiKey(team.id, apiKey)}
                               >
                                 수정


### PR DESCRIPTION
## 연관된 이슈
> # (해당 이슈 번호가 있으면 기입)

## 작업 내용
- **해당 서비스**: Team (`team-service`), Identity Web (`identity-service/web`), Team Web (`team-service/web`), 문서 (`docs/contracts`)

팀 API 키 **삭제 예정** 시 **유예 기간**을 두고(기본 7일, 요청 시 1~365일), 유예 중 **삭제 취소** API를 추가했습니다. Identity `/teams`(`teams-view`)에서는 삭제 확인 후 유예 일수 입력(`prompt`), `DELETE ?gracePeriodDays=`, 삭제 예정 행에 영구 삭제 예정 시각·**삭제 취소**(`POST .../deletion/cancel`)를 연결했습니다. Team API 요약 DTO에 `deletionGraceDays` 등을 반영하고, `web-team-bff.md`에 요약 필드·엔드포인트·데모 순서를 반영했습니다.

## 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 상세 내용
- **team-service**: `TeamApiKeyEntity`에 `deletion_grace_days` 저장, `markDeletionRequested(now, gracePeriodDays)` / `clearDeletionRequest()`. `TeamApiKeyService`: `delete(..., gracePeriodDays)`, `cancelDeletion`, 유예 범위 검증(기본 7일). `TeamController`: `DELETE`에 선택 쿼리 `gracePeriodDays`, 응답 `data`에 키 요약; `POST /teams/{teamId}/api-keys/{keyId}/deletion/cancel` 추가. `TeamApiKeySummaryResponse`에 `deletionGraceDays` 추가.
- **identity-service/web**: `teams-view.tsx` — 유예 입력, 삭제 API 쿼리, 삭제 예정 안내·**삭제 취소** 버튼, 목록 정규화에 `deletionGraceDays`.
- **team-service/web**: `team-management-view.tsx` — 요약 필드·삭제 예정 시 영구 삭제 예정 시각 표시(삭제/취소 버튼은 Identity와 동일하지 않을 수 있음).
- **docs**: `docs/contracts/web-team-bff.md` v0.4 — 요약 객체 표, DELETE/POST cancel, `/teams` 데모 절차, 스케줄러(영구 삭제)는 별도 구현일 수 있음 명시.

## 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [x] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부 — `team_api_keys.deletion_grace_days` 컬럼 추가(Entity 필드). 배포 환경에서 JPA `ddl-auto` 또는 마이그레이션으로 스키마 적용 필요.

## 스크린샷 / 테스트 결과 (선택)
- (로컬에서 삭제 예정 → 유예 일수 → 목록에 예정 시각·삭제 취소 동작 캡처 권장)

## 리뷰 요구사항
- 유예 종료 후 **물리 삭제(배치)** 는 이번 PR 범위에 없음. 운영 정책에 맞춰 후속 이슈로 다룰지 검토 부탁드립니다.
- 기존 DB에 삭제 예정만 있고 `deletion_grace_days`가 null인 행은 UI가 `permanentDeletionAt` 중심으로 동작하는지 확인해 주시면 좋습니다.