### PR TITLE
fix: api key 관련 수정, 비밀번호 찾기 구현

### DIFF
--- a/docs/contracts/web-identity-bff.md
+++ b/docs/contracts/web-identity-bff.md
@@ -1,6 +1,6 @@
 # Web(Next.js) ↔ Identity 인증 BFF 계약
 
-버전: 1.19  
+버전: 1.20  
 관련: [docs/architecture.md](../architecture.md) §1.3, §3.3, §10.2, §13, [Identity 인증 API 계약](../identity-auth-api-contract.md), [Web·Gateway Usage BFF](./web-gateway-bff.md)(Usage BFF·`basePath` 호출 맵), [Web·Team BFF](./web-team-bff.md), [저장소 구조](../repository-structure.md) §6, [웹 경계](./web-split-boundary.md)(§2.4 로컬 `web-edge` Nginx)
 
 **소스 트리:** BFF·화면의 **정본**은 `services/identity-service/web/` 이다. **공용 UI(Shadcn 래퍼·`cn`)** 는 루트 pnpm workspace **`@ai-usage/ui`**(`packages/ui`)를 참조한다([web-split-boundary.md §1.1](./web-split-boundary.md)). Identity vs Usage 라우트·미들웨어 매처는 [web-split-boundary.md](./web-split-boundary.md) §2·§3.
@@ -19,6 +19,8 @@
 | 구분 | Web BFF 브라우저 경로(Next 동일 오리진) | Upstream Identity |
 |------|-----------------------|-------------------|
 | 회원가입 | `POST /api/auth/signup` | `POST /api/auth/signup` |
+| 비밀번호 찾기(재설정 메일 요청) | `POST /api/auth/forgot-password` | `POST /api/auth/forgot-password` |
+| 비밀번호 재설정 | `POST /api/auth/reset-password` | `POST /api/auth/reset-password` |
 | 로그인 | `POST /api/auth/login` | `POST /api/auth/login` |
 | 외부 API 키 조회(개인) | `GET /api/auth/external-keys` | `GET /api/auth/external-keys` |
 | 외부 API 키 등록(개인) | `POST /api/auth/external-keys` | `POST /api/auth/external-keys` |
@@ -102,6 +104,21 @@
 2. **`access_token` 쿠키가 없거나 값이 비어 있으면** BFF는 Identity를 호출하지 않고 `401`로 응답한다.
 3. BFF → Identity: `POST {IDENTITY_SERVICE_URL}/api/auth/external-keys/{id}/deletion-cancel`
 4. 성공 시 Identity 응답을 그대로 전달한다.
+
+### 2.7 `POST /api/auth/forgot-password` 동작
+
+1. 브라우저 → BFF: `POST /api/auth/forgot-password`, JSON `{ "email": "…" }`
+2. BFF: Zod로 이메일 형식을 검증한다.
+3. BFF → Identity: `POST {IDENTITY_SERVICE_URL}/api/auth/forgot-password` (동일 본문)
+4. **성공 시**(`200`) Identity의 `message`는 **이메일 존재 여부와 무관한 동일 문구**를 사용한다(이메일 열거 방지). BFF는 업스트림 본문을 그대로 전달한다. 응답에 `Cache-Control: no-store`를 적용한다.
+5. Identity·SMTP 미구성 시에는 서버 로그에 재설정 링크가 남을 수 있다(로컬 개발). 운영에서는 `IDENTITY_WEB_PUBLIC_BASE_URL`·SMTP를 설정한다([identity-auth-api-contract](../identity-auth-api-contract.md)).
+
+### 2.8 `POST /api/auth/reset-password` 동작
+
+1. 브라우저 → BFF: `POST /api/auth/reset-password`, JSON `{ "token": "…", "password": "…", "passwordConfirm": "…" }` (`token`은 메일 링크의 쿼리 값)
+2. BFF: Zod로 비밀번호 정책·일치 여부를 검증한다(회원가입과 동일 정책).
+3. BFF → Identity: `POST {IDENTITY_SERVICE_URL}/api/auth/reset-password`
+4. **성공 시** 비밀번호가 갱신되며, 웹은 안내 후 **`/login`** 으로 이동할 수 있다. 토큰이 잘못되었거나 만료된 경우 Identity는 `400`과 안내 메시지를 반환할 수 있다.
 
 ---
 

--- a/docs/contracts/web-identity-bff.md
+++ b/docs/contracts/web-identity-bff.md
@@ -1,6 +1,6 @@
 # Web(Next.js) ↔ Identity 인증 BFF 계약
 
-버전: 1.16  
+버전: 1.17  
 관련: [docs/architecture.md](../architecture.md) §1.3, §3.3, §10.2, §13, [Identity 인증 API 계약](../identity-auth-api-contract.md), [Web·Gateway Usage BFF](./web-gateway-bff.md)(Usage BFF·`basePath` 호출 맵), [Web·Team BFF](./web-team-bff.md), [저장소 구조](../repository-structure.md) §6, [웹 경계](./web-split-boundary.md)(§2.4 로컬 `web-edge` Nginx)
 
 **소스 트리:** BFF·화면의 **정본**은 `services/identity-service/web/` 이다. **공용 UI(Shadcn 래퍼·`cn`)** 는 루트 pnpm workspace **`@ai-usage/ui`**(`packages/ui`)를 참조한다([web-split-boundary.md §1.1](./web-split-boundary.md)). Identity vs Usage 라우트·미들웨어 매처는 [web-split-boundary.md](./web-split-boundary.md) §2·§3.
@@ -23,7 +23,7 @@
 | 외부 API 키 조회(개인) | `GET /api/auth/external-keys` | `GET /api/auth/external-keys` |
 | 외부 API 키 등록(개인) | `POST /api/auth/external-keys` | `POST /api/auth/external-keys` |
 | 외부 API 키 수정(개인) | `PUT /api/auth/external-keys/{id}` | `PUT /api/auth/external-keys/{id}` |
-| 외부 API 키 삭제 예약(개인) | `DELETE /api/auth/external-keys/{id}` | `DELETE /api/auth/external-keys/{id}` |
+| 외부 API 키 삭제 예약(개인) | `DELETE /api/auth/external-keys/{id}` (선택 쿼리 `gracePeriodDays`) | `DELETE /api/auth/external-keys/{id}` (동일) |
 | 외부 API 키 삭제 취소(개인) | `POST /api/auth/external-keys/{id}/deletion-cancel` | `POST /api/auth/external-keys/{id}/deletion-cancel` |
 | 세션(로그인 여부 단일 기준) | `GET /api/auth/session` | `GET /api/auth/session` (BFF가 쿠키 JWT를 Bearer로 전달해 프록시) |
 | 로그아웃 | `POST /api/auth/logout` | `POST /api/auth/logout` (선택 프록시; stateless이며 실질 로그아웃은 BFF의 쿠키 삭제) |
@@ -58,8 +58,9 @@
    - `Authorization: Bearer {access_token}`
    - `Accept: application/json`
 4. **성공 시** Identity의 상태 코드/본문(`ApiResponse`)을 가능한 그대로 전달한다. 응답에는 `Cache-Control: no-store`를 적용한다.
-5. **Identity가 `401` 등으로 거절**하면 상태 코드와 JSON 본문을 **그대로** 프론트에 전달한다(§6).
-6. `IDENTITY_SERVICE_URL` 미설정, 업스트림 연결 실패, 업스트림 응답이 계약과 맞지 않는 경우 등은 BFF가 `500`/`502` 등으로 처리할 수 있다.
+5. 목록 항목은 [Identity 인증 API 계약 §6](../identity-auth-api-contract.md)과 동일하며, **삭제 예정** 행에는 `deletionRequestedAt`, `permanentDeletionAt`, `deletionGraceDays`(선택) 등이 포함될 수 있다.
+6. **Identity가 `401` 등으로 거절**하면 상태 코드와 JSON 본문을 **그대로** 프론트에 전달한다(§6).
+7. `IDENTITY_SERVICE_URL` 미설정, 업스트림 연결 실패, 업스트림 응답이 계약과 맞지 않는 경우 등은 BFF가 `500`/`502` 등으로 처리할 수 있다.
 
 ### 2.3 `POST /api/auth/external-keys` 동작
 
@@ -70,7 +71,7 @@
    - `Authorization: Bearer {access_token}`
    - `Content-Type: application/json`, `Accept: application/json`
 5. **성공 시** Identity의 상태 코드/본문(`ApiResponse`)을 가능한 그대로 전달한다. 응답에는 `Cache-Control: no-store`를 적용한다.
-6. **Identity가 `400`/`401`/`409` 등으로 거절**하면 상태 코드와 JSON 본문을 **그대로** 프론트에 전달한다(§6).
+6. **Identity가 `400`/`401`/`409` 등으로 거절**하면 상태 코드와 JSON 본문을 **그대로** 프론트에 전달한다(§6). 동일 provider·동일 키 값에 대해 **활성 행이 이미 있으면** `409` 메시지 예: `이미 등록된 API 키입니다`. **삭제 예정인 행과만 해시가 겹치면** `409` 메시지 예: `삭제예정키와 중복된 키`([identity-auth-api-contract §7](../identity-auth-api-contract.md)).
 7. `IDENTITY_SERVICE_URL` 미설정, 업스트림 연결 실패, 업스트림 응답이 계약과 맞지 않는 경우 등은 BFF가 `500`/`502` 등으로 처리할 수 있다. 단, **외부 API 키 평문(`externalKey`)은 로그/에러 메시지에 포함하지 않는다.**
 
 ### 2.4 `PUT /api/auth/external-keys/{id}` 동작
@@ -85,13 +86,15 @@
    - `Authorization: Bearer {access_token}`
    - `Content-Type: application/json`, `Accept: application/json`
 5. 성공/오류 모두 Identity의 상태 코드/JSON 본문을 가능한 그대로 전달하고, 응답에 `Cache-Control: no-store`를 적용한다.
+6. 키 값을 바꿀 때 다른 행과의 중복·삭제 예정 충돌 메시지는 [identity-auth-api-contract §9](../identity-auth-api-contract.md)와 동일하다.
 
 ### 2.5 `DELETE /api/auth/external-keys/{id}` 동작 (삭제 예약)
 
-1. 브라우저 → BFF: `DELETE /api/auth/external-keys/{id}`
+1. 브라우저 → BFF: `DELETE /api/auth/external-keys/{id}`  
+   - 선택 **쿼리** `gracePeriodDays`(정수): 생략 시 Identity 기본 **7일**, 허용 범위는 Identity 구현(현재 **1~365일**). 잘못된 값은 업스트림이 `400`으로 거절할 수 있다.
 2. **`access_token` 쿠키가 없거나 값이 비어 있으면** BFF는 Identity를 호출하지 않고 `401`로 응답한다.
-3. BFF → Identity: `DELETE {IDENTITY_SERVICE_URL}/api/auth/external-keys/{id}`
-4. 성공 시 Identity 응답(`deletionRequestedAt`, `permanentDeletionAt` 포함 가능)을 그대로 전달한다.
+3. BFF → Identity: 브라우저 요청 URL의 **쿼리 문자열을 그대로 이어 붙여** `DELETE {IDENTITY_SERVICE_URL}/api/auth/external-keys/{id}{?gracePeriodDays=…}` 로 프록시한다(구현: `services/identity-service/web/src/app/api/auth/external-keys/[id]/route.ts`).
+4. 성공 시 Identity 응답(`deletionRequestedAt`, `permanentDeletionAt`, `deletionGraceDays` 등)을 그대로 전달한다. 유예 종료 후 물리 삭제는 스케줄러가 담당한다([identity-auth-api-contract §10.1](../identity-auth-api-contract.md)).
 
 ### 2.6 `POST /api/auth/external-keys/{id}/deletion-cancel` 동작
 
@@ -251,6 +254,7 @@ curl -sS -i -X POST "http://localhost:3000/api/auth/signup" \
   - `.../src/app/api/auth/session/route.test.ts`
   - `.../src/app/api/auth/logout/route.test.ts`
   - `.../src/app/api/auth/external-keys/route.test.ts`
+  - `.../src/app/api/auth/external-keys/[id]/route.test.ts` — `PUT` 및 **`DELETE` 쿼리 전달(`gracePeriodDays`)** 회귀
   - `login`·`signup` Route Handler도 동일 패턴의 `route.test.ts`로 회귀 검증
   - `.../src/app/api/identity/[[...path]]/route.test.ts` — §5.2 관리 API BFF
 - 미들웨어·보호 경로: `middleware.test.ts`, `protected-routes.test.ts` (§6.2).

--- a/docs/contracts/web-identity-bff.md
+++ b/docs/contracts/web-identity-bff.md
@@ -1,6 +1,6 @@
 # Web(Next.js) ↔ Identity 인증 BFF 계약
 
-버전: 1.17  
+버전: 1.19  
 관련: [docs/architecture.md](../architecture.md) §1.3, §3.3, §10.2, §13, [Identity 인증 API 계약](../identity-auth-api-contract.md), [Web·Gateway Usage BFF](./web-gateway-bff.md)(Usage BFF·`basePath` 호출 맵), [Web·Team BFF](./web-team-bff.md), [저장소 구조](../repository-structure.md) §6, [웹 경계](./web-split-boundary.md)(§2.4 로컬 `web-edge` Nginx)
 
 **소스 트리:** BFF·화면의 **정본**은 `services/identity-service/web/` 이다. **공용 UI(Shadcn 래퍼·`cn`)** 는 루트 pnpm workspace **`@ai-usage/ui`**(`packages/ui`)를 참조한다([web-split-boundary.md §1.1](./web-split-boundary.md)). Identity vs Usage 라우트·미들웨어 매처는 [web-split-boundary.md](./web-split-boundary.md) §2·§3.
@@ -107,6 +107,7 @@
 
 ## 3. 회원가입 계약 (정합성)
 
+- 브라우저→BFF 본문에는 **`role`을 넣지 않는다.** BFF(`POST /api/auth/signup` Route Handler)가 Identity로 보낼 때 **`role: "USER"`를 합쳐서** 전달한다(일반 가입자 고정).
 - `passwordConfirm`은 필수이며, `password`와 일치해야 한다.
 - 비밀번호 정책은 Identity와 동일하게 유지한다.
   - 소문자/숫자/특수문자 각각 1개 이상
@@ -244,7 +245,7 @@ curl -sS -i -X POST "http://localhost:3000/api/auth/signup" \
 - 앱 루트 **`/`** (`services/identity-service/web/src/app/page.tsx`)는 서버 컴포넌트로 메타데이터만 두고, 헤더·히어로 CTA는 클라이언트 컴포넌트 **`LandingHomeWithSession`** (`services/identity-service/web/src/components/landing/landing-header.tsx`)가 담당한다.
 - 마운트 시 브라우저가 동일 오리진으로 **`GET /api/auth/session`** 을 호출할 때 **`fetch(..., { credentials: "include", cache: "no-store" })`** 를 쓴다. 응답은 공통 **`ApiResponse<SessionResponse>`** 로 파싱하고, **`data.authenticated === true`** 이면 로그인된 것으로 본다.
 - **비로그인:** 내비·CTA는 **`/login`**, **`/signup`** 과 동일한 안내다.
-- **로그인됨:** **대시보드** 링크는 Usage `web` 경로 **`/dashboard`** 를 가리키되, 로컬 등에서 Identity와 Usage 호스트가 다르면 **`NEXT_PUBLIC_USAGE_WEB_ORIGIN`**(트레일링 슬래시 없음)을 앞에 붙인 절대 URL이 된다. 구현 헬퍼: **`usageAppHref(path)`** (`services/identity-service/web/src/lib/auth/cross-app-navigation.ts`). **설정** 등 Identity 앱 내부 링크는 **`/settings`** 등 상대 경로로 둔다.
+- **로그인됨:** **대시보드** 링크는 Usage `web` 경로 **`/dashboard`** 를 가리키되, 로컬 등에서 Identity와 Usage 호스트가 다르면 **`NEXT_PUBLIC_USAGE_WEB_ORIGIN`**(트레일링 슬래시 없음)을 앞에 붙인 절대 URL이 된다. 구현 헬퍼: **`usageAppHref(path)`** (`services/identity-service/web/src/lib/auth/cross-app-navigation.ts`). **설정** 등 Identity 앱 내부 링크는 **`/settings`** 등 상대 경로로 둔다. 헤더에는 **`로그아웃`** 버튼도 두며, 구현은 **`LogoutButton`** (`services/identity-service/web/src/components/auth/logout-button.tsx`) — 브라우저가 **`POST /api/auth/logout`**(§2 표·§7)을 호출한 뒤 **`/login`** 으로 이동한다.
 - 로그인 후 리다이렉트(`navigateAfterLogin`)도 동일한 오리진 규칙을 쓴다.
 - **크로스 오리진:** 쿠키는 설정한 오리진에만 붙는다. Identity 랜딩에서 세션을 보여 주는 것과 별개로, Usage `web` 쪽 인증·401 처리는 기존 [web-gateway-bff.md](./web-gateway-bff.md)·[web-split-boundary.md §4](./web-split-boundary.md)를 따른다.
 

--- a/docs/contracts/web-split-boundary.md
+++ b/docs/contracts/web-split-boundary.md
@@ -1,6 +1,6 @@
 # Identity vs Usage vs Team 웹 경계 (라우트·BFF·소스)
 
-버전: 1.4  
+버전: 1.5  
 관련: [저장소 구조](../repository-structure.md) §6, [architecture.md](../architecture.md) §10.2, [`docker/web-edge/nginx.conf`](../../docker/web-edge/nginx.conf), [web-identity-bff.md](./web-identity-bff.md), [web-gateway-bff.md](./web-gateway-bff.md), [web-team-bff.md](./web-team-bff.md)
 
 단일 도메인·경로 기반 엣지 프록시 뒤에서는 브라우저 오리진이 하나이므로 아래 **브라우저 경로**가 그대로 유지된다. **소스 트리**는 서비스 소유권에 맞게 `services/<svc>/web/`에 나뉜다.
@@ -37,7 +37,7 @@
 | `/api/auth/*` | 세션·로그인·외부 키 BFF → Identity HTTP |
 | `/api/identity/*` | Identity 관리 API 프록시 (`/api/v1/...` 업스트림) |
 
-랜딩 **`/`** 는 [web-identity-bff.md §10.1](./web-identity-bff.md)에 따라 클라이언트에서 **`GET /api/auth/session`** 으로 세션을 읽어 헤더·CTA를 바꾼다. Usage 대시보드로 가는 링크는 **`usageAppHref("/dashboard")`** 로 조립하며, 분리 호스트 개발 시 **`NEXT_PUBLIC_USAGE_WEB_ORIGIN`** 을 설정한다([§4](#4-로컬-개발쿠키-httponly-access_token)).
+랜딩 **`/`** 는 [web-identity-bff.md §10.1](./web-identity-bff.md)에 따라 클라이언트에서 **`GET /api/auth/session`** 으로 세션을 읽어 헤더·CTA를 바꾼다. 로그인 상태에서는 헤더에 **대시보드·설정·로그아웃**(`POST /api/auth/logout` → 로그인 페이지)을 둔다. Usage 대시보드로 가는 링크는 **`usageAppHref("/dashboard")`** 로 조립하며, 분리 호스트 개발 시 **`NEXT_PUBLIC_USAGE_WEB_ORIGIN`** 을 설정한다([§4](#4-로컬-개발쿠키-httponly-access_token)).
 
 ### 2.2 Usage `web/` (대시보드·Usage BFF)
 

--- a/docs/identity-auth-api-contract.md
+++ b/docs/identity-auth-api-contract.md
@@ -1,6 +1,6 @@
 # Identity 인증 API 계약 (백엔드)
 
-버전: 1.4  
+버전: 1.5  
 관련: [architecture.md](./architecture.md) §1.3, [contracts/web-identity-bff.md](./contracts/web-identity-bff.md)
 
 ---
@@ -37,10 +37,10 @@
 | `POST` | `/api/auth/signup`  | 불필요 | 회원가입                     |
 | `POST` | `/api/auth/login`   | 불필요 | 로그인 및 액세스 토큰 발급          |
 | `GET`  | `/api/auth/session` | 필요  | 세션(인증 상태) 확인             |
-| `GET`  | `/api/auth/external-keys` | 필요  | 내 외부 AI API 키 목록 조회 (`id`, `provider`, `alias`, `monthlyBudgetUsd`, `createdAt`) |
+| `GET`  | `/api/auth/external-keys` | 필요  | 내 외부 AI API 키 목록 조회 (`id`, `provider`, `alias`, `monthlyBudgetUsd`, `createdAt`, 삭제 예정 시 `deletionRequestedAt`·`permanentDeletionAt`·`deletionGraceDays` 등) |
 | `POST` | `/api/auth/external-keys` | 필요  | 외부 AI API 키 등록 (`provider`, `externalKey`, `alias`, `monthlyBudgetUsd`) |
 | `PUT`  | `/api/auth/external-keys/{id}` | 필요  | 외부 AI API 키 수정 (`alias`, `monthlyBudgetUsd` 필수, `externalKey`는 선택) |
-| `DELETE` | `/api/auth/external-keys/{id}` | 필요  | 외부 AI API 키 삭제 예약(7일 유예) |
+| `DELETE` | `/api/auth/external-keys/{id}` | 필요  | 외부 AI API 키 삭제 예약(선택 쿼리 `gracePeriodDays`, 기본 7일·범위 1~365일) |
 | `POST` | `/api/auth/external-keys/{id}/deletion-cancel` | 필요  | 외부 AI API 키 삭제 예약 취소 |
 | `POST` | `/api/auth/logout`  | 불필요 | 로그아웃 신호 응답(BFF 쿠키 삭제 유도) |
 
@@ -128,10 +128,22 @@
       "alias": "데모용 제미나이 키",
       "monthlyBudgetUsd": 20.5,
       "createdAt": "2026-03-29T08:05:19.296098200Z"
+    },
+    {
+      "id": 2,
+      "provider": "OPENAI",
+      "alias": "예시 삭제 예정 키",
+      "monthlyBudgetUsd": 10,
+      "createdAt": "2026-03-30T08:00:00Z",
+      "deletionRequestedAt": "2026-04-01T08:00:00Z",
+      "permanentDeletionAt": "2026-04-08T08:00:00Z",
+      "deletionGraceDays": 7
     }
   ]
 }
 ```
+
+삭제 예정 행이 아니면 `deletionRequestedAt`·`permanentDeletionAt`·`deletionGraceDays`는 응답에서 생략되거나 `null`일 수 있다(JSON 직렬화 정책에 따름).
 
 오류 응답 예시 (`success=false`, `data=null`):
 
@@ -147,7 +159,7 @@
 
 ## 7. 외부 API 키 등록 계약
 
-클라이언트가 Gemini 등 **제3자에서 발급받은 API 키 평문**과 **제공자(`provider`)**, **별칭(`alias`)**, **월 예산(`monthlyBudgetUsd`)**을 전달하면, 서버는 키 평문을 **AES-256-GCM으로 암호화해 DB에 저장**하고, 응답 본문에는 **평문·암호문을 포함하지 않는다**. 동일 사용자가 동일 `provider`에 대해 동일 키 평문을 중복 등록하면 `409`를 반환한다.
+클라이언트가 Gemini 등 **제3자에서 발급받은 API 키 평문**과 **제공자(`provider`)**, **별칭(`alias`)**, **월 예산(`monthlyBudgetUsd`)**을 전달하면, 서버는 키 평문을 **AES-256-GCM으로 암호화해 DB에 저장**하고, 응답 본문에는 **평문·암호문을 포함하지 않는다**. 동일 사용자·동일 `provider`·동일 키 값(해시)에 대해 **이미 활성 행이 있으면** `409`, **삭제 예정 행만 존재하면** `409`(메시지: `삭제예정키와 중복된 키`)를 반환한다.
 
 ### 7.1 요청
 
@@ -219,7 +231,8 @@
 | `alias` 누락 | `400` | `{"success":false,"message":"alias는 필수입니다","data":null}` |
 | `monthlyBudgetUsd` 누락 | `400` | `{"success":false,"message":"monthlyBudgetUsd는 필수입니다","data":null}` |
 | `provider` 값 불가 | `400` | `{"success":false,"message":"provider 값이 올바르지 않습니다. 허용: GEMINI, OPENAI, ANTHROPIC","data":null}` (또는 본문 형식 오류 메시지) |
-| 동일 provider·동일 키 재등록 | `409` | `{"success":false,"message":"이미 등록된 API 키입니다","data":null}` |
+| 동일 provider·동일 키 재등록(활성 행 존재) | `409` | `{"success":false,"message":"이미 등록된 API 키입니다","data":null}` |
+| 동일 provider·동일 키, 삭제 예정 행과만 충돌 | `409` | `{"success":false,"message":"삭제예정키와 중복된 키","data":null}` |
 
 ### 7.3 캐시 정책
 
@@ -295,7 +308,8 @@
 | `monthlyBudgetUsd` 누락 | `400` | `{"success":false,"message":"monthlyBudgetUsd는 필수입니다","data":null}` |
 | 삭제 예정 키 수정 시도 | `409` | `{"success":false,"message":"삭제 예정인 키는 수정할 수 없습니다. 취소 후 다시 시도하세요.","data":null}` |
 | 별칭 중복 | `409` | `{"success":false,"message":"이미 사용 중인 별칭입니다","data":null}` |
-| 동일 provider·동일 키 중복 | `409` | `{"success":false,"message":"이미 등록된 API 키입니다","data":null}` |
+| 동일 provider·동일 키 중복(활성 다른 행) | `409` | `{"success":false,"message":"이미 등록된 API 키입니다","data":null}` |
+| 동일 provider·동일 키, 삭제 예정 행과만 충돌 | `409` | `{"success":false,"message":"삭제예정키와 중복된 키","data":null}` |
 
 ### 9.3 캐시 정책
 
@@ -316,13 +330,19 @@
 
 ## 10.1 외부 API 키 삭제 예약/취소 계약
 
-삭제는 즉시 물리 삭제가 아니라 **7일 유예(soft delete)** 로 처리한다. 유예 중에는 삭제 취소가 가능하며, 유예 종료 후 스케줄러가 물리 삭제한다.
+삭제는 즉시 물리 삭제가 아니라 **유예 기간(soft delete)** 후 물리 삭제로 처리한다. **기본 유예는 7일**이며, 요청 시 **쿼리 `gracePeriodDays`** 로 **1~365일** 범위에서 바꿀 수 있다(생략 시 7일). 유예 중에는 삭제 취소가 가능하며, 유예 종료 후 스케줄러가 물리 삭제한다.
 
 ### 삭제 예약: `DELETE /api/auth/external-keys/{id}`
 
+| 항목 | 설명 |
+| --- | --- |
+| 쿼리 | 선택 `gracePeriodDays`(정수). 생략 시 기본 7일. 범위 위반 시 `400`. |
+| 동작 | `deletionRequestedAt`·`permanentDeletionAt`·`deletionGraceDays` 설정 |
+
 | 상황 | 상태 코드 | 예시 JSON |
 | --- | --- | --- |
-| 삭제 예약 성공 | `200` | `{"success":true,"message":"삭제가 예약되었습니다. 일주일 이내에 취소할 수 있으며, 이후에는 키가 영구 삭제됩니다.","data":{"id":1,"provider":"GEMINI","alias":"데모 키","createdAt":"...","deletionRequestedAt":"...","permanentDeletionAt":"..."}}` |
+| 삭제 예약 성공 | `200` | `{"success":true,"message":"삭제가 예약되었습니다. 일주일 이내에 취소할 수 있으며, 이후에는 키가 영구 삭제됩니다.","data":{"id":1,"provider":"GEMINI","alias":"데모 키","createdAt":"...","monthlyBudgetUsd":10,"deletionRequestedAt":"...","permanentDeletionAt":"...","deletionGraceDays":7}}` |
+| `gracePeriodDays` 범위 밖 | `400` | `{"success":false,"message":"유예 기간은 1일 이상 365일 이하로 설정할 수 있습니다","data":null}` |
 | 대상 키 없음 | `404` | `{"success":false,"message":"등록된 API 키를 찾을 수 없습니다","data":null}` |
 | 이미 삭제 예정 | `409` | `{"success":false,"message":"이미 삭제 예정인 키입니다","data":null}` |
 
@@ -330,7 +350,7 @@
 
 | 상황 | 상태 코드 | 예시 JSON |
 | --- | --- | --- |
-| 삭제 취소 성공 | `200` | `{"success":true,"message":"삭제 예약이 취소되었습니다","data":{"id":1,"provider":"GEMINI","alias":"데모 키","createdAt":"...","deletionRequestedAt":null,"permanentDeletionAt":null}}` |
+| 삭제 취소 성공 | `200` | `{"success":true,"message":"삭제 예약이 취소되었습니다","data":{"id":1,"provider":"GEMINI","alias":"데모 키","createdAt":"...","monthlyBudgetUsd":10,"deletionRequestedAt":null,"permanentDeletionAt":null,"deletionGraceDays":null}}` |
 | 대상 키 없음 | `404` | `{"success":false,"message":"등록된 API 키를 찾을 수 없습니다","data":null}` |
 | 삭제 예정 상태 아님 | `409` | `{"success":false,"message":"삭제 예정 상태가 아닙니다","data":null}` |
 
@@ -341,11 +361,11 @@
 
 | 상황        | 상태 코드 | 설명                           |
 | --------- | ----- | ---------------------------- |
-| 입력 검증 실패  | `400` | 필드 유효성/정책 위반 (`provider`·`externalKey`·`alias` 등) |
+| 입력 검증 실패  | `400` | 필드 유효성/정책 위반 (`provider`·`externalKey`·`alias` 등), 삭제 예약 시 `gracePeriodDays` 범위(1~365) 위반 등 |
 | 로그인 인증 실패 | `401` | 이메일/비밀번호 불일치                 |
 | 보호 API 미인증 | `401` | 액세스 토큰 없음/무효 (`GET/POST/PUT/DELETE /api/auth/external-keys` 등) |
 | 외부 API 키 별칭 중복 | `409` | 동일 사용자 기준 별칭 재사용              |
-| 외부 API 키 중복 등록 | `409` | 동일 사용자·동일 provider·동일 키 평문 재등록 |
+| 외부 API 키 중복 등록 | `409` | 동일 사용자·동일 provider·동일 키 값 — 활성 행 존재 시 `이미 등록된 API 키입니다`, 삭제 예정 행과만 충돌 시 `삭제예정키와 중복된 키` |
 | 외부 API 키 삭제 예정 충돌 | `409` | 이미 삭제 예정이거나, 삭제 예정 상태가 아닌 키 취소 등 상태 충돌 |
 | 외부 API 키 미존재 | `404` | 수정/조회 대상 외부 API 키를 찾을 수 없음    |
 | 이메일 중복    | `409` | 회원가입 중복                      |

--- a/docs/identity-auth-api-contract.md
+++ b/docs/identity-auth-api-contract.md
@@ -1,6 +1,6 @@
 # Identity 인증 API 계약 (백엔드)
 
-버전: 1.5  
+버전: 1.6  
 관련: [architecture.md](./architecture.md) §1.3, [contracts/web-identity-bff.md](./contracts/web-identity-bff.md)
 
 ---
@@ -35,6 +35,8 @@
 | 메서드    | 경로                  | 인증  | 설명                       |
 | ------ | ------------------- | --- | ------------------------ |
 | `POST` | `/api/auth/signup`  | 불필요 | 회원가입                     |
+| `POST` | `/api/auth/forgot-password` | 불필요 | 비밀번호 재설정 메일 요청(이메일 열거 방지용 동일 응답) |
+| `POST` | `/api/auth/reset-password` | 불필요 | 메일 링크 토큰으로 비밀번호 재설정 |
 | `POST` | `/api/auth/login`   | 불필요 | 로그인 및 액세스 토큰 발급          |
 | `GET`  | `/api/auth/session` | 필요  | 세션(인증 상태) 확인             |
 | `GET`  | `/api/auth/external-keys` | 필요  | 내 외부 AI API 키 목록 조회 (`id`, `provider`, `alias`, `monthlyBudgetUsd`, `createdAt`, 삭제 예정 시 `deletionRequestedAt`·`permanentDeletionAt`·`deletionGraceDays` 등) |
@@ -44,6 +46,25 @@
 | `POST` | `/api/auth/external-keys/{id}/deletion-cancel` | 필요  | 외부 AI API 키 삭제 예약 취소 |
 | `POST` | `/api/auth/logout`  | 불필요 | 로그아웃 신호 응답(BFF 쿠키 삭제 유도) |
 
+
+---
+
+## 3.1 비밀번호 찾기·재설정
+
+### 요청 본문
+
+- **`POST /api/auth/forgot-password`:** `{ "email": "user@example.com" }`
+- **`POST /api/auth/reset-password`:** `{ "token": "<메일 링크의 토큰>", "password": "…", "passwordConfirm": "…" }` — 비밀번호 규칙은 회원가입(`SignupRequest`)과 동일하다.
+
+### 동작
+
+- **forgot-password:** 등록된 이메일인 경우에만 재설정 토큰을 발급하고 메일을 보낸다. 응답 **메시지는 항상 동일**하여 이메일 존재 여부를 드러내지 않는다. SMTP가 설정되지 않은 환경에서는 재설정 링크가 서버 로그(INFO)로만 출력될 수 있다.
+- **reset-password:** 토큰은 DB에 SHA-256 해시로만 저장되며 일회용이다. 만료·재사용·불일치 시 `400`과 안내 메시지를 반환한다.
+- 설정: `identity.passwordReset.webBaseUrl`(공개 웹 베이스 URL, 메일 링크에 사용), `identity.passwordReset.tokenValidityHours`, `identity.passwordReset.mailFrom`, 선택적 `spring.mail.*`(SMTP).
+
+### 캐시 정책
+
+- 두 엔드포인트 응답에 `Cache-Control: no-store`를 적용한다.
 
 ---
 

--- a/services/identity-service/build.gradle
+++ b/services/identity-service/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/SecurityConfig.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
 				.exceptionHandling(exception -> exception.authenticationEntryPoint(restAuthenticationEntryPoint))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers("/api/auth/signup").permitAll()
+						.requestMatchers("/api/auth/forgot-password").permitAll()
+						.requestMatchers("/api/auth/reset-password").permitAll()
 						.requestMatchers("/api/auth/login").permitAll()
 						.requestMatchers("/api/auth/logout").permitAll()
 						.requestMatchers("/internal/api-keys/**").permitAll()

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/AuthController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/AuthController.java
@@ -1,12 +1,15 @@
 package com.zerobugfreinds.identity_service.controller;
 
 import com.zerobugfreinds.identity_service.common.ApiResponse;
+import com.zerobugfreinds.identity_service.dto.ForgotPasswordRequest;
 import com.zerobugfreinds.identity_service.dto.LoginRequest;
 import com.zerobugfreinds.identity_service.dto.LoginResponse;
+import com.zerobugfreinds.identity_service.dto.ResetPasswordRequest;
 import com.zerobugfreinds.identity_service.dto.SessionResponse;
 import com.zerobugfreinds.identity_service.dto.SignupRequest;
 import com.zerobugfreinds.identity_service.dto.SignupResponse;
 import com.zerobugfreinds.identity_service.exception.AuthContractViolationException;
+import com.zerobugfreinds.identity_service.service.PasswordResetService;
 import com.zerobugfreinds.identity_service.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.http.CacheControl;
@@ -29,9 +32,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
 	private final UserService userService;
+	private final PasswordResetService passwordResetService;
 
-	public AuthController(UserService userService) {
+	public AuthController(UserService userService, PasswordResetService passwordResetService) {
 		this.userService = userService;
+		this.passwordResetService = passwordResetService;
 	}
 
 	/**
@@ -47,6 +52,28 @@ public class AuthController {
 	/**
 	 * 로그인.
 	 */
+	/**
+	 * 비밀번호 찾기: 이메일로 재설정 링크 발송(등록된 주소만 실제 발송).
+	 */
+	@PostMapping("/forgot-password")
+	public ResponseEntity<ApiResponse<Void>> forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
+		passwordResetService.requestForgotPassword(request);
+		return ResponseEntity.ok()
+				.cacheControl(CacheControl.noStore().mustRevalidate())
+				.body(ApiResponse.ok(PasswordResetService.FORGOT_PASSWORD_UNIFORM_MESSAGE, null));
+	}
+
+	/**
+	 * 비밀번호 재설정: 메일 링크의 토큰과 새 비밀번호로 갱신.
+	 */
+	@PostMapping("/reset-password")
+	public ResponseEntity<ApiResponse<Void>> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+		passwordResetService.resetPassword(request);
+		return ResponseEntity.ok()
+				.cacheControl(CacheControl.noStore().mustRevalidate())
+				.body(ApiResponse.ok("비밀번호가 변경되었습니다. 로그인해 주세요", null));
+	}
+
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
 		LoginResponse body = userService.login(request);

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -78,14 +79,15 @@ public class ExternalApiKeyController {
 	}
 
 	/**
-	 * 삭제 요청: 7일 유예 후 스케줄러가 행을 제거한다. 유예 중에는 취소 가능.
+	 * 삭제 요청: 유예 기간(기본 7일, 쿼리 {@code gracePeriodDays}) 후 스케줄러가 행을 제거한다. 유예 중에는 취소 가능.
 	 */
 	@DeleteMapping("/external-keys/{id}")
 	public ResponseEntity<ApiResponse<ExternalApiKeyRegisterResponse>> requestDeletion(
 			@AuthenticationPrincipal IdentityUserPrincipal principal,
-			@PathVariable("id") Long id
+			@PathVariable("id") Long id,
+			@RequestParam(name = "gracePeriodDays", required = false) Integer gracePeriodDays
 	) {
-		ExternalApiKeyEntity saved = externalApiKeyService.requestDeletion(principal.userId(), id);
+		ExternalApiKeyEntity saved = externalApiKeyService.requestDeletion(principal.userId(), id, gracePeriodDays);
 		return ResponseEntity.ok(ApiResponse.ok(
 				"삭제가 예약되었습니다. 일주일 이내에 취소할 수 있으며, 이후에는 키가 영구 삭제됩니다.",
 				toResponse(saved)
@@ -109,7 +111,8 @@ public class ExternalApiKeyController {
 				key.getCreatedAt(),
 				key.getMonthlyBudgetUsd(),
 				key.getDeletionRequestedAt(),
-				key.getPermanentDeletionAt()
+				key.getPermanentDeletionAt(),
+				key.getDeletionGraceDays()
 		);
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import com.zerobugfreinds.identity_service.exception.ExternalApiKeyNotFoundExcep
 import com.zerobugfreinds.identity_service.exception.ExternalApiKeyNotPendingDeletionException;
 import com.zerobugfreinds.identity_service.exception.ExternalApiKeyPendingDeletionException;
 import com.zerobugfreinds.identity_service.exception.InvalidCredentialsException;
+import com.zerobugfreinds.identity_service.exception.InvalidPasswordResetTokenException;
 import com.zerobugfreinds.identity_service.exception.InvalidSignupRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -40,6 +41,12 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(InvalidSignupRequestException.class)
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ApiResponse<Void> handleInvalidSignupRequest(InvalidSignupRequestException ex) {
+		return ApiResponse.fail(ex.getMessage());
+	}
+
+	@ExceptionHandler(InvalidPasswordResetTokenException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ApiResponse<Void> handleInvalidPasswordResetToken(InvalidPasswordResetTokenException ex) {
 		return ApiResponse.fail(ex.getMessage());
 	}
 

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
@@ -55,6 +55,12 @@ public class GlobalExceptionHandler {
 		return ApiResponse.fail(ex.getMessage());
 	}
 
+	@ExceptionHandler(IllegalArgumentException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ApiResponse<Void> handleIllegalArgument(IllegalArgumentException ex) {
+		return ApiResponse.fail(ex.getMessage());
+	}
+
 	@ExceptionHandler(DuplicateExternalApiKeyException.class)
 	@ResponseStatus(HttpStatus.CONFLICT)
 	public ApiResponse<Void> handleDuplicateExternalApiKey(DuplicateExternalApiKeyException ex) {

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/domain/ExternalApiKeyDeletionPolicy.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/domain/ExternalApiKeyDeletionPolicy.java
@@ -1,13 +1,13 @@
 package com.zerobugfreinds.identity_service.domain;
 
-import java.time.Duration;
-
 /**
- * 삭제 요청 후 완전 삭제까지 유예 기간. 운영에서 바꾸려면 설정 프로퍼티로 승격한다.
+ * 외부 API 키 삭제 예정 유예 기간(일). 기본값과 허용 범위.
  */
 public final class ExternalApiKeyDeletionPolicy {
 
-	public static final Duration PENDING_RETENTION = Duration.ofDays(7);
+	public static final int DEFAULT_GRACE_DAYS = 7;
+	public static final int MIN_GRACE_DAYS = 1;
+	public static final int MAX_GRACE_DAYS = 365;
 
 	private ExternalApiKeyDeletionPolicy() {
 	}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ExternalApiKeyRegisterResponse.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ExternalApiKeyRegisterResponse.java
@@ -18,9 +18,10 @@ public record ExternalApiKeyRegisterResponse(
 		Instant createdAt,
 		@JsonProperty("monthlyBudgetUsd") BigDecimal monthlyBudgetUsd,
 		Instant deletionRequestedAt,
-		Instant permanentDeletionAt
+		Instant permanentDeletionAt,
+		Integer deletionGraceDays
 ) {
 	public ExternalApiKeyRegisterResponse(Long id, String provider, String alias, Instant createdAt) {
-		this(id, provider, alias, createdAt, null, null, null);
+		this(id, provider, alias, createdAt, null, null, null, null);
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ForgotPasswordRequest.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ForgotPasswordRequest.java
@@ -1,0 +1,12 @@
+package com.zerobugfreinds.identity_service.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 비밀번호 찾기(재설정 메일 요청) 본문.
+ */
+public record ForgotPasswordRequest(
+		@NotBlank @Email String email
+) {
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ResetPasswordRequest.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/ResetPasswordRequest.java
@@ -1,0 +1,21 @@
+package com.zerobugfreinds.identity_service.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 비밀번호 재설정 본문. 비밀번호 규칙은 {@link com.zerobugfreinds.identity_service.dto.SignupRequest} 와 동일하다.
+ */
+public record ResetPasswordRequest(
+		@NotBlank @Size(max = 512) String token,
+		@NotBlank
+		@Size(min = 8, max = 100)
+		@Pattern(
+				regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[^a-zA-Z0-9])(?=\\S+$)[^A-Z]{8,100}$",
+				message = "비밀번호는 소문자/숫자/특수문자를 각각 1개 이상 포함하고 대문자 없이 8~100자여야 합니다"
+		)
+		String password,
+		@NotBlank String passwordConfirm
+) {
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/ExternalApiKeyEntity.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/ExternalApiKeyEntity.java
@@ -66,6 +66,10 @@ public class ExternalApiKeyEntity {
 	@Column(name = "permanent_deletion_at")
 	private Instant permanentDeletionAt;
 
+	/** 삭제 요청 시 선택한 유예 기간(일). 삭제 예정이 아니면 null. */
+	@Column(name = "deletion_grace_days")
+	private Integer deletionGraceDays;
+
 	protected ExternalApiKeyEntity() {
 	}
 
@@ -108,15 +112,17 @@ public class ExternalApiKeyEntity {
 	}
 
 	/** 삭제 예정으로 표시한다(서비스에서 중복 여부를 검증한다). */
-	public void markPendingDeletion(Instant now, Duration retention) {
+	public void markPendingDeletion(Instant now, int gracePeriodDays) {
 		this.deletionRequestedAt = now;
-		this.permanentDeletionAt = now.plus(retention);
+		this.deletionGraceDays = gracePeriodDays;
+		this.permanentDeletionAt = now.plus(Duration.ofDays(gracePeriodDays));
 	}
 
 	/** 삭제 예정을 취소한다. */
 	public void clearPendingDeletion() {
 		this.deletionRequestedAt = null;
 		this.permanentDeletionAt = null;
+		this.deletionGraceDays = null;
 	}
 
 	public boolean isPendingDeletion() {
@@ -161,5 +167,9 @@ public class ExternalApiKeyEntity {
 
 	public Instant getPermanentDeletionAt() {
 		return permanentDeletionAt;
+	}
+
+	public Integer getDeletionGraceDays() {
+		return deletionGraceDays;
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/PasswordResetToken.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/PasswordResetToken.java
@@ -1,0 +1,72 @@
+package com.zerobugfreinds.identity_service.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+/**
+ * 비밀번호 재설정용 일회성 토큰. DB에는 토큰 평문이 아니라 SHA-256 해시만 저장한다.
+ */
+@Entity
+@Table(name = "password_reset_tokens")
+public class PasswordResetToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(name = "token_hash", nullable = false, unique = true, length = 64)
+	private String tokenHash;
+
+	@Column(name = "expires_at", nullable = false)
+	private Instant expiresAt;
+
+	@Column(name = "used_at")
+	private Instant usedAt;
+
+	protected PasswordResetToken() {
+	}
+
+	public PasswordResetToken(User user, String tokenHash, Instant expiresAt) {
+		this.user = user;
+		this.tokenHash = tokenHash;
+		this.expiresAt = expiresAt;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public String getTokenHash() {
+		return tokenHash;
+	}
+
+	public Instant getExpiresAt() {
+		return expiresAt;
+	}
+
+	public Instant getUsedAt() {
+		return usedAt;
+	}
+
+	public void markUsed() {
+		this.usedAt = Instant.now();
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/User.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/User.java
@@ -64,4 +64,11 @@ public class User {
 	public Role getRole() {
 		return role;
 	}
+
+	/**
+	 * BCrypt 등으로 인코딩된 비밀번호로 갱신한다 (비밀번호 재설정 등).
+	 */
+	public void setPassword(String password) {
+		this.password = password;
+	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/exception/InvalidPasswordResetTokenException.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/exception/InvalidPasswordResetTokenException.java
@@ -1,0 +1,11 @@
+package com.zerobugfreinds.identity_service.exception;
+
+/**
+ * 재설정 토큰이 없거나 만료·사용됨 등으로 유효하지 않을 때.
+ */
+public class InvalidPasswordResetTokenException extends RuntimeException {
+
+	public InvalidPasswordResetTokenException(String message) {
+		super(message);
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
@@ -25,6 +25,12 @@ public interface ExternalApiKeyRepository extends JpaRepository<ExternalApiKeyEn
 			String keyHash
 	);
 
+	Optional<ExternalApiKeyEntity> findByUserIdAndProviderAndKeyHash(
+			Long userId,
+			ExternalApiKeyProvider provider,
+			String keyHash
+	);
+
 	/** 별칭은 삭제 예정 행까지 포함해 사용자당 유일(유예 중에도 동일 별칭으로 새 등록 불가). */
 	boolean existsByUserIdAndKeyAlias(Long userId, String keyAlias);
 	boolean existsByUserIdAndKeyAliasAndIdNot(Long userId, String keyAlias, Long id);

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/PasswordResetTokenRepository.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,17 @@
+package com.zerobugfreinds.identity_service.repository;
+
+import com.zerobugfreinds.identity_service.entity.PasswordResetToken;
+import com.zerobugfreinds.identity_service.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * 비밀번호 재설정 토큰 영속성.
+ */
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+
+	Optional<PasswordResetToken> findByTokenHash(String tokenHash);
+
+	void deleteByUser(User user);
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
@@ -1,6 +1,5 @@
 package com.zerobugfreinds.identity_service.service;
 
-import com.zerobugfreinds.identity_service.domain.ExternalApiKeyDeletionPolicy;
 import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
 import com.zerobugfreinds.identity_service.dto.InternalApiKeyResponse;
 import com.zerobugfreinds.identity_service.entity.ExternalApiKeyEntity;
@@ -22,6 +21,10 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+
+import static com.zerobugfreinds.identity_service.domain.ExternalApiKeyDeletionPolicy.DEFAULT_GRACE_DAYS;
+import static com.zerobugfreinds.identity_service.domain.ExternalApiKeyDeletionPolicy.MAX_GRACE_DAYS;
+import static com.zerobugfreinds.identity_service.domain.ExternalApiKeyDeletionPolicy.MIN_GRACE_DAYS;
 
 /**
  * 외부 AI API 키 등록·삭제(유예 후 물리 삭제).
@@ -70,19 +73,18 @@ public class ExternalApiKeyService {
 		}
 
 		String keyHash = encryptionUtil.sha256HexForUniqueness(provider.name(), normalizedKey);
-		long duplicateCount = externalApiKeyRepository.countByUserIdAndProviderAndKeyHashAndDeletionRequestedAtIsNull(
-				userId,
-				provider,
-				keyHash
-		);
-		if (duplicateCount > 0) {
+		Optional<ExternalApiKeyEntity> existingSameHash =
+				externalApiKeyRepository.findByUserIdAndProviderAndKeyHash(userId, provider, keyHash);
+		if (existingSameHash.isPresent()) {
+			if (existingSameHash.get().isPendingDeletion()) {
+				throw new DuplicateExternalApiKeyException("삭제예정키와 중복된 키");
+			}
 			log.warn(
-					"[AUDIT] external_api_key_duplicate_detected userId={} provider={} alias={} hashPrefix={} duplicateCount={}",
+					"[AUDIT] external_api_key_duplicate_detected userId={} provider={} alias={} hashPrefix={}",
 					userId,
 					provider.name(),
 					trimmedAlias,
-					keyHash.substring(0, 8),
-					duplicateCount
+					keyHash.substring(0, 8)
 			);
 			throw new DuplicateExternalApiKeyException("이미 등록된 API 키입니다");
 		}
@@ -165,12 +167,12 @@ public class ExternalApiKeyService {
 				throw new IllegalArgumentException("externalKey를 수정할 때 provider는 필수입니다");
 			}
 			String keyHash = encryptionUtil.sha256HexForUniqueness(provider.name(), normalizedKey);
-			if (externalApiKeyRepository.existsByUserIdAndProviderAndKeyHashAndIdNotAndDeletionRequestedAtIsNull(
-					userId,
-					provider,
-					keyHash,
-					externalKeyId
-			)) {
+			Optional<ExternalApiKeyEntity> otherSameHash =
+					externalApiKeyRepository.findByUserIdAndProviderAndKeyHash(userId, provider, keyHash);
+			if (otherSameHash.isPresent() && !otherSameHash.get().getId().equals(externalKeyId)) {
+				if (otherSameHash.get().isPendingDeletion()) {
+					throw new DuplicateExternalApiKeyException("삭제예정키와 중복된 키");
+				}
 				throw new DuplicateExternalApiKeyException("이미 등록된 API 키입니다");
 			}
 
@@ -210,7 +212,7 @@ public class ExternalApiKeyService {
 	 * 삭제 요청: 유예 기간 후 {@link #purgeExpiredKeys()} 가 행을 제거한다.
 	 */
 	@Transactional
-	public ExternalApiKeyEntity requestDeletion(Long userId, Long externalKeyId) {
+	public ExternalApiKeyEntity requestDeletion(Long userId, Long externalKeyId, Integer gracePeriodDays) {
 		if (userId == null || externalKeyId == null) {
 			throw new IllegalArgumentException("userId와 externalKeyId는 필수입니다");
 		}
@@ -219,8 +221,9 @@ public class ExternalApiKeyService {
 		if (entity.isPendingDeletion()) {
 			throw new ExternalApiKeyAlreadyPendingDeletionException("이미 삭제 예정인 키입니다");
 		}
+		int days = resolveGracePeriodDays(gracePeriodDays);
 		Instant now = Instant.now();
-		entity.markPendingDeletion(now, ExternalApiKeyDeletionPolicy.PENDING_RETENTION);
+		entity.markPendingDeletion(now, days);
 		log.info(
 				"[AUDIT] external_api_key_deletion_requested userId={} keyId={} permanentDeletionAt={}",
 				userId,
@@ -262,5 +265,15 @@ public class ExternalApiKeyService {
 		}
 		externalApiKeyRepository.deleteAll(expired);
 		return expired.size();
+	}
+
+	private static int resolveGracePeriodDays(Integer requested) {
+		int days = requested != null ? requested : DEFAULT_GRACE_DAYS;
+		if (days < MIN_GRACE_DAYS || days > MAX_GRACE_DAYS) {
+			throw new IllegalArgumentException(
+					"유예 기간은 " + MIN_GRACE_DAYS + "일 이상 " + MAX_GRACE_DAYS + "일 이하로 설정할 수 있습니다"
+			);
+		}
+		return days;
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/PasswordResetMailService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/PasswordResetMailService.java
@@ -1,0 +1,68 @@
+package com.zerobugfreinds.identity_service.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 비밀번호 재설정 링크 전달. {@code spring.mail.host} 가 없으면 SMTP 대신 로그로 링크를 남긴다(로컬 개발).
+ */
+@Service
+public class PasswordResetMailService {
+
+	private static final Logger log = LoggerFactory.getLogger(PasswordResetMailService.class);
+
+	private final JavaMailSender mailSender;
+	private final String webBaseUrl;
+	private final String mailFrom;
+	private final int tokenValidityHours;
+	private final String applicationName;
+
+	public PasswordResetMailService(
+			@Autowired(required = false) JavaMailSender mailSender,
+			@Value("${identity.passwordReset.webBaseUrl}") String webBaseUrl,
+			@Value("${identity.passwordReset.mailFrom}") String mailFrom,
+			@Value("${identity.passwordReset.tokenValidityHours}") int tokenValidityHours,
+			@Value("${spring.application.name:identity-service}") String applicationName
+	) {
+		this.mailSender = mailSender;
+		this.webBaseUrl = webBaseUrl;
+		this.mailFrom = mailFrom;
+		this.tokenValidityHours = tokenValidityHours;
+		this.applicationName = applicationName;
+	}
+
+	public void sendResetLink(String toEmail, String rawToken) {
+		String base = webBaseUrl.replaceAll("/+$", "");
+		String tokenParam = URLEncoder.encode(rawToken, StandardCharsets.UTF_8);
+		String link = base + "/reset-password?token=" + tokenParam;
+
+		String subject = "[" + applicationName + "] 비밀번호 재설정";
+		String body = """
+				비밀번호 재설정을 요청하셨습니다. 아래 링크를 클릭하여 새 비밀번호를 설정해 주세요.
+
+				%s
+
+				링크는 %d시간 동안 유효합니다. 본인이 요청하지 않았다면 이 메일을 무시해 주세요.
+				""".formatted(link, tokenValidityHours);
+
+		if (mailSender == null) {
+			log.info("[password-reset] SMTP 미구성: email={} resetLink={}", toEmail, link);
+			return;
+		}
+
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setFrom(mailFrom);
+		message.setTo(toEmail);
+		message.setSubject(subject);
+		message.setText(body);
+		mailSender.send(message);
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/PasswordResetService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/PasswordResetService.java
@@ -1,0 +1,112 @@
+package com.zerobugfreinds.identity_service.service;
+
+import com.zerobugfreinds.identity_service.dto.ForgotPasswordRequest;
+import com.zerobugfreinds.identity_service.dto.ResetPasswordRequest;
+import com.zerobugfreinds.identity_service.entity.PasswordResetToken;
+import com.zerobugfreinds.identity_service.entity.User;
+import com.zerobugfreinds.identity_service.exception.InvalidPasswordResetTokenException;
+import com.zerobugfreinds.identity_service.exception.InvalidSignupRequestException;
+import com.zerobugfreinds.identity_service.repository.PasswordResetTokenRepository;
+import com.zerobugfreinds.identity_service.repository.UserRepository;
+import com.zerobugfreinds.identity_service.util.EncryptionUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HexFormat;
+import java.util.Optional;
+
+/**
+ * 비밀번호 찾기·재설정 유스케이스.
+ */
+@Service
+public class PasswordResetService {
+
+	public static final String FORGOT_PASSWORD_UNIFORM_MESSAGE =
+			"등록된 이메일이면 비밀번호 재설정 안내를 보냈습니다";
+
+	private static final int RAW_TOKEN_BYTES = 32;
+
+	private final UserRepository userRepository;
+	private final PasswordResetTokenRepository passwordResetTokenRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final EncryptionUtil encryptionUtil;
+	private final PasswordResetMailService passwordResetMailService;
+	private final SecureRandom secureRandom = new SecureRandom();
+	private final int tokenValidityHours;
+
+	public PasswordResetService(
+			UserRepository userRepository,
+			PasswordResetTokenRepository passwordResetTokenRepository,
+			PasswordEncoder passwordEncoder,
+			EncryptionUtil encryptionUtil,
+			PasswordResetMailService passwordResetMailService,
+			@Value("${identity.passwordReset.tokenValidityHours}") int tokenValidityHours
+	) {
+		this.userRepository = userRepository;
+		this.passwordResetTokenRepository = passwordResetTokenRepository;
+		this.passwordEncoder = passwordEncoder;
+		this.encryptionUtil = encryptionUtil;
+		this.passwordResetMailService = passwordResetMailService;
+		this.tokenValidityHours = tokenValidityHours;
+	}
+
+	/**
+	 * 이메일이 존재하면 재설정 토큰을 발급하고 메일을 보낸다. 존재 여부는 응답으로 드러내지 않는다.
+	 */
+	@Transactional
+	public void requestForgotPassword(ForgotPasswordRequest request) {
+		String email = request.email().trim();
+		Optional<User> userOpt = userRepository.findByEmail(email);
+		if (userOpt.isEmpty()) {
+			return;
+		}
+		User user = userOpt.get();
+		passwordResetTokenRepository.deleteByUser(user);
+
+		String rawToken = randomTokenHex(RAW_TOKEN_BYTES);
+		String tokenHash = encryptionUtil.sha256HexUtf8(rawToken);
+		Instant expiresAt = Instant.now().plus(tokenValidityHours, ChronoUnit.HOURS);
+		passwordResetTokenRepository.save(new PasswordResetToken(user, tokenHash, expiresAt));
+
+		passwordResetMailService.sendResetLink(user.getEmail(), rawToken);
+	}
+
+	/**
+	 * 토큰으로 비밀번호를 재설정한다. 토큰은 일회용이며 사용 후 무효화된다.
+	 */
+	@Transactional
+	public void resetPassword(ResetPasswordRequest request) {
+		if (!request.password().equals(request.passwordConfirm())) {
+			throw new InvalidSignupRequestException("비밀번호와 비밀번호 확인이 일치하지 않습니다");
+		}
+		String tokenHash = encryptionUtil.sha256HexUtf8(request.token().trim());
+		PasswordResetToken entity = passwordResetTokenRepository.findByTokenHash(tokenHash)
+				.orElseThrow(() -> new InvalidPasswordResetTokenException(
+						"링크가 만료되었거나 유효하지 않습니다"));
+
+		if (entity.getUsedAt() != null) {
+			throw new InvalidPasswordResetTokenException("링크가 만료되었거나 유효하지 않습니다");
+		}
+		if (entity.getExpiresAt().isBefore(Instant.now())) {
+			throw new InvalidPasswordResetTokenException("링크가 만료되었거나 유효하지 않습니다");
+		}
+
+		User user = entity.getUser();
+		user.setPassword(passwordEncoder.encode(request.password()));
+		userRepository.save(user);
+
+		entity.markUsed();
+		passwordResetTokenRepository.save(entity);
+	}
+
+	private String randomTokenHex(int numBytes) {
+		byte[] bytes = new byte[numBytes];
+		secureRandom.nextBytes(bytes);
+		return HexFormat.of().formatHex(bytes);
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/util/EncryptionUtil.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/util/EncryptionUtil.java
@@ -37,9 +37,16 @@ public class EncryptionUtil {
 	 */
 	public String sha256HexForUniqueness(String providerName, String normalizedPlainKey) {
 		String payload = providerName + "\0" + normalizedPlainKey;
+		return sha256HexUtf8(payload);
+	}
+
+	/**
+	 * 임의 문자열(UTF-8)에 대한 SHA-256 16진 문자열. 비밀번호 재설정 토큰 해시 등에 사용한다.
+	 */
+	public String sha256HexUtf8(String utf8Text) {
 		try {
 			MessageDigest digest = MessageDigest.getInstance("SHA-256");
-			byte[] hash = digest.digest(payload.getBytes(StandardCharsets.UTF_8));
+			byte[] hash = digest.digest(utf8Text.getBytes(StandardCharsets.UTF_8));
 			return HexFormat.of().formatHex(hash);
 		} catch (NoSuchAlgorithmException e) {
 			throw new IllegalStateException("SHA-256 not available", e);

--- a/services/identity-service/src/main/resources/application.properties
+++ b/services/identity-service/src/main/resources/application.properties
@@ -15,3 +15,16 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ca
 
 # 외부 API 키 저장용 AES 키 유도 문자열(운영에서는 IDENTITY_API_KEY_ENCRYPTION_SECRET 등으로 충분히 긴 값 권장)
 identity.api-key.encryption.secret=${IDENTITY_API_KEY_ENCRYPTION_SECRET:change-this-external-api-key-encryption-secret-min-32-chars}
+
+# 비밀번호 재설정: 메일의 링크에 사용할 공개 웹 베이스 URL (슬래시 없이 끝나도 됨)
+identity.passwordReset.webBaseUrl=${IDENTITY_WEB_PUBLIC_BASE_URL:http://localhost:3000}
+identity.passwordReset.tokenValidityHours=${IDENTITY_PASSWORD_RESET_TOKEN_VALIDITY_HOURS:1}
+identity.passwordReset.mailFrom=${IDENTITY_PASSWORD_RESET_MAIL_FROM:noreply@localhost}
+
+# SMTP (선택). 미설정 시 재설정 링크는 로그(INFO)로만 출력된다.
+# spring.mail.host=
+# spring.mail.port=587
+# spring.mail.username=
+# spring.mail.password=
+# spring.mail.properties.mail.smtp.auth=true
+# spring.mail.properties.mail.smtp.starttls.enable=true

--- a/services/identity-service/src/test/java/com/zerobugfreinds/identity_service/service/PasswordResetServiceTest.java
+++ b/services/identity-service/src/test/java/com/zerobugfreinds/identity_service/service/PasswordResetServiceTest.java
@@ -1,0 +1,121 @@
+package com.zerobugfreinds.identity_service.service;
+
+import com.zerobugfreinds.identity_service.dto.ForgotPasswordRequest;
+import com.zerobugfreinds.identity_service.dto.ResetPasswordRequest;
+import com.zerobugfreinds.identity_service.entity.PasswordResetToken;
+import com.zerobugfreinds.identity_service.entity.Role;
+import com.zerobugfreinds.identity_service.entity.User;
+import com.zerobugfreinds.identity_service.exception.InvalidPasswordResetTokenException;
+import com.zerobugfreinds.identity_service.repository.PasswordResetTokenRepository;
+import com.zerobugfreinds.identity_service.repository.UserRepository;
+import com.zerobugfreinds.identity_service.util.EncryptionUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private PasswordResetTokenRepository passwordResetTokenRepository;
+	@Mock
+	private PasswordEncoder passwordEncoder;
+	@Mock
+	private EncryptionUtil encryptionUtil;
+	@Mock
+	private PasswordResetMailService passwordResetMailService;
+
+	private PasswordResetService passwordResetService;
+
+	@BeforeEach
+	void setUp() {
+		passwordResetService = new PasswordResetService(
+				userRepository,
+				passwordResetTokenRepository,
+				passwordEncoder,
+				encryptionUtil,
+				passwordResetMailService,
+				1
+		);
+	}
+
+	@Test
+	void requestForgotPassword_doesNothingWhenEmailUnknown() {
+		when(userRepository.findByEmail("a@b.com")).thenReturn(Optional.empty());
+
+		passwordResetService.requestForgotPassword(new ForgotPasswordRequest("a@b.com"));
+
+		verify(passwordResetTokenRepository, never()).save(any());
+		verify(passwordResetMailService, never()).sendResetLink(any(), any());
+	}
+
+	@Test
+	void requestForgotPassword_savesTokenAndSendsMailWhenUserExists() {
+		User user = new User("a@b.com", "hash", "n", Role.USER);
+		when(userRepository.findByEmail("a@b.com")).thenReturn(Optional.of(user));
+		when(encryptionUtil.sha256HexUtf8(any())).thenReturn("deadbeef");
+
+		passwordResetService.requestForgotPassword(new ForgotPasswordRequest("a@b.com"));
+
+		verify(passwordResetTokenRepository).deleteByUser(user);
+		verify(passwordResetTokenRepository).save(any(PasswordResetToken.class));
+		verify(passwordResetMailService).sendResetLink(eq("a@b.com"), any());
+	}
+
+	@Test
+	void resetPassword_throwsWhenTokenUnknown() {
+		when(encryptionUtil.sha256HexUtf8("tok")).thenReturn("hh");
+		when(passwordResetTokenRepository.findByTokenHash("hh")).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> passwordResetService.resetPassword(
+				new ResetPasswordRequest("tok", "abc123!@", "abc123!@")
+		)).isInstanceOf(InvalidPasswordResetTokenException.class);
+	}
+
+	@Test
+	void resetPassword_throwsWhenTokenExpired() {
+		User user = new User("a@b.com", "hash", "n", Role.USER);
+		PasswordResetToken token = new PasswordResetToken(user, "hh", Instant.now().minusSeconds(3600));
+		when(encryptionUtil.sha256HexUtf8("tok")).thenReturn("hh");
+		when(passwordResetTokenRepository.findByTokenHash("hh")).thenReturn(Optional.of(token));
+
+		assertThatThrownBy(() -> passwordResetService.resetPassword(
+				new ResetPasswordRequest("tok", "abc123!@", "abc123!@")
+		)).isInstanceOf(InvalidPasswordResetTokenException.class);
+	}
+
+	@Test
+	void resetPassword_updatesUserPassword() {
+		User user = new User("a@b.com", "oldhash", "n", Role.USER);
+		PasswordResetToken token = new PasswordResetToken(user, "hh", Instant.now().plusSeconds(3600));
+		when(encryptionUtil.sha256HexUtf8("tok")).thenReturn("hh");
+		when(passwordResetTokenRepository.findByTokenHash("hh")).thenReturn(Optional.of(token));
+		when(passwordEncoder.encode("abc123!@")).thenReturn("newhash");
+
+		passwordResetService.resetPassword(new ResetPasswordRequest("tok", "abc123!@", "abc123!@"));
+
+		ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+		verify(userRepository).save(userCaptor.capture());
+		org.assertj.core.api.Assertions.assertThat(userCaptor.getValue().getPassword()).isEqualTo("newhash");
+
+		ArgumentCaptor<PasswordResetToken> tokenCaptor = ArgumentCaptor.forClass(PasswordResetToken.class);
+		verify(passwordResetTokenRepository).save(tokenCaptor.capture());
+		org.assertj.core.api.Assertions.assertThat(tokenCaptor.getValue().getUsedAt()).isNotNull();
+	}
+}

--- a/services/identity-service/src/test/resources/application-test.properties
+++ b/services/identity-service/src/test/resources/application-test.properties
@@ -1,3 +1,5 @@
+spring.application.name=identity-service
+
 spring.datasource.url=jdbc:h2:mem:identitytest;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa

--- a/services/identity-service/src/test/resources/application.properties
+++ b/services/identity-service/src/test/resources/application.properties
@@ -1,3 +1,5 @@
+spring.application.name=identity-service
+
 # 통합 테스트용 인메모리 DB (PostgreSQL 프로덕션 설정과 분리)
 spring.datasource.url=jdbc:h2:mem:identity_test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
 spring.datasource.driver-class-name=org.h2.Driver
@@ -7,3 +9,7 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
 
 identity.api-key.encryption.secret=test-external-api-key-encryption-secret-for-ci-only-32chars
+
+identity.passwordReset.webBaseUrl=http://localhost:3000
+identity.passwordReset.tokenValidityHours=1
+identity.passwordReset.mailFrom=test@localhost

--- a/services/identity-service/web/src/app/api/auth/external-keys/[id]/route.test.ts
+++ b/services/identity-service/web/src/app/api/auth/external-keys/[id]/route.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { PUT } from "./route"
+import { DELETE, PUT } from "./route"
 
 const context = { params: Promise.resolve({ id: "123" }) }
 
@@ -19,6 +19,28 @@ function putRequest(body: unknown, cookie?: string) {
 afterEach(() => {
   vi.restoreAllMocks()
   delete process.env.IDENTITY_SERVICE_URL
+})
+
+describe("DELETE /api/auth/external-keys/[id] (route handler)", () => {
+  it("forwards query string to upstream", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe("http://localhost:8080/api/auth/external-keys/123?gracePeriodDays=14")
+      return new Response(JSON.stringify({ success: true, message: "ok", data: null }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const req = new Request("http://localhost/api/auth/external-keys/123?gracePeriodDays=14", {
+      method: "DELETE",
+      headers: { cookie: "access_token=t", Accept: "application/json" },
+    })
+    const res = await DELETE(req, context)
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe("PUT /api/auth/external-keys/[id] (route handler)", () => {

--- a/services/identity-service/web/src/app/api/auth/external-keys/[id]/route.ts
+++ b/services/identity-service/web/src/app/api/auth/external-keys/[id]/route.ts
@@ -118,15 +118,21 @@ export async function DELETE(request: Request, context: RouteContext) {
     return json(400, { success: false, message: "잘못된 키 id입니다", data: null })
   }
 
+  const url = new URL(request.url)
+  const search = url.search
+
   let upstream: Response
   try {
-    upstream = await fetch(`${identityBaseUrl}/api/auth/external-keys/${encodeURIComponent(id)}`, {
-      method: "DELETE",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/json",
+    upstream = await fetch(
+      `${identityBaseUrl}/api/auth/external-keys/${encodeURIComponent(id)}${search}`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
       },
-    })
+    )
   } catch {
     return json(502, { success: false, message: "인증 서비스에 연결할 수 없습니다", data: null })
   }

--- a/services/identity-service/web/src/app/api/auth/forgot-password/route.ts
+++ b/services/identity-service/web/src/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server"
+
+import { forgotPasswordSchema } from "@/lib/api/identity/password-reset.schema"
+import type { ApiResponse } from "@/lib/api/identity/types"
+
+function json<T>(status: number, body: ApiResponse<T>) {
+  return NextResponse.json(body, { status, headers: { "Cache-Control": "no-store" } })
+}
+
+function envIdentityBaseUrl() {
+  const url = process.env.IDENTITY_SERVICE_URL
+  if (!url) return null
+  return url.replace(/\/+$/, "")
+}
+
+export async function POST(request: Request) {
+  const identityBaseUrl = envIdentityBaseUrl()
+  if (!identityBaseUrl) {
+    return json(500, {
+      success: false,
+      message: "서버 설정이 필요합니다 (IDENTITY_SERVICE_URL)",
+      data: null,
+    })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return json(400, { success: false, message: "JSON 형식이 올바르지 않습니다", data: null })
+  }
+
+  const parsed = forgotPasswordSchema.safeParse(payload)
+  if (!parsed.success) {
+    const first = parsed.error.issues[0]
+    return json(400, { success: false, message: first?.message ?? "입력값이 올바르지 않습니다", data: null })
+  }
+
+  let upstream: Response
+  try {
+    upstream = await fetch(`${identityBaseUrl}/api/auth/forgot-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsed.data),
+    })
+  } catch {
+    return json(502, { success: false, message: "인증 서비스에 연결할 수 없습니다", data: null })
+  }
+
+  let upstreamJson: unknown = null
+  try {
+    upstreamJson = await upstream.json()
+  } catch {
+    upstreamJson = null
+  }
+
+  if (upstream.ok) {
+    const body = upstreamJson as ApiResponse<null>
+    if (!body?.success) {
+      return json(502, { success: false, message: "응답 형식이 올바르지 않습니다", data: null })
+    }
+    return json(200, body)
+  }
+
+  const message =
+    typeof upstreamJson === "object" &&
+    upstreamJson !== null &&
+    "message" in upstreamJson &&
+    typeof (upstreamJson as { message?: unknown }).message === "string"
+      ? (upstreamJson as { message: string }).message
+      : "요청 처리에 실패했습니다"
+
+  return json(upstream.status, { success: false, message, data: null })
+}

--- a/services/identity-service/web/src/app/api/auth/reset-password/route.ts
+++ b/services/identity-service/web/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server"
+
+import { resetPasswordSchema } from "@/lib/api/identity/password-reset.schema"
+import type { ApiResponse } from "@/lib/api/identity/types"
+
+function json<T>(status: number, body: ApiResponse<T>) {
+  return NextResponse.json(body, { status, headers: { "Cache-Control": "no-store" } })
+}
+
+function envIdentityBaseUrl() {
+  const url = process.env.IDENTITY_SERVICE_URL
+  if (!url) return null
+  return url.replace(/\/+$/, "")
+}
+
+export async function POST(request: Request) {
+  const identityBaseUrl = envIdentityBaseUrl()
+  if (!identityBaseUrl) {
+    return json(500, {
+      success: false,
+      message: "서버 설정이 필요합니다 (IDENTITY_SERVICE_URL)",
+      data: null,
+    })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return json(400, { success: false, message: "JSON 형식이 올바르지 않습니다", data: null })
+  }
+
+  const parsed = resetPasswordSchema.safeParse(payload)
+  if (!parsed.success) {
+    const first = parsed.error.issues[0]
+    return json(400, { success: false, message: first?.message ?? "입력값이 올바르지 않습니다", data: null })
+  }
+
+  let upstream: Response
+  try {
+    upstream = await fetch(`${identityBaseUrl}/api/auth/reset-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsed.data),
+    })
+  } catch {
+    return json(502, { success: false, message: "인증 서비스에 연결할 수 없습니다", data: null })
+  }
+
+  let upstreamJson: unknown = null
+  try {
+    upstreamJson = await upstream.json()
+  } catch {
+    upstreamJson = null
+  }
+
+  if (upstream.ok) {
+    const body = upstreamJson as ApiResponse<null>
+    if (!body?.success) {
+      return json(502, { success: false, message: "응답 형식이 올바르지 않습니다", data: null })
+    }
+    return json(200, body)
+  }
+
+  const message =
+    typeof upstreamJson === "object" &&
+    upstreamJson !== null &&
+    "message" in upstreamJson &&
+    typeof (upstreamJson as { message?: unknown }).message === "string"
+      ? (upstreamJson as { message: string }).message
+      : "요청 처리에 실패했습니다"
+
+  return json(upstream.status, { success: false, message, data: null })
+}

--- a/services/identity-service/web/src/app/api/auth/signup/route.test.ts
+++ b/services/identity-service/web/src/app/api/auth/signup/route.test.ts
@@ -47,7 +47,6 @@ describe("POST /api/auth/signup (route handler)", () => {
         password: "123",
         passwordConfirm: "123",
         name: "",
-        role: "USER",
       })
     )
     expect(res.status).toBe(400)
@@ -73,7 +72,6 @@ describe("POST /api/auth/signup (route handler)", () => {
       password: validPassword,
       passwordConfirm: validPassword,
       name: "testDemo",
-      role: "USER",
     }
 
     const res = await POST(jsonRequest(body))
@@ -88,7 +86,7 @@ describe("POST /api/auth/signup (route handler)", () => {
       expect.objectContaining({
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
+        body: JSON.stringify({ ...body, role: "USER" }),
       })
     )
   })
@@ -112,7 +110,6 @@ describe("POST /api/auth/signup (route handler)", () => {
         password: validPassword,
         passwordConfirm: validPassword,
         name: "testDemo",
-        role: "USER",
       })
     )
 

--- a/services/identity-service/web/src/app/api/auth/signup/route.ts
+++ b/services/identity-service/web/src/app/api/auth/signup/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: Request) {
     upstream = await fetch(`${identityBaseUrl}/api/auth/signup`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(parsed.data),
+      body: JSON.stringify({ ...parsed.data, role: "USER" }),
     })
   } catch {
     return json(502, { success: false, message: "인증 서비스에 연결할 수 없습니다", data: null })

--- a/services/identity-service/web/src/app/forgot-password/page.tsx
+++ b/services/identity-service/web/src/app/forgot-password/page.tsx
@@ -1,0 +1,9 @@
+import { ForgotPasswordForm } from "@/components/forgot-password/forgot-password-form"
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="flex flex-1 items-center justify-center bg-background px-4 py-16">
+      <ForgotPasswordForm />
+    </div>
+  )
+}

--- a/services/identity-service/web/src/app/reset-password/page.tsx
+++ b/services/identity-service/web/src/app/reset-password/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from "react"
+
+import { ResetPasswordForm } from "@/components/reset-password/reset-password-form"
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="flex flex-1 items-center justify-center bg-background px-4 py-16">
+      <Suspense fallback={<div className="text-sm text-muted-foreground">불러오는 중…</div>}>
+        <ResetPasswordForm />
+      </Suspense>
+    </div>
+  )
+}

--- a/services/identity-service/web/src/components/account/account-settings-view.tsx
+++ b/services/identity-service/web/src/components/account/account-settings-view.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { Eye, EyeOff } from "lucide-react"
 
 import { apiFetch } from "@/lib/api/client-fetch"
 import type {
@@ -59,6 +60,10 @@ function formatBudgetUsd(value: number | null | undefined) {
   }).format(value)
 }
 
+const DEFAULT_DELETION_GRACE_DAYS = 7
+const MIN_DELETION_GRACE_DAYS = 1
+const MAX_DELETION_GRACE_DAYS = 365
+
 function sanitizeBudgetInput(value: string) {
   const normalized = value.replace(/,/g, ".")
   const filtered = normalized.replace(/[^\d.]/g, "")
@@ -96,6 +101,7 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
   const [editAliasValue, setEditAliasValue] = React.useState("")
   const [editMonthlyBudgetUsdInput, setEditMonthlyBudgetUsdInput] = React.useState("")
   const [saveEditLoadingId, setSaveEditLoadingId] = React.useState<number | null>(null)
+  const [revealExternalKey, setRevealExternalKey] = React.useState(false)
 
   const loadExternalKeys = React.useCallback(async (signal?: AbortSignal) => {
     setKeysLoading(true)
@@ -219,6 +225,7 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
         setSubmitMessage({ kind: "success", text: apiResponse.message || "등록되었습니다" })
         setAliasTouched(false)
         setAlias(defaultAlias(provider))
+        setRevealExternalKey(false)
         void loadExternalKeys()
       } else {
         setSubmitMessage({ kind: "error", text: apiResponse?.message || "등록에 실패했습니다" })
@@ -234,13 +241,31 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
 
   async function requestKeyDeletion(id: number) {
     const ok = window.confirm(
-      "이 API 키를 삭제 예약합니다.\n\n일주일 동안 취소할 수 있으며, 일주일이 지나면 DB에서 키가 영구 삭제됩니다. 과거 사용량 로그는 usage 쪽 기록에 남을 수 있습니다."
+      `이 API 키를 삭제 예약합니다.\n\n유예 기간이 지나면 DB에서 키가 영구 삭제됩니다. 유예 중에는 취소할 수 있습니다.\n과거 사용량 로그는 usage 쪽 기록에 남을 수 있습니다.\n\n다음 단계에서 유예 기간(일)을 입력합니다. (기본 ${DEFAULT_DELETION_GRACE_DAYS}일)`,
     )
     if (!ok) return
+    const raw = window.prompt(
+      `유예 기간(일) (${MIN_DELETION_GRACE_DAYS}~${MAX_DELETION_GRACE_DAYS}, 비우면 ${DEFAULT_DELETION_GRACE_DAYS}일)`,
+      String(DEFAULT_DELETION_GRACE_DAYS),
+    )
+    if (raw === null) return
+    const trimmed = raw.trim()
+    let graceDays = DEFAULT_DELETION_GRACE_DAYS
+    if (trimmed !== "") {
+      const n = Number.parseInt(trimmed, 10)
+      if (!Number.isFinite(n) || n < MIN_DELETION_GRACE_DAYS || n > MAX_DELETION_GRACE_DAYS) {
+        setKeysError(
+          `유예 기간은 ${MIN_DELETION_GRACE_DAYS}~${MAX_DELETION_GRACE_DAYS}일 사이의 정수로 입력해 주세요`,
+        )
+        return
+      }
+      graceDays = n
+    }
     setKeyActionId(id)
     try {
+      const q = new URLSearchParams({ gracePeriodDays: String(graceDays) })
       const { response, json } = await apiFetch<unknown>(
-        `/api/auth/external-keys/${id}`,
+        `/api/auth/external-keys/${id}?${q.toString()}`,
         { method: "DELETE", credentials: "include", cache: "no-store", headers: { Accept: "application/json" } },
         { authRequired: true }
       )
@@ -386,7 +411,7 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
           <div className="space-y-1">
             <h2 className="text-sm font-semibold tracking-tight">등록된 외부 API Key</h2>
             <p className="text-sm text-muted-foreground">
-              Provider·별칭·등록일만 표시됩니다. 삭제 예정인 키는 별칭 옆에 표시되며, 일주일 이내 취소할 수 있습니다.
+              Provider·별칭·등록일만 표시됩니다. 삭제 예정인 키는 별칭 옆에 표시되며, 유예 기간 안에 삭제 예약을 취소할 수 있습니다.
             </p>
           </div>
 
@@ -440,8 +465,9 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
                       ) : null}
                     </div>
                     {isPendingDeletion(row) && row.permanentDeletionAt ? (
-                      <p className="text-xs text-muted-foreground">
-                        영구 삭제 예정: {formatDeadline(row.permanentDeletionAt)}까지 취소 가능
+                      <p className="text-xs text-amber-800 dark:text-amber-300">
+                        영구 삭제 예정: {formatDeadline(row.permanentDeletionAt)}
+                        {typeof row.deletionGraceDays === "number" ? ` (${row.deletionGraceDays}일 유예)` : ""}
                       </p>
                     ) : null}
                     {row.monthlyBudgetUsd !== null && row.monthlyBudgetUsd !== undefined ? (
@@ -559,17 +585,28 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
             <label className="text-sm font-medium" htmlFor="external-key-value">
               외부 API Key
             </label>
-            <input
-              id="external-key-value"
-              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-              type="password"
-              value={externalKey}
-              onChange={(e) => setExternalKey(e.target.value)}
-              placeholder="키를 입력하세요"
-              autoComplete="off"
-              disabled={submitLoading}
-              required
-            />
+            <div className="flex gap-1">
+              <input
+                id="external-key-value"
+                className="h-10 min-w-0 flex-1 rounded-md border border-input bg-background px-3 text-sm"
+                type={revealExternalKey ? "text" : "password"}
+                value={externalKey}
+                onChange={(e) => setExternalKey(e.target.value)}
+                placeholder="키를 입력하세요"
+                autoComplete="new-password"
+                disabled={submitLoading}
+                required
+              />
+              <button
+                type="button"
+                className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-input bg-background text-muted-foreground hover:bg-muted disabled:opacity-50"
+                aria-label={revealExternalKey ? "API Key 숨기기" : "API Key 보기"}
+                disabled={submitLoading}
+                onClick={() => setRevealExternalKey((v) => !v)}
+              >
+                {revealExternalKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
           </div>
 
           <div className="grid gap-1.5">

--- a/services/identity-service/web/src/components/forgot-password/forgot-password-form.tsx
+++ b/services/identity-service/web/src/components/forgot-password/forgot-password-form.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import Link from "next/link"
+import * as React from "react"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+
+import { Button, Input, Label } from "@ai-usage/ui"
+import { apiFetch } from "@/lib/api/client-fetch"
+import { forgotPasswordSchema, type ForgotPasswordInput } from "@/lib/api/identity/password-reset.schema"
+import type { ApiResponse } from "@/lib/api/identity/types"
+
+type FormState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "error"; message: string }
+  | { status: "success"; message: string }
+
+export function ForgotPasswordForm() {
+  const [state, setState] = React.useState<FormState>({ status: "idle" })
+
+  const form = useForm<ForgotPasswordInput>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: { email: "" },
+    mode: "onSubmit",
+  })
+
+  async function onSubmit(values: ForgotPasswordInput) {
+    setState({ status: "submitting" })
+
+    let res: Response
+    let json: ApiResponse<null> | null = null
+    try {
+      const result = await apiFetch<null>(
+        "/api/auth/forgot-password",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(values),
+        },
+        { authRequired: false }
+      )
+      res = result.response
+      json = result.json
+    } catch {
+      setState({ status: "error", message: "네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요." })
+      return
+    }
+
+    if (res.ok && json?.success) {
+      setState({ status: "success", message: json.message })
+      return
+    }
+
+    const message = json?.message ?? "요청 처리에 실패했습니다"
+    setState({ status: "error", message })
+  }
+
+  const isSubmitting = state.status === "submitting"
+
+  if (state.status === "success") {
+    return (
+      <div className="w-full max-w-md rounded-xl border bg-card p-6 shadow-sm">
+        <h1 className="text-xl font-semibold tracking-tight">안내</h1>
+        <p className="mt-3 text-sm text-muted-foreground">{state.message}</p>
+        <p className="mt-4 text-sm text-muted-foreground">
+          <Link href="/login" className="font-medium text-foreground underline underline-offset-4">
+            로그인으로 돌아가기
+          </Link>
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="w-full max-w-md rounded-xl border bg-card p-6 shadow-sm">
+      <div className="space-y-1">
+        <h1 className="text-xl font-semibold tracking-tight">비밀번호 찾기</h1>
+        <p className="text-sm text-muted-foreground">
+          가입 시 사용한 이메일을 입력하면 재설정 링크를 보냅니다.
+        </p>
+      </div>
+
+      <form className="mt-6 space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+        <div className="space-y-2">
+          <Label htmlFor="email">이메일</Label>
+          <Input
+            id="email"
+            type="email"
+            autoComplete="email"
+            placeholder="you@example.com"
+            aria-invalid={!!form.formState.errors.email}
+            {...form.register("email")}
+          />
+          {form.formState.errors.email?.message ? (
+            <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
+          ) : null}
+        </div>
+
+        {state.status === "error" ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {state.message}
+          </div>
+        ) : null}
+
+        <Button type="submit" className="w-full" disabled={isSubmitting}>
+          {isSubmitting ? "전송 중..." : "재설정 링크 보내기"}
+        </Button>
+      </form>
+
+      <p className="mt-4 text-sm text-muted-foreground">
+        <Link href="/login" className="font-medium text-foreground underline underline-offset-4">
+          로그인으로 돌아가기
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/services/identity-service/web/src/components/landing/landing-header.tsx
+++ b/services/identity-service/web/src/components/landing/landing-header.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import Link from "next/link"
 
+import { LogoutButton } from "@/components/auth/logout-button"
 import type { ApiResponse, SessionResponse } from "@/lib/api/identity/types"
 import { usageAppHref } from "@/lib/auth/cross-app-navigation"
 
@@ -75,6 +76,10 @@ export function LandingHomeWithSession() {
                 >
                   설정
                 </Link>
+                <LogoutButton
+                  variant="outline"
+                  className="h-9 border-zinc-300 bg-white text-sm text-zinc-900 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-50 dark:hover:bg-zinc-900"
+                />
               </>
             ) : (
               <>

--- a/services/identity-service/web/src/components/login/login-form.tsx
+++ b/services/identity-service/web/src/components/login/login-form.tsx
@@ -100,7 +100,15 @@ export function LoginForm() {
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="password">비밀번호</Label>
+          <div className="flex items-center justify-between gap-2">
+            <Label htmlFor="password">비밀번호</Label>
+            <Link
+              href="/forgot-password"
+              className="text-xs font-medium text-muted-foreground underline underline-offset-4 hover:text-foreground"
+            >
+              비밀번호를 잊으셨나요?
+            </Link>
+          </div>
           <div className="flex gap-1">
             <Input
               id="password"

--- a/services/identity-service/web/src/components/login/login-form.tsx
+++ b/services/identity-service/web/src/components/login/login-form.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
 import * as React from "react"
+import { Eye, EyeOff } from "lucide-react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 
@@ -29,6 +30,7 @@ export function LoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [state, setState] = React.useState<FormState>({ status: "idle" })
+  const [showPassword, setShowPassword] = React.useState(false)
 
   const form = useForm<LoginRequestInput>({
     resolver: zodResolver(loginRequestSchema),
@@ -99,14 +101,26 @@ export function LoginForm() {
 
         <div className="space-y-2">
           <Label htmlFor="password">비밀번호</Label>
-          <Input
-            id="password"
-            type="password"
-            autoComplete="current-password"
-            placeholder="비밀번호를 입력하세요"
-            aria-invalid={!!form.formState.errors.password}
-            {...form.register("password")}
-          />
+          <div className="flex gap-1">
+            <Input
+              id="password"
+              className="min-w-0 flex-1"
+              type={showPassword ? "text" : "password"}
+              autoComplete="current-password"
+              placeholder="비밀번호를 입력하세요"
+              aria-invalid={!!form.formState.errors.password}
+              {...form.register("password")}
+            />
+            <button
+              type="button"
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-input bg-background text-muted-foreground hover:bg-muted disabled:opacity-50"
+              aria-label={showPassword ? "비밀번호 숨기기" : "비밀번호 보기"}
+              disabled={isSubmitting}
+              onClick={() => setShowPassword((v) => !v)}
+            >
+              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
           {form.formState.errors.password?.message ? (
             <p className="text-sm text-destructive">{form.formState.errors.password.message}</p>
           ) : null}

--- a/services/identity-service/web/src/components/reset-password/reset-password-form.tsx
+++ b/services/identity-service/web/src/components/reset-password/reset-password-form.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
+import * as React from "react"
+import { Eye, EyeOff } from "lucide-react"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+
+import { Button, Input, Label } from "@ai-usage/ui"
+import { apiFetch } from "@/lib/api/client-fetch"
+import { resetPasswordSchema, type ResetPasswordInput } from "@/lib/api/identity/password-reset.schema"
+import type { ApiResponse } from "@/lib/api/identity/types"
+
+type FormState = { status: "idle" } | { status: "submitting" } | { status: "error"; message: string }
+
+export function ResetPasswordForm() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const tokenFromUrl = searchParams.get("token")?.trim() ?? ""
+
+  const [state, setState] = React.useState<FormState>({ status: "idle" })
+  const [showPassword, setShowPassword] = React.useState(false)
+  const [showConfirm, setShowConfirm] = React.useState(false)
+
+  const form = useForm<ResetPasswordInput>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: {
+      token: tokenFromUrl,
+      password: "",
+      passwordConfirm: "",
+    },
+    mode: "onSubmit",
+  })
+
+  React.useEffect(() => {
+    form.setValue("token", tokenFromUrl)
+  }, [tokenFromUrl, form])
+
+  async function onSubmit(values: ResetPasswordInput) {
+    setState({ status: "submitting" })
+
+    let res: Response
+    let json: ApiResponse<null> | null = null
+    try {
+      const result = await apiFetch<null>(
+        "/api/auth/reset-password",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(values),
+        },
+        { authRequired: false }
+      )
+      res = result.response
+      json = result.json
+    } catch {
+      setState({ status: "error", message: "네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요." })
+      return
+    }
+
+    if (res.ok && json?.success) {
+      router.replace("/login")
+      return
+    }
+
+    const message = json?.message ?? "비밀번호 재설정에 실패했습니다"
+    setState({ status: "error", message })
+  }
+
+  const isSubmitting = state.status === "submitting"
+
+  if (!tokenFromUrl) {
+    return (
+      <div className="w-full max-w-md rounded-xl border bg-card p-6 shadow-sm">
+        <h1 className="text-xl font-semibold tracking-tight">링크가 올바르지 않습니다</h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          이메일로 받은 재설정 링크로 다시 접속하거나, 비밀번호 찾기를 다시 요청해 주세요.
+        </p>
+        <p className="mt-4 text-sm">
+          <Link href="/forgot-password" className="font-medium text-foreground underline underline-offset-4">
+            비밀번호 찾기
+          </Link>
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="w-full max-w-md rounded-xl border bg-card p-6 shadow-sm">
+      <div className="space-y-1">
+        <h1 className="text-xl font-semibold tracking-tight">새 비밀번호 설정</h1>
+        <p className="text-sm text-muted-foreground">회원가입과 동일한 비밀번호 규칙이 적용됩니다.</p>
+      </div>
+
+      <form className="mt-6 space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+        <input type="hidden" {...form.register("token")} />
+
+        <div className="space-y-2">
+          <Label htmlFor="password">새 비밀번호</Label>
+          <div className="flex gap-1">
+            <Input
+              id="password"
+              className="min-w-0 flex-1"
+              type={showPassword ? "text" : "password"}
+              autoComplete="new-password"
+              placeholder="새 비밀번호"
+              aria-invalid={!!form.formState.errors.password}
+              {...form.register("password")}
+            />
+            <button
+              type="button"
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-input bg-background text-muted-foreground hover:bg-muted disabled:opacity-50"
+              aria-label={showPassword ? "비밀번호 숨기기" : "비밀번호 보기"}
+              disabled={isSubmitting}
+              onClick={() => setShowPassword((v) => !v)}
+            >
+              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+          {form.formState.errors.password?.message ? (
+            <p className="text-sm text-destructive">{form.formState.errors.password.message}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="passwordConfirm">새 비밀번호 확인</Label>
+          <div className="flex gap-1">
+            <Input
+              id="passwordConfirm"
+              className="min-w-0 flex-1"
+              type={showConfirm ? "text" : "password"}
+              autoComplete="new-password"
+              placeholder="비밀번호 확인"
+              aria-invalid={!!form.formState.errors.passwordConfirm}
+              {...form.register("passwordConfirm")}
+            />
+            <button
+              type="button"
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-input bg-background text-muted-foreground hover:bg-muted disabled:opacity-50"
+              aria-label={showConfirm ? "비밀번호 확인 숨기기" : "비밀번호 확인 보기"}
+              disabled={isSubmitting}
+              onClick={() => setShowConfirm((v) => !v)}
+            >
+              {showConfirm ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+          {form.formState.errors.passwordConfirm?.message ? (
+            <p className="text-sm text-destructive">{form.formState.errors.passwordConfirm.message}</p>
+          ) : null}
+        </div>
+
+        {state.status === "error" ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {state.message}
+          </div>
+        ) : null}
+
+        <Button type="submit" className="w-full" disabled={isSubmitting}>
+          {isSubmitting ? "저장 중..." : "비밀번호 변경"}
+        </Button>
+      </form>
+
+      <p className="mt-4 text-sm text-muted-foreground">
+        <Link href="/login" className="font-medium text-foreground underline underline-offset-4">
+          로그인으로 돌아가기
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/services/identity-service/web/src/components/signup/signup-form.tsx
+++ b/services/identity-service/web/src/components/signup/signup-form.tsx
@@ -3,19 +3,11 @@
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import * as React from "react"
+import { Eye, EyeOff } from "lucide-react"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useForm, Controller } from "react-hook-form"
+import { useForm } from "react-hook-form"
 
-import {
-  Button,
-  Input,
-  Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@ai-usage/ui"
+import { Button, Input, Label } from "@ai-usage/ui"
 import { apiFetch } from "@/lib/api/client-fetch"
 import {
   signupPasswordPolicyMessage,
@@ -36,6 +28,8 @@ function safeMessage(err: unknown, fallback: string) {
 export function SignupForm() {
   const router = useRouter()
   const [state, setState] = React.useState<FormState>({ status: "idle" })
+  const [showPassword, setShowPassword] = React.useState(false)
+  const [showPasswordConfirm, setShowPasswordConfirm] = React.useState(false)
 
   const form = useForm<SignupRequestInput>({
     resolver: zodResolver(signupRequestSchema),
@@ -44,7 +38,6 @@ export function SignupForm() {
       password: "",
       passwordConfirm: "",
       name: "",
-      role: "USER",
     },
     mode: "onSubmit",
   })
@@ -115,14 +108,26 @@ export function SignupForm() {
 
         <div className="space-y-2">
           <Label htmlFor="password">비밀번호</Label>
-          <Input
-            id="password"
-            type="password"
-            autoComplete="new-password"
-            placeholder="예: abc123!@"
-            aria-invalid={!!form.formState.errors.password}
-            {...form.register("password")}
-          />
+          <div className="flex gap-1">
+            <Input
+              id="password"
+              className="min-w-0 flex-1"
+              type={showPassword ? "text" : "password"}
+              autoComplete="new-password"
+              placeholder="예: abc123!@"
+              aria-invalid={!!form.formState.errors.password}
+              {...form.register("password")}
+            />
+            <button
+              type="button"
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-input bg-background text-muted-foreground hover:bg-muted disabled:opacity-50"
+              aria-label={showPassword ? "비밀번호 숨기기" : "비밀번호 보기"}
+              disabled={isSubmitting}
+              onClick={() => setShowPassword((v) => !v)}
+            >
+              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
           {form.formState.errors.password?.message ? (
             <p className="text-sm text-destructive">
               {form.formState.errors.password.message}
@@ -134,14 +139,26 @@ export function SignupForm() {
 
         <div className="space-y-2">
           <Label htmlFor="passwordConfirm">비밀번호 확인</Label>
-          <Input
-            id="passwordConfirm"
-            type="password"
-            autoComplete="new-password"
-            placeholder="비밀번호를 다시 입력하세요"
-            aria-invalid={!!form.formState.errors.passwordConfirm}
-            {...form.register("passwordConfirm")}
-          />
+          <div className="flex gap-1">
+            <Input
+              id="passwordConfirm"
+              className="min-w-0 flex-1"
+              type={showPasswordConfirm ? "text" : "password"}
+              autoComplete="new-password"
+              placeholder="비밀번호를 다시 입력하세요"
+              aria-invalid={!!form.formState.errors.passwordConfirm}
+              {...form.register("passwordConfirm")}
+            />
+            <button
+              type="button"
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-input bg-background text-muted-foreground hover:bg-muted disabled:opacity-50"
+              aria-label={showPasswordConfirm ? "비밀번호 확인 숨기기" : "비밀번호 확인 보기"}
+              disabled={isSubmitting}
+              onClick={() => setShowPasswordConfirm((v) => !v)}
+            >
+              {showPasswordConfirm ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
           {form.formState.errors.passwordConfirm?.message ? (
             <p className="text-sm text-destructive">
               {form.formState.errors.passwordConfirm.message}
@@ -162,30 +179,6 @@ export function SignupForm() {
           {form.formState.errors.name?.message ? (
             <p className="text-sm text-destructive">{form.formState.errors.name.message}</p>
           ) : null}
-        </div>
-
-        <div className="space-y-2">
-          <Label>역할</Label>
-          <Controller
-            control={form.control}
-            name="role"
-            render={({ field }) => (
-              <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder="역할 선택" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="USER">USER</SelectItem>
-                  <SelectItem value="ADMIN">ADMIN</SelectItem>
-                </SelectContent>
-              </Select>
-            )}
-          />
-          {form.formState.errors.role?.message ? (
-            <p className="text-sm text-destructive">{form.formState.errors.role.message}</p>
-          ) : (
-            <p className="text-xs text-muted-foreground">기본값은 USER 입니다.</p>
-          )}
         </div>
 
         {state.status === "error" ? (

--- a/services/identity-service/web/src/lib/api/identity/password-reset.schema.test.ts
+++ b/services/identity-service/web/src/lib/api/identity/password-reset.schema.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { forgotPasswordSchema, resetPasswordSchema } from "./password-reset.schema"
+
+describe("forgotPasswordSchema", () => {
+  it("accepts a valid email", () => {
+    const parsed = forgotPasswordSchema.safeParse({ email: "u@example.com" })
+    expect(parsed.success).toBe(true)
+  })
+})
+
+describe("resetPasswordSchema", () => {
+  it("accepts matching passwords", () => {
+    const parsed = resetPasswordSchema.safeParse({
+      token: "a".repeat(64),
+      password: "abc123!@",
+      passwordConfirm: "abc123!@",
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it("rejects mismatched passwords", () => {
+    const parsed = resetPasswordSchema.safeParse({
+      token: "a".repeat(64),
+      password: "abc123!@",
+      passwordConfirm: "abc123!@x",
+    })
+    expect(parsed.success).toBe(false)
+  })
+})

--- a/services/identity-service/web/src/lib/api/identity/password-reset.schema.ts
+++ b/services/identity-service/web/src/lib/api/identity/password-reset.schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+import { SIGNUP_PASSWORD_REGEX, signupPasswordPolicyMessage } from "@/lib/api/identity/signup.schema"
+
+export const forgotPasswordSchema = z.object({
+  email: z.string().email("이메일 형식이 올바르지 않습니다"),
+})
+
+export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>
+
+export const resetPasswordSchema = z
+  .object({
+    token: z.string().min(1, "재설정 토큰이 없습니다").max(512),
+    password: z.string().regex(SIGNUP_PASSWORD_REGEX, signupPasswordPolicyMessage),
+    passwordConfirm: z.string().min(1, "비밀번호 확인을 입력해주세요"),
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    message: "비밀번호가 일치하지 않습니다",
+    path: ["passwordConfirm"],
+  })
+
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>

--- a/services/identity-service/web/src/lib/api/identity/signup.schema.test.ts
+++ b/services/identity-service/web/src/lib/api/identity/signup.schema.test.ts
@@ -7,7 +7,6 @@ const validBase = {
   password: "abc123!@",
   passwordConfirm: "abc123!@",
   name: "testDemo",
-  role: "USER" as const,
 }
 
 describe("signupRequestSchema", () => {

--- a/services/identity-service/web/src/lib/api/identity/signup.schema.ts
+++ b/services/identity-service/web/src/lib/api/identity/signup.schema.ts
@@ -1,7 +1,5 @@
 import { z } from "zod"
 
-export const roleSchema = z.enum(["USER", "ADMIN"])
-
 /** Identity `SignupRequest` `@Pattern` 메시지와 동일 (services/identity-service) */
 export const signupPasswordPolicyMessage =
   "비밀번호는 소문자/숫자/특수문자를 각각 1개 이상 포함하고 대문자 없이 8~100자여야 합니다"
@@ -16,7 +14,6 @@ export const signupRequestSchema = z
     password: z.string().regex(SIGNUP_PASSWORD_REGEX, signupPasswordPolicyMessage),
     passwordConfirm: z.string().min(1, "비밀번호 확인을 입력해주세요"),
     name: z.string().min(1, "이름은 필수입니다").max(100, "이름은 100자 이하여야 합니다"),
-    role: roleSchema,
   })
   .refine((data) => data.password === data.passwordConfirm, {
     message: "비밀번호가 일치하지 않습니다",

--- a/services/identity-service/web/src/lib/api/identity/signup.schema.ts
+++ b/services/identity-service/web/src/lib/api/identity/signup.schema.ts
@@ -5,7 +5,7 @@ export const signupPasswordPolicyMessage =
   "비밀번호는 소문자/숫자/특수문자를 각각 1개 이상 포함하고 대문자 없이 8~100자여야 합니다"
 
 /** 백엔드 `SignupRequest` 정규식과 동일 */
-const SIGNUP_PASSWORD_REGEX =
+export const SIGNUP_PASSWORD_REGEX =
   /^(?=.*[a-z])(?=.*\d)(?=.*[^a-zA-Z0-9])(?=\S+$)[^A-Z]{8,100}$/
 
 export const signupRequestSchema = z

--- a/services/identity-service/web/src/lib/api/identity/types.ts
+++ b/services/identity-service/web/src/lib/api/identity/types.ts
@@ -6,12 +6,12 @@ export type ApiResponse<T> = {
 
 export type Role = "USER" | "ADMIN"
 
+/** 브라우저→BFF `POST /api/auth/signup` 본문. `role`은 BFF가 `USER`로 고정해 Identity에 전달한다. */
 export type SignupRequest = {
   email: string
   password: string
   passwordConfirm: string
   name: string
-  role: Role
 }
 
 export type SignupResponse = {

--- a/services/identity-service/web/src/lib/api/identity/types.ts
+++ b/services/identity-service/web/src/lib/api/identity/types.ts
@@ -68,6 +68,8 @@ export type ExternalKeySummary = {
   deletionRequestedAt?: string | null
   /** ISO-8601, 영구 삭제 예정 시각(유예 종료) */
   permanentDeletionAt?: string | null
+  /** 삭제 요청 시 선택한 유예 기간(일), 삭제 예정일 때만 */
+  deletionGraceDays?: number | null
 }
 
 /** Identity `GET /api/auth/external-keys`의 `data` 본문과 동기화 */


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> 없음 (추후 이슈 번호 연결 예정)

## 작업 내용
- **해당 서비스**: Identity (Backend / Web BFF)
> 1) 외부 API 키 삭제 시 고정되어 있던 7일의 유예 기간을 사용자가 직접 설정(1~365일)할 수 있도록 기능을 확장하고, 2) 사용자 편의성(비밀번호 보기 토글 추가, 회원가입 Role 강제 고정)을 개선했습니다. 3) 추가로 **이메일 기반의 비밀번호 찾기 및 재설정 기능**을 완벽하게 구현하여 보안과 사용성을 강화했습니다. 관련 API 및 BFF 계약 문서도 모두 최신화했습니다.

## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`) - DB 컬럼, 토큰 테이블, SMTP 설정 및 API 문서 업데이트

## 📝 상세 내용
### 1. 외부 API 키 삭제 유예 기간 동적 설정 (Backend & BFF)
- `DELETE /api/auth/external-keys/{id}` 호출 시 `gracePeriodDays` 쿼리를 받아 유예 기간을 1~365일 사이로 설정하도록 기능 추가 (생략 시 기본 7일).
- `ExternalApiKeyEntity`에 `deletion_grace_days` 컬럼 추가 및 응답 DTO(`deletionGraceDays`) 반영.
- 프론트엔드(`account-settings-view.tsx`)에서 키 삭제 예약 시 `window.prompt`를 통해 사용자에게 직접 유예 기간을 입력받도록 흐름 수정.
- 삭제 예정 키와 중복 등록을 시도할 경우 예외 메시지를 명확히 분리 ("삭제예정키와 중복된 키").

### 2. 회원가입 Role 선택 제거 및 BFF 강제 고정
- 프론트엔드 회원가입 폼(`signup-form.tsx`) 및 스키마에서 `role` 입력 필드 완전 제거.
- BFF(`signup/route.ts`)에서 업스트림(백엔드)으로 요청을 넘길 때 무조건 `role: "USER"`를 하드코딩하여 병합 전송하도록 정책 변경.

### 3. UI/UX 개선 (비밀번호 가시성 토글)
- 로그인(`login-form.tsx`), 회원가입(`signup-form.tsx`), 외부 API 키 등록란 등 보안 텍스트가 들어가는 모든 Input에 비밀번호 숨기기/보기(Eye 아이콘) 토글 기능 추가.

### 4. 비밀번호 찾기 및 재설정 기능 추가 (보안 강화)
- **보안 설계**: `/forgot-password` 호출 시 이메일 열거 공격(Enumeration Attack)을 방지하기 위해 계정 존재 여부와 무관하게 항상 동일한 안내 메시지를 반환하도록 처리.
- **메일 발송 연동**: Spring Boot `JavaMailSender`를 도입하여 SMTP 메일 발송 로직 구현 (설정 누락 시 INFO 로그로 대체 발송 처리).
- **토큰 관리**: 비밀번호 재설정 토큰(`password_reset_tokens`)은 탈취를 대비해 DB에 평문이 아닌 SHA-256 해시값으로만 저장하며, 1회용 및 만료 시간을 엄격히 적용.
- 프론트엔드 로그인 폼에 '비밀번호를 잊으셨나요?' 링크 추가 및 `/reset-password` 페이지 라우팅 적용.

### 5. API / BFF 계약 문서 최신화
- `identity-auth-api-contract.md` (v1.6), `web-identity-bff.md` (v1.20), `web-split-boundary.md` 등 변경된 API 스펙과 응답 모델, 에러 코드에 맞게 문서 동기화 완료.

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [x] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부 (ExternalApiKey `deletion_grace_days` 컬럼 및 `password_reset_tokens` 테이블 추가)
- [x] **기타 (SMTP)**: 메일 발송을 위한 `spring.mail.*` 관련 환경변수 설정 추가

## 📸 스크린샷 / 테스트 결과 (선택)
- (필요시 프론트엔드의 비밀번호 토글 UI, 삭제 유예기간 입력 prompt, 비밀번호 찾기 폼 화면 등을 캡처해서 첨부해 주세요.)

## 리뷰 요구사항 
- `ExternalApiKeyEntity` 필드 추가 및 `password_reset_tokens` 엔티티가 새롭게 생성되었으므로 DB 스키마 업데이트가 잘 반영되는지 확인 부탁드립니다.
- 로컬에서 실제 이메일 수신을 테스트하시려면 `.env`에 `SPRING_MAIL_HOST` 등 SMTP 설정을 추가한 뒤 진행해 주시면 됩니다. (설정이 없으면 백엔드 터미널 INFO 로그에 링크가 찍힙니다!)
- 프론트엔드 쪽 로그인/회원가입/설정 화면의 '비밀번호 보기 토글' UI가 기존 컴포넌트와 잘 어울리는지 리뷰 부탁드립니다.