### PR TITLE
Feat: add user monthly budget endpoint for billing

### DIFF
--- a/docs/billing-identity-budget.md
+++ b/docs/billing-identity-budget.md
@@ -6,7 +6,7 @@
 
 - `BILLING_IDENTITY_ENABLED` — `true`로 켠다.
 - `BILLING_IDENTITY_BASE_URL` — identity HTTP 베이스 (예: `http://localhost:8090`).
-- `BILLING_IDENTITY_BUDGET_PATH` — Spring 설정 `billing.identity.budget-path-template`에 매핑된다. `{userId}` 플레이스홀더를 쓸 수 있다. 예: `/api/v1/users/{userId}/budget`.
+- `BILLING_IDENTITY_BUDGET_PATH` — Spring 설정 `billing.identity.budget-path-template`에 매핑된다. `{userId}` 플레이스홀더를 쓸 수 있다. 예: `/api/identity/v1/users/{userId}/budget`.
 
 ## 응답 JSON
 

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/SecurityConfig.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
 						.requestMatchers("/api/auth/reset-password").permitAll()
 						.requestMatchers("/api/auth/login").permitAll()
 						.requestMatchers("/api/auth/logout").permitAll()
+						.requestMatchers("/api/identity/v1/users/**").permitAll()
 						.requestMatchers("/internal/api-keys/**").permitAll()
 						.requestMatchers("/internal/users/**").permitAll()
 						.requestMatchers("/error").permitAll()

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/IdentityBudgetController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/IdentityBudgetController.java
@@ -1,0 +1,33 @@
+package com.zerobugfreinds.identity_service.controller;
+
+import com.zerobugfreinds.identity_service.service.ExternalApiKeyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/identity/v1/users")
+public class IdentityBudgetController {
+
+	private final ExternalApiKeyService externalApiKeyService;
+
+	public IdentityBudgetController(ExternalApiKeyService externalApiKeyService) {
+		this.externalApiKeyService = externalApiKeyService;
+	}
+
+	@GetMapping("/{userId}/budget")
+	public ResponseEntity<BudgetResponse> getUserMonthlyBudget(@PathVariable("userId") Long userId) {
+		Optional<BigDecimal> monthlyBudgetUsd = externalApiKeyService.resolveUserMonthlyBudgetUsd(userId);
+		return monthlyBudgetUsd
+				.map(value -> ResponseEntity.ok(new BudgetResponse(value)))
+				.orElseGet(() -> ResponseEntity.notFound().build());
+	}
+
+	public record BudgetResponse(BigDecimal monthlyBudgetUsd) {
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
@@ -3,6 +3,8 @@ package com.zerobugfreinds.identity_service.repository;
 import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
 import com.zerobugfreinds.identity_service.entity.ExternalApiKeyEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.List;
@@ -44,12 +46,22 @@ public interface ExternalApiKeyRepository extends JpaRepository<ExternalApiKeyEn
 
 	long countByUserId(Long userId);
 
+	long countByUserIdAndDeletionRequestedAtIsNull(Long userId);
+
 	List<ExternalApiKeyEntity> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 
 	Optional<ExternalApiKeyEntity> findTopByUserIdAndProviderAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(
 			Long userId,
 			ExternalApiKeyProvider provider
 	);
+
+	@Query("""
+			select coalesce(sum(e.monthlyBudgetUsd), 0)
+			from ExternalApiKeyEntity e
+			where e.userId = :userId
+			  and e.deletionRequestedAt is null
+			""")
+	java.math.BigDecimal sumMonthlyBudgetUsdByUserIdAndDeletionRequestedAtIsNull(@Param("userId") Long userId);
 
 	Optional<ExternalApiKeyEntity> findByIdAndUserId(Long id, Long userId);
 

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
@@ -208,6 +208,19 @@ public class ExternalApiKeyService {
 		return new InternalApiKeyResponse(plainKey, String.valueOf(entity.getId()));
 	}
 
+	@Transactional(readOnly = true)
+	public Optional<BigDecimal> resolveUserMonthlyBudgetUsd(Long userId) {
+		if (userId == null) {
+			throw new IllegalArgumentException("userId는 필수입니다");
+		}
+		long activeKeyCount = externalApiKeyRepository.countByUserIdAndDeletionRequestedAtIsNull(userId);
+		if (activeKeyCount == 0) {
+			return Optional.empty();
+		}
+		BigDecimal totalBudget = externalApiKeyRepository.sumMonthlyBudgetUsdByUserIdAndDeletionRequestedAtIsNull(userId);
+		return Optional.ofNullable(totalBudget);
+	}
+
 	/**
 	 * 삭제 요청: 유예 기간 후 {@link #purgeExpiredKeys()} 가 행을 제거한다.
 	 */


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호 (이슈 번호가 있다면 기입해 주세요)

## 작업 내용
- **해당 서비스**: Identity / Billing
> Billing UI의 예산 바(Budget Bar) 렌더링을 위해, Identity 서비스에 유저 단위의 월 예산(`monthlyBudgetUsd`)을 조회하는 API를 추가하고 Billing 서비스와의 HTTP 연동을 위한 환경설정을 추가했습니다. 

## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- **Identity 서비스: 유저 단위 월 예산 조회 API 신규 스펙 제안**
  - **Endpoint**: `GET /api/identity/v1/users/{userId}/budget` (팀 컨벤션에 맞게 조정 가능)
  - **Response**: `{ "monthlyBudgetUsd": 123.45 }`
  - 활성화된 API 키 예산이 없을 경우 `404 Not Found` 반환 (Billing 쪽의 기존 "예산 없음" Fallback 로직과 연동)
  - 내부 호출을 위한 서비스 간 인증 방식(게이트웨이/세션/토큰 등) 적용.
  - 💡 **정책 논의 필요**: 현재 DB는 API 키 단위 필드로 구성되어 있어, `monthlyBudgetUsd`를 "유저 단위 예산"으로 할지 "키 단위 예산의 합산"으로 할지 정책 결정이 필요합니다.

- **Billing 서비스: Identity 연동 환경 설정 (Cursor 적용용)**
  - 아래 설정을 Cursor에 넣어주시면 바로 예산 바가 렌더링됩니다.
    - `BILLING_IDENTITY_ENABLED=true`
    - `BILLING_IDENTITY_BASE_URL=http://<identity-host>:<port>`
    - `BILLING_IDENTITY_BUDGET_PATH=/api/identity/v1/users/{userId}/budget`

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [x] **DB**: 기존 키 단위 예산을 합산하는 등 쿼리 로직 확인/변경 필요
- [x] **기타**: MSA 환경 내 Identity - Billing 간 HTTP 통신 연동

## 📸 스크린샷 / 테스트 결과 (선택)
- (예산 바가 정상적으로 노출되는 UI 스크린샷 첨부)

## 리뷰 요구사항 
> 
- Billing 쪽에서 DB 직접 접근 없이 HTTP 연동으로 예산을 확인할 수 있도록 **월 예산 전용 API 발행을 요청**드립니다. 
- Endpoint와 404 응답 스펙 확인 부탁드리며, `monthlyBudgetUsd`를 조회할 때 유저 단위로 갈지 기존 키 단위 필드를 합산해서 줄지 **정책 결정**이 필요합니다.
- 기재된 Billing 쪽 환경변수 설정값을 Cursor에 넣어서 적용해 주시면 예산 바가 정상적으로 작동할 것입니다!