### PR TITLE
Fix/team detail

### DIFF
--- a/apps/web/src/components/host-shell-layout.tsx
+++ b/apps/web/src/components/host-shell-layout.tsx
@@ -1,36 +1,16 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { ConsoleLayoutOverride, ConsoleSidebar } from "@ai-usage/shell";
 
 export function HostShellLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-screen w-full min-w-0 bg-background">
-      <div className="flex h-full min-h-0 w-64 min-w-[240px] max-w-[280px] shrink-0 flex-col">
-        <aside className="flex h-full min-h-0 w-full flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
-          <div className="border-b border-sidebar-border px-4 py-4">
-            <p className="text-xs font-medium uppercase tracking-wide text-sidebar-foreground/60">콘솔</p>
-            <p className="mt-1 text-sm font-semibold leading-tight tracking-tight text-sidebar-foreground">
-              사용량 모니터
-            </p>
-          </div>
-          <nav className="flex flex-1 flex-col gap-1 px-3 py-3" aria-label="앱 메뉴">
-            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-            <a href="/" className="block rounded-md px-3 py-2.5 text-sm font-medium hover:bg-sidebar-accent/60">
-              홈(/)
-            </a>
-            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-            <a href="/team" className="block rounded-md px-3 py-2.5 text-sm font-medium hover:bg-sidebar-accent/60">
-              팀(/team)
-            </a>
-          </nav>
-          <div className="mt-auto border-t border-sidebar-border px-3 py-4">
-            <p className="text-xs text-muted-foreground">web-host · module federation</p>
-          </div>
-        </aside>
-      </div>
-      <main className="flex min-h-screen min-w-0 flex-1 flex-col overflow-x-auto overflow-y-auto">
-        <div className="mx-auto min-h-full w-full max-w-6xl flex-1 px-4 py-6 sm:px-6 lg:px-8">{children}</div>
-      </main>
-    </div>
+    <ConsoleLayoutOverride
+      primarySidebar={
+        <ConsoleSidebar profile="team" />
+      }
+    >
+      {children}
+    </ConsoleLayoutOverride>
   );
 }

--- a/apps/web/src/components/team-page-content.tsx
+++ b/apps/web/src/components/team-page-content.tsx
@@ -7,38 +7,13 @@ const TeamManagement = dynamic(() => import("team/TeamManagement"), {
   ssr: false,
   loading: () => <p className="text-sm text-muted-foreground">Team remote loading...</p>,
 });
-const TeamUsageDashboard = dynamic(() => import("usage/TeamUsageDashboard"), {
-  ssr: false,
-  loading: () => <p className="text-sm text-muted-foreground">Usage remote loading...</p>,
-});
 
 export function TeamPageContent() {
   return (
-    <div className="flex h-full w-full gap-4 p-4">
-      <div className="flex w-1/4 min-w-[240px] flex-col gap-4">
-        <section className="flex-1 overflow-y-auto rounded-lg border border-border bg-card p-4">
-          <RemoteErrorBoundary
-            fallback={<p className="text-sm text-muted-foreground">Team remote를 불러오지 못했습니다.</p>}
-          >
-            <TeamManagement />
-          </RemoteErrorBoundary>
-        </section>
-      </div>
-
-      <div className="flex w-3/4 min-w-0 flex-col gap-4">
-        <section className="h-fit rounded-lg border border-border bg-card p-4">
-          <p className="text-sm text-muted-foreground">
-            TeamInfo 영역은 현재 team-service 단일 컴포넌트(TeamManagement)에 포함되어 있습니다.
-          </p>
-        </section>
-        <section className="flex-1 rounded-lg border border-border bg-card p-4">
-          <RemoteErrorBoundary
-            fallback={<p className="text-sm text-muted-foreground">Usage remote를 불러오지 못했습니다.</p>}
-          >
-            <TeamUsageDashboard />
-          </RemoteErrorBoundary>
-        </section>
-      </div>
-    </div>
+    <RemoteErrorBoundary
+      fallback={<p className="p-4 text-sm text-muted-foreground">Team remote를 불러오지 못했습니다.</p>}
+    >
+      <TeamManagement />
+    </RemoteErrorBoundary>
   );
 }

--- a/packages/shell/src/console-layout-override.tsx
+++ b/packages/shell/src/console-layout-override.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react"
+
+type ConsoleLayoutOverrideProps = {
+  primarySidebar: ReactNode
+  secondarySidebar?: ReactNode
+  children: ReactNode
+  rootClassName?: string
+  mainClassName?: string
+  contentClassName?: string
+}
+
+/**
+ * MFE 페이지별 레이아웃을 독립적으로 구성하기 위한 공용 뼈대.
+ * - primarySidebar: 글로벌(최좌측) 내비 영역
+ * - secondarySidebar: 페이지 전용 보조 사이드바(선택)
+ * - children: 메인 콘텐츠
+ */
+export function ConsoleLayoutOverride({
+  primarySidebar,
+  secondarySidebar,
+  children,
+  rootClassName = "flex min-h-screen w-full min-w-0 bg-background",
+  mainClassName = "flex min-h-screen min-w-0 flex-1 flex-col overflow-x-auto overflow-y-auto",
+  contentClassName = "mx-auto min-h-full w-full max-w-6xl flex-1 px-4 py-6 sm:px-6 lg:px-8",
+}: ConsoleLayoutOverrideProps) {
+  return (
+    <div className={rootClassName}>
+      {primarySidebar}
+      {secondarySidebar}
+      <main className={mainClassName}>
+        <div className={contentClassName}>{children}</div>
+      </main>
+    </div>
+  )
+}

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -20,6 +20,7 @@ export {
   type ConsoleShellProps,
   resolveIdentityLogoutPathsFromEnv,
 } from "./console-shell"
+export { ConsoleLayoutOverride } from "./console-layout-override"
 
 /** Alias for billing layouts (same layout as `ConsoleShell`). */
 export { ConsoleShell as BillingConsoleShell } from "./console-shell"

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/InternalUserController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/InternalUserController.java
@@ -1,12 +1,19 @@
 package com.zerobugfreinds.identity_service.controller;
 
 import com.zerobugfreinds.identity_service.common.ApiResponse;
+import com.zerobugfreinds.identity_service.dto.InternalUserIdsExistenceRequest;
+import com.zerobugfreinds.identity_service.dto.InternalUserIdsExistenceResponse;
 import com.zerobugfreinds.identity_service.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/internal/users")
@@ -21,5 +28,15 @@ public class InternalUserController {
     public ResponseEntity<ApiResponse<Boolean>> existsByEmail(@RequestParam("email") String email) {
         boolean exists = userService.existsByEmail(email);
         return ResponseEntity.ok(ApiResponse.ok("사용자 존재 여부 조회에 성공했습니다", exists));
+    }
+
+    @PostMapping("/exists/user-ids")
+    public ResponseEntity<ApiResponse<InternalUserIdsExistenceResponse>> existsByUserIds(
+            @RequestBody(required = false) InternalUserIdsExistenceRequest request
+    ) {
+        List<String> userIds = request == null || request.userIds() == null ? List.of() : request.userIds();
+        Set<String> existingUserIds = userService.findExistingUserIds(userIds);
+        InternalUserIdsExistenceResponse response = new InternalUserIdsExistenceResponse(existingUserIds.stream().toList());
+        return ResponseEntity.ok(ApiResponse.ok("사용자 ID 존재 여부 조회에 성공했습니다", response));
     }
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/InternalUserIdsExistenceRequest.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/InternalUserIdsExistenceRequest.java
@@ -1,0 +1,8 @@
+package com.zerobugfreinds.identity_service.dto;
+
+import java.util.List;
+
+public record InternalUserIdsExistenceRequest(
+		List<String> userIds
+) {
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/InternalUserIdsExistenceResponse.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/InternalUserIdsExistenceResponse.java
@@ -1,0 +1,8 @@
+package com.zerobugfreinds.identity_service.dto;
+
+import java.util.List;
+
+public record InternalUserIdsExistenceResponse(
+		List<String> existingUserIds
+) {
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/UserService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/UserService.java
@@ -14,6 +14,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 /**
  * 사용자 도메인 유스케이스.
  */
@@ -83,5 +87,29 @@ public class UserService {
 			return false;
 		}
 		return userRepository.existsByEmail(email.trim());
+	}
+
+	@Transactional(readOnly = true)
+	public Set<String> findExistingUserIds(List<String> rawUserIds) {
+		if (rawUserIds == null || rawUserIds.isEmpty()) {
+			return Set.of();
+		}
+		Set<Long> numericUserIds = new LinkedHashSet<>();
+		for (String rawUserId : rawUserIds) {
+			if (rawUserId == null || rawUserId.isBlank()) {
+				continue;
+			}
+			try {
+				numericUserIds.add(Long.parseLong(rawUserId.trim()));
+			} catch (NumberFormatException ignored) {
+				// team-service userId 는 문자열이므로 숫자 변환 실패 값은 미존재 사용자로 취급한다.
+			}
+		}
+		if (numericUserIds.isEmpty()) {
+			return Set.of();
+		}
+		return userRepository.findAllById(numericUserIds).stream()
+				.map(user -> String.valueOf(user.getId()))
+				.collect(LinkedHashSet::new, Set::add, Set::addAll);
 	}
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/config/SecurityConfig.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
 				.exceptionHandling(exception -> exception.authenticationEntryPoint(restAuthenticationEntryPoint))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers("/internal/teams/**").permitAll()
+						.requestMatchers("/internal/admin/**").permitAll()
 						.requestMatchers("/error").permitAll()
 						.anyRequest().authenticated()
 				)

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/InternalTeamAdminController.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/InternalTeamAdminController.java
@@ -1,0 +1,25 @@
+package com.zerobugfreinds.team_service.controller;
+
+import com.zerobugfreinds.team_service.common.ApiResponse;
+import com.zerobugfreinds.team_service.dto.TeamIdentityConsistencyResponse;
+import com.zerobugfreinds.team_service.service.TeamIdentityConsistencyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/admin")
+public class InternalTeamAdminController {
+	private final TeamIdentityConsistencyService teamIdentityConsistencyService;
+
+	public InternalTeamAdminController(TeamIdentityConsistencyService teamIdentityConsistencyService) {
+		this.teamIdentityConsistencyService = teamIdentityConsistencyService;
+	}
+
+	@GetMapping("/consistency/identity-users")
+	public ResponseEntity<ApiResponse<TeamIdentityConsistencyResponse>> getIdentityConsistency() {
+		TeamIdentityConsistencyResponse response = teamIdentityConsistencyService.findZombieUsers();
+		return ResponseEntity.ok(ApiResponse.ok("Identity-Team 데이터 정합성 점검이 완료되었습니다", response));
+	}
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/TeamController.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/TeamController.java
@@ -7,12 +7,16 @@ import com.zerobugfreinds.team_service.dto.RegisterTeamApiKeyRequest;
 import com.zerobugfreinds.team_service.dto.TeamApiKeySummaryResponse;
 import com.zerobugfreinds.team_service.dto.TeamInvitationActionResponse;
 import com.zerobugfreinds.team_service.dto.TeamInvitationResponse;
+import com.zerobugfreinds.team_service.dto.TeamResponse;
 import com.zerobugfreinds.team_service.dto.UpdateTeamApiKeyRequest;
 import com.zerobugfreinds.team_service.dto.TeamSummaryResponse;
 import com.zerobugfreinds.team_service.security.TeamUserPrincipal;
 import com.zerobugfreinds.team_service.service.TeamApiKeyService;
 import com.zerobugfreinds.team_service.service.TeamService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -54,6 +58,15 @@ public class TeamController {
 	) {
 		List<TeamSummaryResponse> teams = teamService.getMyTeams(principal.userId());
 		return ResponseEntity.ok(ApiResponse.ok("팀 목록 조회에 성공했습니다", teams));
+	}
+
+	@GetMapping("/teams")
+	public ResponseEntity<ApiResponse<Page<TeamResponse>>> getTeams(
+			@RequestParam(name = "keyword", required = false) String keyword,
+			@PageableDefault(size = 20) Pageable pageable
+	) {
+		Page<TeamResponse> teams = teamService.getTeams(keyword, pageable);
+		return ResponseEntity.ok(ApiResponse.ok("팀 검색에 성공했습니다", teams));
 	}
 
 	@PostMapping("/teams/{id}/members")

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/TeamIdentityConsistencyResponse.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/TeamIdentityConsistencyResponse.java
@@ -1,0 +1,13 @@
+package com.zerobugfreinds.team_service.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record TeamIdentityConsistencyResponse(
+		int checkedUserCount,
+		int zombieUserCount,
+		List<String> zombieUserIds,
+		Instant checkedAt,
+		String remediationNote
+) {
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/TeamResponse.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/TeamResponse.java
@@ -1,0 +1,8 @@
+package com.zerobugfreinds.team_service.dto;
+
+public record TeamResponse(
+		String id,
+		String name,
+		long memberCount
+) {
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamInvitationRepository.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamInvitationRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 public interface TeamInvitationRepository extends JpaRepository<TeamInvitationEntity, Long> {
 
 	boolean existsByTeamIdAndInviteeIdAndStatus(Long teamId, String inviteeId, TeamInvitationStatus status);
+	boolean existsByInviteeIdOrInviterId(String inviteeId, String inviterId);
 
 	List<TeamInvitationEntity> findAllByInviteeIdAndStatusOrderByCreatedAtDesc(String inviteeId, TeamInvitationStatus status);
 

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamMemberRepository.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamMemberRepository.java
@@ -17,6 +17,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMemberEntity, Lo
 	boolean existsByTeamIdAndUserId(Long teamId, String userId);
 
 	Optional<TeamMemberEntity> findByTeamIdAndUserId(Long teamId, String userId);
+	long countByTeamId(Long teamId);
 
 	long deleteByUserId(String userId);
 

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamMemberRepository.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamMemberRepository.java
@@ -2,6 +2,7 @@ package com.zerobugfreinds.team_service.repository;
 
 import com.zerobugfreinds.team_service.entity.TeamMemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,6 +10,9 @@ import java.util.Optional;
 public interface TeamMemberRepository extends JpaRepository<TeamMemberEntity, Long> {
 	List<TeamMemberEntity> findAllByUserId(String userId);
 	List<TeamMemberEntity> findAllByTeamId(Long teamId);
+	@Query("select distinct teamMember.userId from TeamMemberEntity teamMember")
+	List<String> findDistinctUserIds();
+	boolean existsByUserId(String userId);
 
 	boolean existsByTeamIdAndUserId(Long teamId, String userId);
 

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamRepository.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamRepository.java
@@ -2,6 +2,9 @@ package com.zerobugfreinds.team_service.repository;
 
 import com.zerobugfreinds.team_service.entity.TeamEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface TeamRepository extends JpaRepository<TeamEntity, Long> {
+	Page<TeamEntity> findByNameContainingIgnoreCase(String keyword, Pageable pageable);
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/IdentityUserLookupClient.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/IdentityUserLookupClient.java
@@ -1,5 +1,7 @@
 package com.zerobugfreinds.team_service.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -10,18 +12,24 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 @Component
 public class IdentityUserLookupClient {
     private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
     private final String identityServiceBaseUrl;
 
     public IdentityUserLookupClient(
+            ObjectMapper objectMapper,
             @Value("${identity.service.url:http://host.docker.internal:8090}") String identityServiceBaseUrl
     ) {
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(3))
                 .build();
+        this.objectMapper = objectMapper;
         this.identityServiceBaseUrl = identityServiceBaseUrl.replaceAll("/+$", "");
     }
 
@@ -51,5 +59,53 @@ public class IdentityUserLookupClient {
         } catch (IOException ex) {
             return false;
         }
+    }
+
+    public Set<String> findExistingUserIds(List<String> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Set.of();
+        }
+        URI uri = URI.create(identityServiceBaseUrl + "/internal/users/exists/user-ids");
+        String requestBody;
+        try {
+            requestBody = objectMapper.writeValueAsString(new UserIdsExistenceRequest(userIds));
+        } catch (IOException ex) {
+            return Set.of();
+        }
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofSeconds(10))
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                return Set.of();
+            }
+            JsonNode root = objectMapper.readTree(response.body());
+            JsonNode existingUserIds = root.path("data").path("existingUserIds");
+            if (!existingUserIds.isArray()) {
+                return Set.of();
+            }
+            Set<String> result = new LinkedHashSet<>();
+            for (JsonNode existingUserId : existingUserIds) {
+                if (existingUserId.isTextual()) {
+                    result.add(existingUserId.asText());
+                }
+            }
+            return result;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return Set.of();
+        } catch (IOException ex) {
+            return Set.of();
+        }
+    }
+
+    private record UserIdsExistenceRequest(
+            List<String> userIds
+    ) {
     }
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamIdentityConsistencyService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamIdentityConsistencyService.java
@@ -1,0 +1,47 @@
+package com.zerobugfreinds.team_service.service;
+
+import com.zerobugfreinds.team_service.dto.TeamIdentityConsistencyResponse;
+import com.zerobugfreinds.team_service.repository.TeamMemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class TeamIdentityConsistencyService {
+	private static final String REMEDIATION_NOTE =
+			"TODO: zombie userId 발견 시 팀 멤버 강제 탈퇴 및 초대/소유권 재검증 배치로 정리하세요.";
+
+	private final TeamMemberRepository teamMemberRepository;
+	private final IdentityUserLookupClient identityUserLookupClient;
+
+	public TeamIdentityConsistencyService(
+			TeamMemberRepository teamMemberRepository,
+			IdentityUserLookupClient identityUserLookupClient
+	) {
+		this.teamMemberRepository = teamMemberRepository;
+		this.identityUserLookupClient = identityUserLookupClient;
+	}
+
+	@Transactional(readOnly = true)
+	public TeamIdentityConsistencyResponse findZombieUsers() {
+		List<String> teamMemberUserIds = teamMemberRepository.findDistinctUserIds().stream()
+				.filter(userId -> userId != null && !userId.isBlank())
+				.map(String::trim)
+				.distinct()
+				.toList();
+		Set<String> existingUserIds = identityUserLookupClient.findExistingUserIds(teamMemberUserIds);
+		List<String> zombieUserIds = teamMemberUserIds.stream()
+				.filter(userId -> !existingUserIds.contains(userId))
+				.toList();
+		return new TeamIdentityConsistencyResponse(
+				teamMemberUserIds.size(),
+				zombieUserIds.size(),
+				zombieUserIds,
+				Instant.now(),
+				REMEDIATION_NOTE
+		);
+	}
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamService.java
@@ -116,6 +116,9 @@ public class TeamService {
 		if (teamMemberRepository.existsByTeamIdAndUserId(teamId, invitee)) {
 			throw new DuplicateTeamMemberException("이미 팀에 참여 중인 사용자입니다");
 		}
+		if (!existsUserInTeamDb(invitee)) {
+			throw new IllegalArgumentException("존재하는 사용자만 초대할 수 있습니다");
+		}
 		if (teamInvitationRepository.existsByTeamIdAndInviteeIdAndStatus(teamId, invitee, TeamInvitationStatus.PENDING)) {
 			throw new DuplicateTeamInvitationException("이미 대기 중인 팀 초대가 있습니다");
 		}
@@ -356,5 +359,10 @@ public class TeamService {
 		}
 		return teamInvitationRepository.findByIdAndInviteeId(invitationId, actorUserId.trim())
 				.orElseThrow(() -> new TeamInvitationNotFoundException("초대를 찾을 수 없습니다"));
+	}
+
+	private boolean existsUserInTeamDb(String userId) {
+		return teamMemberRepository.existsByUserId(userId)
+				|| teamInvitationRepository.existsByInviteeIdOrInviterId(userId, userId);
 	}
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamService.java
@@ -5,6 +5,7 @@ import com.zerobugfreinds.team_service.domain.TeamInvitationStatus;
 import com.zerobugfreinds.team_service.dto.InternalTeamDetailResponse;
 import com.zerobugfreinds.team_service.dto.InternalBillingTeamApiKeyResponse;
 import com.zerobugfreinds.team_service.dto.InternalBillingTeamSummaryResponse;
+import com.zerobugfreinds.team_service.dto.TeamResponse;
 import com.zerobugfreinds.team_service.dto.TeamInvitationActionResponse;
 import com.zerobugfreinds.team_service.dto.TeamInvitationResponse;
 import com.zerobugfreinds.team_service.dto.TeamSummaryResponse;
@@ -26,6 +27,8 @@ import com.zerobugfreinds.team_service.repository.TeamApiKeyRepository;
 import com.zerobugfreinds.team_service.repository.TeamInvitationRepository;
 import com.zerobugfreinds.team_service.repository.TeamMemberRepository;
 import com.zerobugfreinds.team_service.repository.TeamRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -99,6 +102,21 @@ public class TeamService {
 			}
 		}
 		return result;
+	}
+
+	@Transactional(readOnly = true)
+	public Page<TeamResponse> getTeams(String keyword, Pageable pageable) {
+		Page<TeamEntity> page;
+		if (!StringUtils.hasText(keyword)) {
+			page = teamRepository.findAll(pageable);
+		} else {
+			page = teamRepository.findByNameContainingIgnoreCase(keyword.trim(), pageable);
+		}
+		return page.map(team -> new TeamResponse(
+				String.valueOf(team.getId()),
+				team.getName(),
+				teamMemberRepository.countByTeamId(team.getId())
+		));
 	}
 
 	@Transactional

--- a/services/team-service/web/src/components/team/team-management-view.tsx
+++ b/services/team-service/web/src/components/team/team-management-view.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ChevronDown, ChevronRight, Eye, EyeOff, Minus, Plus } from "lucide-react"
+import { ChevronDown, ChevronRight, Eye, EyeOff, Minus, Plus, Search } from "lucide-react"
 
 type ApiResponse<T> = {
   success: boolean
@@ -115,6 +115,17 @@ function teamApiPath(path: string): string {
   return `${TEAM_WEB_BASE_PATH}${normalized}`
 }
 
+function useDebounce<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = React.useState(value)
+
+  React.useEffect(() => {
+    const timeoutId = window.setTimeout(() => setDebouncedValue(value), delayMs)
+    return () => window.clearTimeout(timeoutId)
+  }, [value, delayMs])
+
+  return debouncedValue
+}
+
 function normalizeBudgetNumericString(raw: string): string {
   const t = raw.trim()
   if (t === "") return ""
@@ -139,6 +150,9 @@ export function TeamManagementView() {
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
   const [teams, setTeams] = React.useState<TeamSummary[]>([])
+  const [keyword, setKeyword] = React.useState("")
+  const debouncedKeyword = useDebounce(keyword, 500)
+  const [isSearching, setIsSearching] = React.useState(false)
   const [teamMemberIdsByTeamId, setTeamMemberIdsByTeamId] = React.useState<Record<string, string[]>>({})
   const [isTeamOwnerByTeamId, setIsTeamOwnerByTeamId] = React.useState<Record<string, boolean>>({})
   const [showCreateForm, setShowCreateForm] = React.useState(false)
@@ -165,27 +179,53 @@ export function TeamManagementView() {
   const [removeMemberLoadingKey, setRemoveMemberLoadingKey] = React.useState<string | null>(null)
   const [deleteTeamLoadingId, setDeleteTeamLoadingId] = React.useState<string | null>(null)
   const [openTeamId, setOpenTeamId] = React.useState<string | null>(null)
+  const latestLoadSeqRef = React.useRef(0)
 
-  const loadTeams = React.useCallback(async () => {
+  const loadTeams = React.useCallback(async (keywordParam?: string) => {
+    const requestSeq = latestLoadSeqRef.current + 1
+    latestLoadSeqRef.current = requestSeq
     setLoading(true)
+    setIsSearching(true)
     setError(null)
+    const q = new URLSearchParams({
+      page: "0",
+      size: "10",
+    })
+    const trimmedKeyword = (keywordParam ?? "").trim()
+    if (trimmedKeyword !== "") {
+      q.set("keyword", trimmedKeyword)
+    }
     try {
-      const { res, body } = await requestApi("/api/team/v1/me/teams", { method: "GET" })
-      if (!res.ok || !body?.success || !Array.isArray(body.data)) {
+      const { res, body } = await requestApi(`/api/team/v1/teams?${q.toString()}`, { method: "GET" })
+      if (requestSeq !== latestLoadSeqRef.current) {
+        return
+      }
+      const pageData = body?.data
+      const content =
+        pageData && typeof pageData === "object" && Array.isArray((pageData as { content?: unknown[] }).content)
+          ? (pageData as { content: unknown[] }).content
+          : null
+      if (!res.ok || !body?.success || content === null) {
         setError(body?.message ?? "팀 목록을 불러오지 못했습니다")
         setTeams([])
         return
       }
       setTeams(
-        body.data
+        content
           .map((item) => normalizeTeamSummary(item))
           .filter((item): item is TeamSummary => item !== null)
       )
     } catch {
+      if (requestSeq !== latestLoadSeqRef.current) {
+        return
+      }
       setError("팀 목록을 불러오지 못했습니다")
       setTeams([])
     } finally {
-      setLoading(false)
+      if (requestSeq === latestLoadSeqRef.current) {
+        setLoading(false)
+        setIsSearching(false)
+      }
     }
   }, [])
 
@@ -236,8 +276,8 @@ export function TeamManagementView() {
   }, [])
 
   React.useEffect(() => {
-    void loadTeams()
-  }, [loadTeams])
+    void loadTeams(debouncedKeyword)
+  }, [loadTeams, debouncedKeyword])
 
   React.useEffect(() => {
     if (teams.length === 0) {
@@ -327,7 +367,7 @@ export function TeamManagementView() {
       setTeamName("")
       setInviteesOnCreate([newInviteeRow()])
       setShowCreateForm(false)
-      await loadTeams()
+      await loadTeams(debouncedKeyword)
     } catch {
       setMessage({ kind: "error", text: "팀 생성에 실패했습니다" })
     } finally {
@@ -630,7 +670,7 @@ export function TeamManagementView() {
         return
       }
       setMessage({ kind: "success", text: "팀을 삭제했습니다" })
-      await loadTeams()
+      await loadTeams(debouncedKeyword)
       cancelEditTeamApiKey()
     } catch {
       setMessage({ kind: "error", text: "팀 삭제에 실패했습니다" })
@@ -647,6 +687,23 @@ export function TeamManagementView() {
           팀 생성 후 사용자 이메일로 팀원을 초대할 수 있으며, 팀 API Key를 등록하고 월 예산(USD)을 설정할 수 있습니다.
         </p>
       </header>
+
+      <section className="rounded-lg border border-zinc-200 bg-white p-4">
+        <label htmlFor="team-search" className="mb-2 block text-sm font-medium text-zinc-700">
+          팀 이름 검색
+        </label>
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" aria-hidden />
+          <input
+            id="team-search"
+            className="h-10 w-full rounded-md border border-zinc-300 bg-white pl-9 pr-3 text-sm outline-none transition focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            placeholder="팀 이름을 입력해 주세요"
+            autoComplete="off"
+          />
+        </div>
+      </section>
 
       <section className="space-y-3 rounded-lg border border-zinc-200 bg-white p-4">
         {!showCreateForm ? (
@@ -738,10 +795,12 @@ export function TeamManagementView() {
       </section>
 
       {message ? <p className={message.kind === "success" ? "text-sm text-emerald-600" : "text-sm text-red-600"}>{message.text}</p> : null}
-      {loading ? <p className="text-sm text-zinc-500">불러오는 중…</p> : null}
+      {loading ? <p className="text-sm text-zinc-500">{isSearching ? "검색 중..." : "불러오는 중…"}</p> : null}
       {error && !loading ? <p className="text-sm text-red-600">{error}</p> : null}
 
-      {!loading && !error && teams.length === 0 ? <p className="text-sm text-zinc-500">참여 중인 팀이 없습니다.</p> : null}
+      {!loading && !error && teams.length === 0 ? (
+        <p className="text-sm text-zinc-500">{debouncedKeyword.trim() ? "검색된 팀이 없습니다" : "참여 중인 팀이 없습니다."}</p>
+      ) : null}
 
       {!loading && teams.length > 0 ? (
         <ul className="divide-y divide-zinc-200 rounded-lg border border-zinc-200 bg-white">

--- a/services/team-service/web/src/components/team/team-management-view.tsx
+++ b/services/team-service/web/src/components/team/team-management-view.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ChevronDown, ChevronRight, Eye, EyeOff, Minus, Plus, Search } from "lucide-react"
+import { ChevronRight, Eye, EyeOff, Minus, Plus, Search } from "lucide-react"
 
 type ApiResponse<T> = {
   success: boolean
@@ -178,7 +178,8 @@ export function TeamManagementView() {
   const [cancelDeleteLoadingKey, setCancelDeleteLoadingKey] = React.useState<string | null>(null)
   const [removeMemberLoadingKey, setRemoveMemberLoadingKey] = React.useState<string | null>(null)
   const [deleteTeamLoadingId, setDeleteTeamLoadingId] = React.useState<string | null>(null)
-  const [openTeamId, setOpenTeamId] = React.useState<string | null>(null)
+  const [selectedTeamId, setSelectedTeamId] = React.useState<string | null>(null)
+  const [activeTab, setActiveTab] = React.useState<"dashboard" | "members" | "settings">("dashboard")
   const latestLoadSeqRef = React.useRef(0)
 
   const loadTeams = React.useCallback(async (keywordParam?: string) => {
@@ -284,23 +285,27 @@ export function TeamManagementView() {
       setTeamMemberIdsByTeamId({})
       setIsTeamOwnerByTeamId({})
       setTeamApiKeysByTeamId({})
-      setOpenTeamId(null)
+      setSelectedTeamId(null)
     }
   }, [teams.length])
 
   React.useEffect(() => {
-    if (openTeamId && !teams.some((t) => t.id === openTeamId)) {
-      setOpenTeamId(null)
+    if (selectedTeamId && !teams.some((t) => t.id === selectedTeamId)) {
+      setSelectedTeamId(null)
     }
-  }, [teams, openTeamId])
+  }, [teams, selectedTeamId])
 
   React.useEffect(() => {
-    if (!openTeamId) return
-    if (!teams.some((t) => t.id === openTeamId)) return
-    void loadTeamOwnerFlag(openTeamId)
-    void loadTeamMembers(openTeamId)
-    void loadTeamApiKeys(openTeamId)
-  }, [openTeamId, teams, loadTeamApiKeys, loadTeamMembers, loadTeamOwnerFlag])
+    setActiveTab("dashboard")
+  }, [selectedTeamId])
+
+  React.useEffect(() => {
+    if (!selectedTeamId) return
+    if (!teams.some((t) => t.id === selectedTeamId)) return
+    void loadTeamOwnerFlag(selectedTeamId)
+    void loadTeamMembers(selectedTeamId)
+    void loadTeamApiKeys(selectedTeamId)
+  }, [selectedTeamId, teams, loadTeamApiKeys, loadTeamMembers, loadTeamOwnerFlag])
 
   async function createTeam(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -679,491 +684,533 @@ export function TeamManagementView() {
     }
   }
 
+  const selectedTeam = selectedTeamId ? teams.find((team) => team.id === selectedTeamId) ?? null : null
+
   return (
-    <main className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-4">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">팀 관리</h1>
-        <p className="text-sm text-zinc-600">
-          팀 생성 후 사용자 이메일로 팀원을 초대할 수 있으며, 팀 API Key를 등록하고 월 예산(USD)을 설정할 수 있습니다.
-        </p>
-      </header>
-
-      <section className="rounded-lg border border-zinc-200 bg-white p-4">
-        <label htmlFor="team-search" className="mb-2 block text-sm font-medium text-zinc-700">
-          팀 이름 검색
-        </label>
-        <div className="relative">
-          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" aria-hidden />
-          <input
-            id="team-search"
-            className="h-10 w-full rounded-md border border-zinc-300 bg-white pl-9 pr-3 text-sm outline-none transition focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200"
-            value={keyword}
-            onChange={(e) => setKeyword(e.target.value)}
-            placeholder="팀 이름을 입력해 주세요"
-            autoComplete="off"
-          />
-        </div>
-      </section>
-
-      <section className="space-y-3 rounded-lg border border-zinc-200 bg-white p-4">
-        {!showCreateForm ? (
-          <button
-            type="button"
-            className="h-10 rounded-md bg-black px-4 text-sm font-medium text-white disabled:opacity-60"
-            onClick={openCreateForm}
-            disabled={createLoading}
-          >
-            팀 만들기
-          </button>
-        ) : (
-          <form className="space-y-3" onSubmit={createTeam}>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">팀 이름 (필수)</label>
-              <input
-                className="h-10 w-full rounded-md border border-zinc-300 bg-white px-3 text-sm"
-                value={teamName}
-                onChange={(e) => setTeamName(e.target.value)}
-                placeholder="예: 플랫폼팀"
-                autoComplete="off"
+    <main className="flex min-h-screen overflow-hidden bg-white">
+      <aside className="w-72 shrink-0 border-r border-zinc-200 bg-gray-50">
+        <div className="flex h-full flex-col">
+          <div className="border-b border-zinc-200 px-4 py-4">
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="text-base font-semibold text-zinc-900">팀 목록</h2>
+              <button
+                type="button"
+                className="h-8 rounded-md border border-zinc-300 bg-white px-2.5 text-xs font-medium text-zinc-700 hover:bg-zinc-100 disabled:opacity-60"
+                onClick={openCreateForm}
                 disabled={createLoading}
-                required
+              >
+                + 새 팀
+              </button>
+            </div>
+            <p className="mt-1 text-xs text-zinc-500">팀을 선택하면 우측에서 상세 설정을 수정할 수 있습니다.</p>
+            <div className="relative mt-3">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" aria-hidden />
+              <input
+                id="team-search"
+                className="h-10 w-full rounded-md border border-zinc-300 bg-white pl-9 pr-3 text-sm outline-none transition focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200"
+                value={keyword}
+                onChange={(e) => setKeyword(e.target.value)}
+                placeholder="팀 이름 검색"
+                autoComplete="off"
               />
             </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium">팀원 초대 (선택)</label>
-              <div className="space-y-2">
-                {inviteesOnCreate.map((row) => (
-                  <div key={row.id} className="flex gap-2">
-                    <input
-                      className="h-10 min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-3 text-sm"
-                      value={row.value}
-                      onChange={(e) => {
-                        const v = e.target.value
-                        setInviteesOnCreate((prev) =>
-                          prev.map((r) => (r.id === row.id ? { ...r, value: v } : r)),
-                        )
-                      }}
-                      placeholder="초대할 사용자 이메일 또는 아이디"
-                      autoComplete="off"
-                      disabled={createLoading}
-                    />
-                    {inviteesOnCreate.length > 1 ? (
-                      <button
-                        type="button"
-                        className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-                        aria-label="이 초대 행 삭제"
-                        disabled={createLoading}
-                        onClick={() =>
-                          setInviteesOnCreate((prev) => prev.filter((r) => r.id !== row.id))
-                        }
-                      >
-                        <Minus className="h-4 w-4" aria-hidden />
-                      </button>
-                    ) : null}
-                  </div>
-                ))}
-                <button
-                  type="button"
-                  className="inline-flex h-10 items-center gap-1.5 rounded-md border border-dashed border-zinc-300 bg-zinc-50 px-3 text-sm text-zinc-700 hover:bg-zinc-100 disabled:opacity-50"
-                  disabled={createLoading}
-                  onClick={() => setInviteesOnCreate((prev) => [...prev, newInviteeRow()])}
-                >
-                  <Plus className="h-4 w-4" aria-hidden />
-                  초대 대상 추가
-                </button>
-              </div>
-            </div>
-            <div className="flex gap-2">
-              <button
-                type="submit"
-                className="h-10 rounded-md bg-black px-4 text-sm font-medium text-white disabled:opacity-60"
-                disabled={createLoading}
-              >
-                {createLoading ? "생성 중…" : "생성"}
-              </button>
-              <button
-                type="button"
-                className="h-10 rounded-md border border-zinc-300 bg-white px-4 text-sm font-medium"
-                onClick={closeCreateForm}
-                disabled={createLoading}
-              >
-                취소
-              </button>
-            </div>
-          </form>
-        )}
-      </section>
-
-      {message ? <p className={message.kind === "success" ? "text-sm text-emerald-600" : "text-sm text-red-600"}>{message.text}</p> : null}
-      {loading ? <p className="text-sm text-zinc-500">{isSearching ? "검색 중..." : "불러오는 중…"}</p> : null}
-      {error && !loading ? <p className="text-sm text-red-600">{error}</p> : null}
-
-      {!loading && !error && teams.length === 0 ? (
-        <p className="text-sm text-zinc-500">{debouncedKeyword.trim() ? "검색된 팀이 없습니다" : "참여 중인 팀이 없습니다."}</p>
-      ) : null}
-
-      {!loading && teams.length > 0 ? (
-        <ul className="divide-y divide-zinc-200 rounded-lg border border-zinc-200 bg-white">
-          {teams.map((team) => {
-            const isOpen = openTeamId === team.id
-            const isOwner = isTeamOwnerByTeamId[team.id] === true
-            return (
-            <li key={team.id} className="overflow-hidden">
-              <button
-                type="button"
-                className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-zinc-50"
-                aria-expanded={isOpen}
-                onClick={() => {
-                  setOpenTeamId((prev) => {
-                    if (prev === team.id) {
-                      cancelEditTeamApiKey()
-                      return null
-                    }
-                    cancelEditTeamApiKey()
-                    setInviteInputsByTeamId((p) =>
-                      p[team.id] !== undefined ? p : { ...p, [team.id]: [newInviteeRow()] },
-                    )
-                    return team.id
-                  })
-                }}
-              >
-                {isOpen ? (
-                  <ChevronDown className="h-4 w-4 shrink-0 text-zinc-500" aria-hidden />
-                ) : (
-                  <ChevronRight className="h-4 w-4 shrink-0 text-zinc-500" aria-hidden />
-                )}
-                <span className="min-w-0 flex-1 font-medium">{team.name}</span>
-              </button>
-
-              {isOpen ? (
-              <div className="space-y-2 border-t border-zinc-200 bg-zinc-50/50 px-4 pb-4 pt-2">
-              <div>
-                <p className="text-xs text-zinc-500">멤버 {(teamMemberIdsByTeamId[team.id] ?? []).length}명</p>
-                {(teamMemberIdsByTeamId[team.id] ?? []).length > 0 ? (
-                  <ul className="mt-2 space-y-1 text-xs text-zinc-600">
-                    {(teamMemberIdsByTeamId[team.id] ?? []).map((memberId) => (
-                      <li key={`${team.id}-${memberId}`} className="flex items-center justify-between gap-2">
-                        <span className="truncate">{memberId}</span>
-                        {isOwner ? (
+            {showCreateForm ? (
+              <form className="mt-3 space-y-3 rounded-md border border-zinc-200 bg-white p-3" onSubmit={createTeam}>
+                <div className="space-y-1">
+                  <label className="text-xs font-medium">팀 이름 (필수)</label>
+                  <input
+                    className="h-9 w-full rounded-md border border-zinc-300 bg-white px-3 text-sm"
+                    value={teamName}
+                    onChange={(e) => setTeamName(e.target.value)}
+                    placeholder="예: 플랫폼팀"
+                    autoComplete="off"
+                    disabled={createLoading}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs font-medium">팀원 초대 (선택)</label>
+                  <div className="space-y-2">
+                    {inviteesOnCreate.map((row) => (
+                      <div key={row.id} className="flex gap-2">
+                        <input
+                          className="h-9 min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-3 text-sm"
+                          value={row.value}
+                          onChange={(e) => {
+                            const v = e.target.value
+                            setInviteesOnCreate((prev) =>
+                              prev.map((r) => (r.id === row.id ? { ...r, value: v } : r)),
+                            )
+                          }}
+                          placeholder="초대할 사용자 이메일 또는 아이디"
+                          autoComplete="off"
+                          disabled={createLoading}
+                        />
+                        {inviteesOnCreate.length > 1 ? (
                           <button
                             type="button"
-                            className="rounded border border-red-300 bg-white px-2 py-1 text-[11px] text-red-600 disabled:opacity-50"
-                            disabled={removeMemberLoadingKey === `${team.id}:${memberId}`}
-                            onClick={() => void removeTeamMember(team.id, memberId)}
+                            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+                            aria-label="이 초대 행 삭제"
+                            disabled={createLoading}
+                            onClick={() =>
+                              setInviteesOnCreate((prev) => prev.filter((r) => r.id !== row.id))
+                            }
                           >
-                            {removeMemberLoadingKey === `${team.id}:${memberId}` ? "삭제 중…" : "팀원 삭제"}
+                            <Minus className="h-4 w-4" aria-hidden />
                           </button>
                         ) : null}
-                      </li>
+                      </div>
                     ))}
-                  </ul>
-                ) : (
-                  <p className="mt-1 text-xs text-zinc-500">등록된 팀원이 없습니다.</p>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <p className="text-xs font-medium text-zinc-700">팀원 초대</p>
-                {(inviteInputsByTeamId[team.id] ?? []).map((row) => (
-                  <div key={row.id} className="flex gap-2">
-                    <input
-                      className="h-9 min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-3 text-sm"
-                      value={row.value}
-                      onChange={(e) => {
-                        const v = e.target.value
-                        setInviteInputsByTeamId((prev) => {
-                          const list = prev[team.id] ?? []
-                          return {
-                            ...prev,
-                            [team.id]: list.map((r) => (r.id === row.id ? { ...r, value: v } : r)),
-                          }
-                        })
-                      }}
-                      placeholder="초대할 사용자 이메일 또는 아이디"
-                      autoComplete="off"
-                      disabled={inviteLoadingTeamId === team.id}
-                    />
-                    {(inviteInputsByTeamId[team.id] ?? []).length > 1 ? (
-                      <button
-                        type="button"
-                        className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-                        aria-label="이 초대 행 삭제"
-                        disabled={inviteLoadingTeamId === team.id}
-                        onClick={() =>
-                          setInviteInputsByTeamId((prev) => {
-                            const list = prev[team.id] ?? []
-                            const next = list.filter((r) => r.id !== row.id)
-                            return { ...prev, [team.id]: next.length > 0 ? next : [newInviteeRow()] }
-                          })
-                        }
-                      >
-                        <Minus className="h-4 w-4" aria-hidden />
-                      </button>
-                    ) : null}
-                  </div>
-                ))}
-                <button
-                  type="button"
-                  className="inline-flex h-9 w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-zinc-300 bg-white px-3 text-xs text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 sm:w-auto sm:justify-start"
-                  disabled={inviteLoadingTeamId === team.id}
-                  onClick={() =>
-                    setInviteInputsByTeamId((prev) => {
-                      const list = prev[team.id] ?? [newInviteeRow()]
-                      return { ...prev, [team.id]: [...list, newInviteeRow()] }
-                    })
-                  }
-                >
-                  <Plus className="h-4 w-4" aria-hidden />
-                  초대 대상 추가
-                </button>
-                <button
-                  type="button"
-                  className="h-9 w-full rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium disabled:opacity-60 sm:w-auto"
-                  disabled={inviteLoadingTeamId === team.id}
-                  onClick={() => void invite(team.id)}
-                >
-                  {inviteLoadingTeamId === team.id ? "초대 중…" : "멤버 초대"}
-                </button>
-              </div>
-
-              <div className="space-y-2 rounded-md border border-zinc-200 bg-zinc-50 p-3">
-                <p className="text-xs font-medium text-zinc-700">팀 API Key 등록</p>
-                <div className="flex flex-col gap-2">
-                  <select
-                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs"
-                    value={apiKeyProviderByTeamId[team.id] ?? "OPENAI"}
-                    onChange={(e) => setApiKeyProviderByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
-                    disabled={apiKeyLoadingTeamId === team.id}
-                  >
-                    <option value="OPENAI">OPENAI</option>
-                    <option value="GEMINI">GEMINI</option>
-                    <option value="CLAUDE">CLAUDE</option>
-                  </select>
-                  <input
-                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs"
-                    value={apiKeyAliasByTeamId[team.id] ?? ""}
-                    onChange={(e) => setApiKeyAliasByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
-                    placeholder="API Key 별칭"
-                    autoComplete="off"
-                    disabled={apiKeyLoadingTeamId === team.id}
-                  />
-                  <div className="flex gap-1">
-                    <input
-                      type={apiKeyRevealByTeamId[team.id] ? "text" : "password"}
-                      className="h-9 min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-3 text-xs"
-                      value={apiKeyValueByTeamId[team.id] ?? ""}
-                      onChange={(e) => setApiKeyValueByTeamId((prev) => ({ ...prev, [team.id]: e.target.value }))}
-                      placeholder="API Key 값"
-                      autoComplete="new-password"
-                      disabled={apiKeyLoadingTeamId === team.id}
-                    />
                     <button
                       type="button"
-                      className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-zinc-300 bg-white text-zinc-600 hover:bg-zinc-50 disabled:opacity-50"
-                      aria-label={apiKeyRevealByTeamId[team.id] ? "API Key 숨기기" : "API Key 보기"}
-                      disabled={apiKeyLoadingTeamId === team.id}
-                      onClick={() =>
-                        setApiKeyRevealByTeamId((prev) => ({ ...prev, [team.id]: !prev[team.id] }))
-                      }
+                      className="inline-flex h-9 w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-zinc-300 bg-zinc-50 px-3 text-xs text-zinc-700 hover:bg-zinc-100 disabled:opacity-50"
+                      disabled={createLoading}
+                      onClick={() => setInviteesOnCreate((prev) => [...prev, newInviteeRow()])}
                     >
-                      {apiKeyRevealByTeamId[team.id] ? (
-                        <EyeOff className="h-4 w-4" aria-hidden />
-                      ) : (
-                        <Eye className="h-4 w-4" aria-hidden />
-                      )}
+                      <Plus className="h-4 w-4" aria-hidden />
+                      초대 대상 추가
                     </button>
                   </div>
-                  <input
-                    type="number"
-                    step={0.01}
-                    min={0}
-                    className="h-9 w-full rounded-md border border-zinc-300 bg-white px-3 text-xs"
-                    value={apiKeyMonthlyBudgetByTeamId[team.id] ?? ""}
-                    onChange={(e) => {
-                      const v = e.target.value
-                      if (v === "") {
-                        setApiKeyMonthlyBudgetByTeamId((prev) => ({ ...prev, [team.id]: "" }))
-                        return
-                      }
-                      const n = Number(v)
-                      if (!Number.isFinite(n) || n < 0) return
-                      setApiKeyMonthlyBudgetByTeamId((prev) => ({ ...prev, [team.id]: v }))
-                    }}
-                    onBlur={() =>
-                      setApiKeyMonthlyBudgetByTeamId((prev) => {
-                        const cur = prev[team.id] ?? ""
-                        if (cur.trim() === "") return prev
-                        const next = normalizeBudgetNumericString(cur)
-                        if (next === cur) return prev
-                        return { ...prev, [team.id]: next }
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="submit"
+                    className="h-9 rounded-md bg-black px-3 text-xs font-medium text-white disabled:opacity-60"
+                    disabled={createLoading}
+                  >
+                    {createLoading ? "생성 중…" : "생성"}
+                  </button>
+                  <button
+                    type="button"
+                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium"
+                    onClick={closeCreateForm}
+                    disabled={createLoading}
+                  >
+                    취소
+                  </button>
+                </div>
+              </form>
+            ) : null}
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-3">
+            {loading ? <p className="px-2 py-3 text-sm text-zinc-500">{isSearching ? "검색 중..." : "불러오는 중…"}</p> : null}
+            {error && !loading ? <p className="px-2 py-3 text-sm text-red-600">{error}</p> : null}
+            {!loading && !error && teams.length === 0 ? (
+              <p className="px-2 py-3 text-sm text-zinc-500">{debouncedKeyword.trim() ? "검색된 팀이 없습니다" : "참여 중인 팀이 없습니다."}</p>
+            ) : null}
+            {!loading && teams.length > 0 ? (
+              <ul className="space-y-2">
+                {teams.map((team) => {
+                  const isSelected = selectedTeamId === team.id
+                  return (
+                    <li key={team.id}>
+                      <button
+                        type="button"
+                        className={`w-full rounded-lg border px-3 py-2 text-left transition ${
+                          isSelected
+                            ? "border-zinc-900 bg-white shadow-sm"
+                            : "border-zinc-200 bg-white hover:border-zinc-300 hover:bg-zinc-50"
+                        }`}
+                        onClick={() => {
+                          cancelEditTeamApiKey()
+                          setSelectedTeamId(team.id)
+                          setInviteInputsByTeamId((prev) =>
+                            prev[team.id] !== undefined ? prev : { ...prev, [team.id]: [newInviteeRow()] },
+                          )
+                        }}
+                      >
+                        <div className="flex items-center gap-2">
+                          {isSelected ? (
+                            <ChevronRight className="h-4 w-4 shrink-0 text-zinc-700" aria-hidden />
+                          ) : (
+                            <ChevronRight className="h-4 w-4 shrink-0 text-zinc-400" aria-hidden />
+                          )}
+                          <span className="truncate text-sm font-medium text-zinc-900">{team.name}</span>
+                        </div>
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            ) : null}
+          </div>
+        </div>
+      </aside>
+
+      <section className="flex-1 overflow-y-auto bg-white px-6 py-5">
+
+        {message ? (
+          <p className={`mt-4 text-sm ${message.kind === "success" ? "text-emerald-600" : "text-red-600"}`}>{message.text}</p>
+        ) : null}
+
+        {!selectedTeam ? (
+          <div className="mt-6 flex min-h-[360px] items-center justify-center rounded-lg border border-dashed border-zinc-300 bg-zinc-50">
+            <p className="text-sm text-zinc-500">왼쪽에서 팀을 선택해 주세요.</p>
+          </div>
+        ) : (
+          <div className="mt-6 space-y-4 rounded-lg border border-zinc-200 bg-zinc-50/50 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold">{selectedTeam.name}</h2>
+              <p className="text-xs text-zinc-500">멤버 {(teamMemberIdsByTeamId[selectedTeam.id] ?? []).length}명</p>
+            </div>
+            <div className="border-b border-zinc-200">
+              <nav className="flex items-center gap-5">
+                <button
+                  type="button"
+                  className={`pb-2 text-sm font-medium ${
+                    activeTab === "dashboard"
+                      ? "border-b-2 border-blue-500 text-blue-600"
+                      : "border-b-2 border-transparent text-zinc-500 hover:text-zinc-700"
+                  }`}
+                  onClick={() => setActiveTab("dashboard")}
+                >
+                  대시보드
+                </button>
+                <button
+                  type="button"
+                  className={`pb-2 text-sm font-medium ${
+                    activeTab === "members"
+                      ? "border-b-2 border-blue-500 text-blue-600"
+                      : "border-b-2 border-transparent text-zinc-500 hover:text-zinc-700"
+                  }`}
+                  onClick={() => setActiveTab("members")}
+                >
+                  멤버 관리
+                </button>
+                <button
+                  type="button"
+                  className={`pb-2 text-sm font-medium ${
+                    activeTab === "settings"
+                      ? "border-b-2 border-blue-500 text-blue-600"
+                      : "border-b-2 border-transparent text-zinc-500 hover:text-zinc-700"
+                  }`}
+                  onClick={() => setActiveTab("settings")}
+                >
+                  API 및 설정
+                </button>
+              </nav>
+            </div>
+
+            {activeTab === "dashboard" ? (
+              <div className="flex min-h-[320px] items-center justify-center rounded-lg border border-dashed border-zinc-300 bg-white p-6">
+                <p className="text-sm text-zinc-500">여기에 사용량 차트와 대시보드가 들어갈 예정입니다.</p>
+              </div>
+            ) : null}
+
+            {activeTab === "members" ? (
+              <>
+                <div>
+                  {(teamMemberIdsByTeamId[selectedTeam.id] ?? []).length > 0 ? (
+                    <ul className="space-y-1 text-xs text-zinc-600">
+                      {(teamMemberIdsByTeamId[selectedTeam.id] ?? []).map((memberId) => (
+                        <li key={`${selectedTeam.id}-${memberId}`} className="flex items-center justify-between gap-2">
+                          <span className="truncate">{memberId}</span>
+                          {isTeamOwnerByTeamId[selectedTeam.id] ? (
+                            <button
+                              type="button"
+                              className="rounded border border-red-300 bg-white px-2 py-1 text-[11px] text-red-600 disabled:opacity-50"
+                              disabled={removeMemberLoadingKey === `${selectedTeam.id}:${memberId}`}
+                              onClick={() => void removeTeamMember(selectedTeam.id, memberId)}
+                            >
+                              {removeMemberLoadingKey === `${selectedTeam.id}:${memberId}` ? "삭제 중…" : "팀원 삭제"}
+                            </button>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-1 text-xs text-zinc-500">등록된 팀원이 없습니다.</p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-zinc-700">팀원 초대</p>
+                  {(inviteInputsByTeamId[selectedTeam.id] ?? []).map((row) => (
+                    <div key={row.id} className="flex gap-2">
+                      <input
+                        className="h-9 min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-3 text-sm"
+                        value={row.value}
+                        onChange={(e) => {
+                          const v = e.target.value
+                          setInviteInputsByTeamId((prev) => {
+                            const list = prev[selectedTeam.id] ?? []
+                            return {
+                              ...prev,
+                              [selectedTeam.id]: list.map((r) => (r.id === row.id ? { ...r, value: v } : r)),
+                            }
+                          })
+                        }}
+                        placeholder="초대할 사용자 이메일 또는 아이디"
+                        autoComplete="off"
+                        disabled={inviteLoadingTeamId === selectedTeam.id}
+                      />
+                    </div>
+                  ))}
+                  <button
+                    type="button"
+                    className="inline-flex h-9 w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-zinc-300 bg-white px-3 text-xs text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 sm:w-auto sm:justify-start"
+                    disabled={inviteLoadingTeamId === selectedTeam.id}
+                    onClick={() =>
+                      setInviteInputsByTeamId((prev) => {
+                        const list = prev[selectedTeam.id] ?? [newInviteeRow()]
+                        return { ...prev, [selectedTeam.id]: [...list, newInviteeRow()] }
                       })
                     }
-                    placeholder="월 예산 USD"
-                    inputMode="decimal"
-                    autoComplete="off"
-                    disabled={apiKeyLoadingTeamId === team.id}
+                  >
+                    <Plus className="h-4 w-4" aria-hidden />
+                    초대 대상 추가
+                  </button>
+                  <button
+                    type="button"
+                    className="h-9 w-full rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium disabled:opacity-60 sm:w-auto"
+                    disabled={inviteLoadingTeamId === selectedTeam.id}
+                    onClick={() => void invite(selectedTeam.id)}
+                  >
+                    {inviteLoadingTeamId === selectedTeam.id ? "초대 중…" : "멤버 초대"}
+                  </button>
+                </div>
+              </>
+            ) : null}
+
+            {activeTab === "settings" ? (
+              <>
+                <div className="space-y-2 rounded-md border border-zinc-200 bg-zinc-50 p-3">
+              <p className="text-xs font-medium text-zinc-700">팀 API Key 등록</p>
+              <div className="flex flex-col gap-2">
+                <select
+                  className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs"
+                  value={apiKeyProviderByTeamId[selectedTeam.id] ?? "OPENAI"}
+                  onChange={(e) => setApiKeyProviderByTeamId((prev) => ({ ...prev, [selectedTeam.id]: e.target.value }))}
+                  disabled={apiKeyLoadingTeamId === selectedTeam.id}
+                >
+                  <option value="OPENAI">OPENAI</option>
+                  <option value="GEMINI">GEMINI</option>
+                  <option value="CLAUDE">CLAUDE</option>
+                </select>
+                <input
+                  className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs"
+                  value={apiKeyAliasByTeamId[selectedTeam.id] ?? ""}
+                  onChange={(e) => setApiKeyAliasByTeamId((prev) => ({ ...prev, [selectedTeam.id]: e.target.value }))}
+                  placeholder="API Key 별칭"
+                  autoComplete="off"
+                  disabled={apiKeyLoadingTeamId === selectedTeam.id}
+                />
+                <div className="flex gap-1">
+                  <input
+                    type={apiKeyRevealByTeamId[selectedTeam.id] ? "text" : "password"}
+                    className="h-9 min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-3 text-xs"
+                    value={apiKeyValueByTeamId[selectedTeam.id] ?? ""}
+                    onChange={(e) => setApiKeyValueByTeamId((prev) => ({ ...prev, [selectedTeam.id]: e.target.value }))}
+                    placeholder="API Key 값"
+                    autoComplete="new-password"
+                    disabled={apiKeyLoadingTeamId === selectedTeam.id}
                   />
                   <button
                     type="button"
-                    className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium disabled:opacity-60"
-                    disabled={apiKeyLoadingTeamId === team.id}
-                    onClick={() => void registerTeamApiKey(team.id)}
+                    className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-zinc-300 bg-white text-zinc-600 hover:bg-zinc-50 disabled:opacity-50"
+                    aria-label={apiKeyRevealByTeamId[selectedTeam.id] ? "API Key 숨기기" : "API Key 보기"}
+                    disabled={apiKeyLoadingTeamId === selectedTeam.id}
+                    onClick={() =>
+                      setApiKeyRevealByTeamId((prev) => ({ ...prev, [selectedTeam.id]: !prev[selectedTeam.id] }))
+                    }
                   >
-                    {apiKeyLoadingTeamId === team.id ? "등록 중…" : "팀 API Key 등록"}
+                    {apiKeyRevealByTeamId[selectedTeam.id] ? (
+                      <EyeOff className="h-4 w-4" aria-hidden />
+                    ) : (
+                      <Eye className="h-4 w-4" aria-hidden />
+                    )}
                   </button>
                 </div>
+                <input
+                  type="number"
+                  step={0.01}
+                  min={0}
+                  className="h-9 w-full rounded-md border border-zinc-300 bg-white px-3 text-xs"
+                  value={apiKeyMonthlyBudgetByTeamId[selectedTeam.id] ?? ""}
+                  onChange={(e) => {
+                    const v = e.target.value
+                    if (v === "") {
+                      setApiKeyMonthlyBudgetByTeamId((prev) => ({ ...prev, [selectedTeam.id]: "" }))
+                      return
+                    }
+                    const n = Number(v)
+                    if (!Number.isFinite(n) || n < 0) return
+                    setApiKeyMonthlyBudgetByTeamId((prev) => ({ ...prev, [selectedTeam.id]: v }))
+                  }}
+                  onBlur={() =>
+                    setApiKeyMonthlyBudgetByTeamId((prev) => {
+                      const cur = prev[selectedTeam.id] ?? ""
+                      if (cur.trim() === "") return prev
+                      const next = normalizeBudgetNumericString(cur)
+                      if (next === cur) return prev
+                      return { ...prev, [selectedTeam.id]: next }
+                    })
+                  }
+                  placeholder="월 예산 USD"
+                  inputMode="decimal"
+                  autoComplete="off"
+                  disabled={apiKeyLoadingTeamId === selectedTeam.id}
+                />
+                <button
+                  type="button"
+                  className="h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium disabled:opacity-60"
+                  disabled={apiKeyLoadingTeamId === selectedTeam.id}
+                  onClick={() => void registerTeamApiKey(selectedTeam.id)}
+                >
+                  {apiKeyLoadingTeamId === selectedTeam.id ? "등록 중…" : "팀 API Key 등록"}
+                </button>
+              </div>
 
-                {(teamApiKeysByTeamId[team.id] ?? []).length > 0 ? (
-                  <ul className="space-y-2 text-xs text-zinc-700">
-                    {(teamApiKeysByTeamId[team.id] ?? []).map((apiKey) => {
-                      const isEditing =
-                        editingTeamApiKey?.teamId === team.id && editingTeamApiKey?.keyId === apiKey.id
-                      const updateKey = `${team.id}:${apiKey.id}`
-                      const updating = teamApiKeyUpdateLoading === updateKey
-                      const keyPendingDeletion = Boolean(apiKey.deletionRequestedAt)
-                      return (
-                        <li
-                          key={`${team.id}-api-key-${apiKey.id}`}
-                          className="rounded border border-zinc-200 bg-white px-2 py-2"
-                        >
-                          {!isEditing ? (
-                            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                              <div>
-                                <p>
-                                  {apiKey.provider} · {apiKey.alias}
-                                  {keyPendingDeletion ? (
-                                    <span className="ml-1.5 rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium text-zinc-700">
-                                      삭제 예정
-                                    </span>
-                                  ) : null}
-                                </p>
-                                <p className="text-[11px] text-zinc-500">
-                                  월 예산:{" "}
-                                  {formatBudgetUsd(apiKey.monthlyBudgetUsd ?? undefined) ?? "— (기존 데이터)"}
-                                </p>
-                                {keyPendingDeletion && apiKey.permanentDeletionAt ? (
-                                  <p className="text-[11px] text-amber-800">
-                                    영구 삭제 예정: {formatDeletionDeadline(apiKey.permanentDeletionAt)}
-                                    {typeof apiKey.deletionGraceDays === "number"
-                                      ? ` (${apiKey.deletionGraceDays}일 유예)`
-                                      : ""}
-                                  </p>
+              {(teamApiKeysByTeamId[selectedTeam.id] ?? []).length > 0 ? (
+                <ul className="space-y-2 text-xs text-zinc-700">
+                  {(teamApiKeysByTeamId[selectedTeam.id] ?? []).map((apiKey) => {
+                    const isEditing =
+                      editingTeamApiKey?.teamId === selectedTeam.id && editingTeamApiKey?.keyId === apiKey.id
+                    const updateKey = `${selectedTeam.id}:${apiKey.id}`
+                    const updating = teamApiKeyUpdateLoading === updateKey
+                    const keyPendingDeletion = Boolean(apiKey.deletionRequestedAt)
+                    return (
+                      <li
+                        key={`${selectedTeam.id}-api-key-${apiKey.id}`}
+                        className="rounded border border-zinc-200 bg-white px-2 py-2"
+                      >
+                        {!isEditing ? (
+                          <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                              <p>
+                                {apiKey.provider} · {apiKey.alias}
+                                {keyPendingDeletion ? (
+                                  <span className="ml-1.5 rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium text-zinc-700">
+                                    삭제 예정
+                                  </span>
                                 ) : null}
-                              </div>
-                              <button
-                                type="button"
-                                className="h-8 shrink-0 rounded-md border border-zinc-300 bg-white px-2 text-[11px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
-                                disabled={keyPendingDeletion}
-                                title={keyPendingDeletion ? "삭제 예정인 키는 수정할 수 없습니다" : undefined}
-                                onClick={() => startEditTeamApiKey(team.id, apiKey)}
-                              >
-                                수정
-                              </button>
-                              {isOwner ? (
-                                keyPendingDeletion ? (
-                                  <button
-                                    type="button"
-                                    className="h-8 shrink-0 rounded-md border border-zinc-300 bg-white px-2 text-[11px] font-medium disabled:opacity-50"
-                                    disabled={cancelDeleteLoadingKey === `${team.id}:${apiKey.id}`}
-                                    onClick={() => void cancelTeamApiKeyDeletion(team.id, apiKey.id)}
-                                  >
-                                    {cancelDeleteLoadingKey === `${team.id}:${apiKey.id}` ? "처리 중…" : "삭제 취소"}
-                                  </button>
-                                ) : (
-                                  <button
-                                    type="button"
-                                    className="h-8 shrink-0 rounded-md border border-red-300 bg-white px-2 text-[11px] font-medium text-red-600 disabled:opacity-50"
-                                    disabled={deleteLoadingKey === `${team.id}:${apiKey.id}`}
-                                    onClick={() => void deleteTeamApiKey(team.id, apiKey.id)}
-                                  >
-                                    {deleteLoadingKey === `${team.id}:${apiKey.id}` ? "처리 중…" : "삭제"}
-                                  </button>
-                                )
+                              </p>
+                              <p className="text-[11px] text-zinc-500">
+                                월 예산:{" "}
+                                {formatBudgetUsd(apiKey.monthlyBudgetUsd ?? undefined) ?? "— (기존 데이터)"}
+                              </p>
+                              {keyPendingDeletion && apiKey.permanentDeletionAt ? (
+                                <p className="text-[11px] text-amber-800">
+                                  영구 삭제 예정: {formatDeletionDeadline(apiKey.permanentDeletionAt)}
+                                  {typeof apiKey.deletionGraceDays === "number"
+                                    ? ` (${apiKey.deletionGraceDays}일 유예)`
+                                    : ""}
+                                </p>
                               ) : null}
                             </div>
-                          ) : (
-                            <div className="flex flex-col gap-2">
-                              <input
-                                className="h-8 rounded-md border border-zinc-300 bg-white px-2 text-xs"
-                                value={editTeamApiKeyAlias}
-                                onChange={(e) => setEditTeamApiKeyAlias(e.target.value)}
-                                placeholder="별칭"
-                                disabled={updating}
-                              />
-                              <input
-                                type="number"
-                                step={0.01}
-                                min={0}
-                                className="h-8 w-full max-w-[12rem] rounded-md border border-zinc-300 bg-white px-2 text-xs"
-                                value={editTeamApiKeyBudget}
-                                onChange={(e) => {
-                                  const v = e.target.value
-                                  if (v === "") {
-                                    setEditTeamApiKeyBudget("")
-                                    return
-                                  }
-                                  const n = Number(v)
-                                  if (!Number.isFinite(n) || n < 0) return
-                                  setEditTeamApiKeyBudget(v)
-                                }}
-                                onBlur={() =>
-                                  setEditTeamApiKeyBudget((prev) =>
-                                    prev.trim() === "" ? prev : normalizeBudgetNumericString(prev),
-                                  )
+                            <button
+                              type="button"
+                              className="h-8 shrink-0 rounded-md border border-zinc-300 bg-white px-2 text-[11px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
+                              disabled={keyPendingDeletion}
+                              title={keyPendingDeletion ? "삭제 예정인 키는 수정할 수 없습니다" : undefined}
+                              onClick={() => startEditTeamApiKey(selectedTeam.id, apiKey)}
+                            >
+                              수정
+                            </button>
+                            {isTeamOwnerByTeamId[selectedTeam.id] ? (
+                              keyPendingDeletion ? (
+                                <button
+                                  type="button"
+                                  className="h-8 shrink-0 rounded-md border border-zinc-300 bg-white px-2 text-[11px] font-medium disabled:opacity-50"
+                                  disabled={cancelDeleteLoadingKey === `${selectedTeam.id}:${apiKey.id}`}
+                                  onClick={() => void cancelTeamApiKeyDeletion(selectedTeam.id, apiKey.id)}
+                                >
+                                  {cancelDeleteLoadingKey === `${selectedTeam.id}:${apiKey.id}` ? "처리 중…" : "삭제 취소"}
+                                </button>
+                              ) : (
+                                <button
+                                  type="button"
+                                  className="h-8 shrink-0 rounded-md border border-red-300 bg-white px-2 text-[11px] font-medium text-red-600 disabled:opacity-50"
+                                  disabled={deleteLoadingKey === `${selectedTeam.id}:${apiKey.id}`}
+                                  onClick={() => void deleteTeamApiKey(selectedTeam.id, apiKey.id)}
+                                >
+                                  {deleteLoadingKey === `${selectedTeam.id}:${apiKey.id}` ? "처리 중…" : "삭제"}
+                                </button>
+                              )
+                            ) : null}
+                          </div>
+                        ) : (
+                          <div className="flex flex-col gap-2">
+                            <input
+                              className="h-8 rounded-md border border-zinc-300 bg-white px-2 text-xs"
+                              value={editTeamApiKeyAlias}
+                              onChange={(e) => setEditTeamApiKeyAlias(e.target.value)}
+                              placeholder="별칭"
+                              disabled={updating}
+                            />
+                            <input
+                              type="number"
+                              step={0.01}
+                              min={0}
+                              className="h-8 w-full max-w-[12rem] rounded-md border border-zinc-300 bg-white px-2 text-xs"
+                              value={editTeamApiKeyBudget}
+                              onChange={(e) => {
+                                const v = e.target.value
+                                if (v === "") {
+                                  setEditTeamApiKeyBudget("")
+                                  return
                                 }
-                                placeholder="월 예산 USD"
-                                inputMode="decimal"
+                                const n = Number(v)
+                                if (!Number.isFinite(n) || n < 0) return
+                                setEditTeamApiKeyBudget(v)
+                              }}
+                              onBlur={() =>
+                                setEditTeamApiKeyBudget((prev) =>
+                                  prev.trim() === "" ? prev : normalizeBudgetNumericString(prev),
+                                )
+                              }
+                              placeholder="월 예산 USD"
+                              inputMode="decimal"
+                              disabled={updating}
+                            />
+                            <div className="flex gap-2">
+                              <button
+                                type="button"
+                                className="h-8 rounded-md bg-black px-3 text-[11px] font-medium text-white disabled:opacity-60"
                                 disabled={updating}
-                              />
-                              <div className="flex gap-2">
-                                <button
-                                  type="button"
-                                  className="h-8 rounded-md bg-black px-3 text-[11px] font-medium text-white disabled:opacity-60"
-                                  disabled={updating}
-                                  onClick={() => void saveEditTeamApiKey(team.id)}
-                                >
-                                  {updating ? "저장 중…" : "저장"}
-                                </button>
-                                <button
-                                  type="button"
-                                  className="h-8 rounded-md border border-zinc-300 bg-white px-3 text-[11px] font-medium"
-                                  disabled={updating}
-                                  onClick={cancelEditTeamApiKey}
-                                >
-                                  취소
-                                </button>
-                              </div>
+                                onClick={() => void saveEditTeamApiKey(selectedTeam.id)}
+                              >
+                                {updating ? "저장 중…" : "저장"}
+                              </button>
+                              <button
+                                type="button"
+                                className="h-8 rounded-md border border-zinc-300 bg-white px-3 text-[11px] font-medium"
+                                disabled={updating}
+                                onClick={cancelEditTeamApiKey}
+                              >
+                                취소
+                              </button>
                             </div>
-                          )}
-                        </li>
-                      )
-                    })}
-                  </ul>
-                ) : (
-                  <p className="text-xs text-zinc-500">등록된 팀 API Key가 없습니다.</p>
-                )}
-              </div>
+                          </div>
+                        )}
+                      </li>
+                    )
+                  })}
+                </ul>
+              ) : (
+                <p className="text-xs text-zinc-500">등록된 팀 API Key가 없습니다.</p>
+              )}
+            </div>
 
-              {isOwner ? (
-                <div className="rounded-md border border-red-200 bg-red-50 p-3">
-                  <p className="text-xs text-zinc-600">팀장은 팀 API 키를 모두 정리한 뒤 팀을 삭제할 수 있습니다.</p>
-                  <button
-                    type="button"
-                    className="mt-2 rounded-md border border-red-300 bg-white px-3 py-1 text-xs font-medium text-red-600 disabled:opacity-50"
-                    disabled={deleteTeamLoadingId === team.id}
-                    onClick={() => void deleteTeam(team.id, team.name)}
-                  >
-                    {deleteTeamLoadingId === team.id ? "팀 삭제 중…" : "팀 삭제"}
-                  </button>
-                </div>
-              ) : null}
-              </div>
-              ) : null}
-            </li>
-            )
-          })}
-        </ul>
-      ) : null}
+                {isTeamOwnerByTeamId[selectedTeam.id] ? (
+                  <div className="rounded-md border border-red-200 bg-red-50 p-3">
+                    <p className="text-xs text-zinc-600">팀장은 팀 API 키를 모두 정리한 뒤 팀을 삭제할 수 있습니다.</p>
+                    <button
+                      type="button"
+                      className="mt-2 rounded-md border border-red-300 bg-white px-3 py-1 text-xs font-medium text-red-600 disabled:opacity-50"
+                      disabled={deleteTeamLoadingId === selectedTeam.id}
+                      onClick={() => void deleteTeam(selectedTeam.id, selectedTeam.name)}
+                    >
+                      {deleteTeamLoadingId === selectedTeam.id ? "팀 삭제 중…" : "팀 삭제"}
+                    </button>
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        )}
+      </section>
     </main>
   )
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> 

## 작업 내용
- **해당 서비스**: `Host (apps/web)`, `Shell (packages/shell)`, `Team (services/team-service)`
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
MFE(Micro Frontend) 아키텍처의 독립성을 강화하기 위해 **슬롯(Slot) 기반의 공용 레이아웃 오버라이드 구조**를 도입하고, 문서 정합성에 맞게 팀 관련 **라우트(`/teams`)를 표준화**했습니다. 호스트(Host)가 레이아웃을 강제하지 않고 Remote 앱이 자율성을 가지도록 구조를 크게 리팩터링했습니다.

## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [x] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- **MFE 슬롯 기반 레이아웃 분리 (`packages/shell`)**
  - `packages/shell/src/console-layout-override.tsx` 추가 (MFE별 레이아웃 독립 제어)
  - `primarySidebar`, `secondarySidebar`, `children` 슬롯을 통해 레이아웃 뼈대 제공
- **Host App 렌더링 최적화 (`apps/web`)**
  - 하드코딩되어 있던 자체 사이드바 마크업 제거 및 공용 쉘(`ConsoleSidebar`) 연결
  - Remote 페이지를 억지로 감싸던 2열 Wrapper를 제거하여 Team Remote 컴포넌트가 화면을 온전히 주도하도록 개선
- **라우트 및 네비게이션 정합성 통일**
  - RESTful 표준 및 기획 문서에 맞춰 `/team` 단수형 경로를 `/teams` 복수형으로 일괄 변경
  - 네비게이션 바 링크 및 내부 라우팅 의존성 모두 `/teams`로 동기화 완료

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부
*(본 PR은 프론트엔드 UI/UX 및 아키텍처 리팩토링으로 백엔드 인프라 변경 사항은 없습니다.)*

## 📸 스크린샷 / 테스트 결과 (선택)
*(로컬에서 띄운 `/teams` 화면 캡처나 2-Depth 탭 구조 화면을 하나 첨부하시면 좋습니다!)*
<img width="1919" height="907" alt="image" src="https://github.com/user-attachments/assets/4196e531-2ba8-498a-8f26-c79676e078cb" />

## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- **아키텍처 리뷰:** `Host`가 껍데기만 쥐고, 실제 알맹이는 `Remote`가 슬롯으로 끼워 넣는 MFE 구조가 잘 지켜졌는지 확인 부탁드립니다.
- **예나님(Usage/대시보드 담당):** 이제 우측 메인 영역의 도화지(max-width) 제한이 풀렸습니다! 대시보드 탭 구역에서 그래프 2x3 배치 테스트해 보시고 공간 부족하면 말씀해 주세요.
- **QA:** `/teams` 라우트로 접속 시 404 에러가 나는 곳이 없는지, 네비게이션 이동이 매끄러운지 체크해 주시면 감사하겠습니다.