### PR TITLE
Feature/fix billing service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,9 +93,13 @@ NOTIFICATION_SERVICE_PORT=18096
 NOTIFICATION_INTERNAL_SECRET=
 
 # billing → identity 월 예산(선택, docs/billing-identity-budget.md)
-# BILLING_IDENTITY_ENABLED=true
-# BILLING_IDENTITY_BASE_URL=http://localhost:8090
-# BILLING_IDENTITY_BUDGET_PATH=/api/v1/users/{userId}/budget
+BILLING_IDENTITY_ENABLED=true
+BILLING_IDENTITY_BASE_URL=http://localhost:8090
+BILLING_IDENTITY_BUDGET_PATH=/api/identity/v1/users/budget?email={userId}
+
+# billing pricing seed (local/dev)
+# When true, inserts missing rows from OfficialProviderModelPriceCatalog even if the table is not empty.
+BILLING_PRICING_SEED_MISSING=true
 
 # scripts/verify-expenditure-chain.ps1|sh — GATEWAY_DEV_MODE=false 일 때 2단계(게이트웨이 JWT 경로) 검사용 (선택)
 # 게이트웨이는 identity 가 발급한 JWT 를 검증하므로 GATEWAY_JWT_SECRET 과 identity 의 JWT_SECRET(서명 키)이 같아야 한다.

--- a/docs/billing-identity-budget.md
+++ b/docs/billing-identity-budget.md
@@ -6,7 +6,9 @@
 
 - `BILLING_IDENTITY_ENABLED` — `true`로 켠다.
 - `BILLING_IDENTITY_BASE_URL` — identity HTTP 베이스 (예: `http://localhost:8090`).
-- `BILLING_IDENTITY_BUDGET_PATH` — Spring 설정 `billing.identity.budget-path-template`에 매핑된다. `{userId}` 플레이스홀더를 쓸 수 있다. 예: `/api/identity/v1/users/{userId}/budget`.
+- `BILLING_IDENTITY_BUDGET_PATH` — Spring 설정 `billing.identity.budget-path-template`에 매핑된다. `{userId}` 플레이스홀더를 쓸 수 있다.
+  - 이메일 기반(권장, `X-User-Id`가 이메일인 구성): `/api/identity/v1/users/budget?email={userId}`
+  - 숫자 userId 기반: `/api/identity/v1/users/{userId}/budget`
 
 ## 응답 JSON
 

--- a/docs/billing-pricing-catalog-ops.md
+++ b/docs/billing-pricing-catalog-ops.md
@@ -21,6 +21,18 @@
 2. **새 모델** 추가 시 동일하게 `provider_model_price`에 행을 넣는다.
 3. 변경 후 **로컬·스테이징**에서 지출 집계 샘플 이벤트로 금액을 검증한다.
 
+## OpenAI 스냅샷 모델(날짜 suffix) 주의
+
+OpenAI 이벤트의 `model`이 `gpt-5.4-mini-2026-03-17`처럼 **날짜 suffix**를 포함할 수 있다.
+`provider_model_price`는 `(provider, model)` **완전 일치**로 매칭하므로, DB에 `gpt-5.4-mini`만 있고 스냅샷 ID가 들어오면 단가를 못 찾아 비용이 `0`이 될 수 있다.
+
+로컬/개발 편의를 위해 billing은 다음 정책을 지원한다:
+
+- OpenAI의 `-YYYY-MM-DD` suffix 패턴이 들어온 모델은 base 모델(`gpt-5.4-mini`) 단가를 먼저 조회하고,
+- base 단가가 존재하면 스냅샷 모델명으로 **alias 단가 row를 자동으로 upsert**해서 이후 이벤트부터는 DB가 따라가도록 한다.
+
+> 운영 환경에서는 가격 정책(스냅샷 모델이 base와 동일 단가인지)을 팀 기준으로 확인하고, 필요하면 별도 row를 명시적으로 관리하는 것을 권장한다.
+
 ## 참고
 
 - 집계 일자·월 경계는 **KST**를 사용한다 (`BillingRecordedService`, `MonthlyExpenditureFinalizeScheduler`).

--- a/docs/billing-service-overview-20260412.md
+++ b/docs/billing-service-overview-20260412.md
@@ -56,6 +56,7 @@
   - `GET /daily` — 일별 비용 시계열
   - `GET /monthly` — 월별 비용 시계열(확정 여부 포함)
   - `GET /api-keys` — 사용자가 본 API Key 목록(공급사 필터 선택)
+  - `GET /me` — 현재 사용자 식별자(`X-User-Id`) 반환(웹 UI 상단 표시 용도)
   - `POST /team/month-rollup` — 팀(또는 관리) 뷰: 여러 플랫폼 `userId`에 대해 지정 월의 `monthly_expenditure_agg` 합산(본문: `TeamMonthRollupRequest`). 호출자는 **노출 가능한 userId만** 넘기도록 BFF/Gateway에서 제한하는 것을 전제로 한다.
 - **인증**: Gateway가 넘기는 `X-User-Id` 필수; `billing.gateway.shared-secret`이 설정된 경우 `X-Gateway-Auth` 일치 필요.
 
@@ -103,11 +104,13 @@
 | `GET /api/v1/expenditure/daily` | 동일 | 일자별 `totalCostUsd` 시계열(`DailyExpenditurePoint`). |
 | `GET /api/v1/expenditure/monthly` | `apiKeyId`, `from`, `to` (**provider 없음**) | 월 시작일(`month_start_date`)별 누적 비용 + `isFinalized` 플래그(`MonthlyExpenditurePoint`). |
 | `GET /api/v1/expenditure/api-keys` | `provider` 선택 | `billing_user_api_key_seen`에서 해당 사용자의 API Key·provider·`firstSeenAt` 목록. provider 생략 시 전체. |
+| `GET /api/v1/expenditure/me` | (없음) | `{ userId }` 반환. 웹 UI에서 “현재 사용자 식별자” 표시 및 예산 연동 상태 설명에 사용. |
 | `POST /api/v1/expenditure/team/month-rollup` | JSON 본문 `userIds`, `monthStartDate`(해당 월의 **1일** 필수, 최대 500명) | `monthly_expenditure_agg`에서 해당 월·user 집합에 대한 합계 및 사용자별 비용(`TeamMonthRollupResponse`). |
 
 **기간 제한**: `from`~`to` 포함 일수가 `billing.analytics.max-range-days`(기본 400)를 넘으면 `IllegalArgumentException` → HTTP 400.
 
 **예산 연동**: `billing.identity.enabled=true`이고 `base-url`·`budget-path-template`이 유효할 때만 `IdentityBudgetClient`가 GET으로 JSON을 읽고, 루트에 `monthlyBudgetUsd` 필드가 있으면 요약에 포함. 404·비활성·오류 시 예산 필드는 null에 가깝게 동작(클라이언트는 empty optional).
+`budget-path-template`에 `{userId}`가 들어가고 이메일을 쿼리에 넣는 구성(예: `...?email={userId}`)에서도 깨지지 않도록 billing은 URL-safe 인코딩으로 URI를 구성한다.
 
 ### 4.8 스케줄러 (`MonthlyExpenditureFinalizeScheduler`)
 
@@ -119,6 +122,7 @@
 
 - 애플리케이션 기동 시 `provider_model_price` **행 수가 0**일 때만 카탈로그 행을 INSERT.
 - 금액·모델 ID·공식 URL·as-of는 카탈로그 클래스 및 `private-docs` 설계 문서에 정의된 스냅샷을 따른다(런타임 크롤링 없음).
+- 로컬/개발에서 기존 DB를 재사용하는 경우, `billing.pricing.seed-missing=true`(또는 `BILLING_PRICING_SEED_MISSING=true`)로 “카탈로그에 있는데 DB에 없는 row만” 보강 삽입할 수 있다.
 
 ### 4.10 Next.js BFF (`services/billing-service/web`)
 
@@ -126,6 +130,8 @@
 - **인증**: 쿠키 `access_token`을 `Authorization: Bearer`로 전달.
 - **게이트웨이 개발 모드**(`GATEWAY_DEV_MODE`): Identity `GET /api/auth/session`으로 이메일 등을 받아 **`X-User-Id`**를 세팅(운영에서는 Gateway가 사용자 식별 헤더를 붙이는 패턴).
 - **환경 변수**: `API_GATEWAY_URL` 필수, 개발 모드 시 `IDENTITY_SERVICE_URL` 필수.
+  - 지출 화면은 기간(`from`, `to`)을 프리셋(최근 7/30/90일, 이번 달) 또는 커스텀 날짜로 선택해 `/api/expenditure/summary|daily|monthly`에 반영한다.
+  - 팀 모드 집계는 월 선택(type="month") UI에서 선택한 월의 `YYYY-MM-01`을 `monthStartDate`로 전송한다.
 
 ### 4.11 기타 런타임 구성
 

--- a/services/billing-service/src/main/java/com/eevee/billingservice/api/ExpenditureController.java
+++ b/services/billing-service/src/main/java/com/eevee/billingservice/api/ExpenditureController.java
@@ -85,6 +85,11 @@ public class ExpenditureController {
         return expenditureQueryService.listApiKeys(userId, provider);
     }
 
+    @GetMapping("/me")
+    public MeResponse me(HttpServletRequest request) {
+        return new MeResponse(currentUser(request));
+    }
+
     /**
      * Team (or admin) view: sum {@code monthly_expenditure_agg} for many platform user ids for one calendar month.
      * Caller must only pass ids the user is allowed to see (enforced at BFF/Gateway in production).
@@ -106,5 +111,8 @@ public class ExpenditureController {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> badRequest(IllegalArgumentException ex, WebRequest req) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    public record MeResponse(String userId) {
     }
 }

--- a/services/billing-service/src/main/java/com/eevee/billingservice/integration/IdentityBudgetClient.java
+++ b/services/billing-service/src/main/java/com/eevee/billingservice/integration/IdentityBudgetClient.java
@@ -8,9 +8,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.math.BigDecimal;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 /**
@@ -38,12 +40,18 @@ public class IdentityBudgetClient {
         if (base == null || base.isBlank() || template == null || template.isBlank()) {
             return Optional.empty();
         }
-        String path = template.contains("{userId}")
-                ? template.replace("{userId}", userId)
-                : template;
         String normalizedBase = base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
-        String normalizedPath = path.startsWith("/") ? path : "/" + path;
-        URI uri = URI.create(normalizedBase + normalizedPath);
+        String normalizedTemplate = template.startsWith("/") ? template : "/" + template;
+        String uriTemplate = normalizedBase + normalizedTemplate;
+        URI uri = template.contains("{userId}")
+                ? UriComponentsBuilder.fromUriString(uriTemplate)
+                .buildAndExpand(userId)
+                .encode(StandardCharsets.UTF_8)
+                .toUri()
+                : UriComponentsBuilder.fromUriString(uriTemplate)
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUri();
 
         try {
             String body = RestClient.create()

--- a/services/billing-service/src/main/java/com/eevee/billingservice/pricing/OfficialProviderModelPriceCatalog.java
+++ b/services/billing-service/src/main/java/com/eevee/billingservice/pricing/OfficialProviderModelPriceCatalog.java
@@ -19,13 +19,13 @@ public final class OfficialProviderModelPriceCatalog {
     /**
      * Calendar date when the numbers below were checked against the official pages (YYYY-MM-DD).
      */
-    public static final String DOCUMENTED_AS_OF = "2026-04-11";
+    public static final String DOCUMENTED_AS_OF = "2026-04-17";
 
     /** Google AI Gemini API pricing (Korean page). */
     public static final String REFERENCE_URL_GOOGLE_GEMINI = "https://ai.google.dev/gemini-api/docs/pricing?hl=ko";
 
-    /** OpenAI consumer API pricing (Korean). */
-    public static final String REFERENCE_URL_OPENAI = "https://openai.com/ko-KR/api/pricing/";
+    /** OpenAI API pricing table. */
+    public static final String REFERENCE_URL_OPENAI = "https://openai.com/api/pricing";
 
     /**
      * OpenAI model matrix with per-model input/output USD (Standard tier, per 1M tokens).
@@ -112,8 +112,62 @@ public final class OfficialProviderModelPriceCatalog {
                         new BigDecimal("0.15"),
                         new BigDecimal("0.60"),
                         DEFAULT_VALID_FROM,
-                        REFERENCE_URL_OPENAI_PLATFORM_DOCS,
-                        "gpt-4o-mini: Standard tier, input/output USD per 1M tokens (platform pricing table)"
+                        REFERENCE_URL_OPENAI,
+                        "gpt-4o-mini: Standard tier, input/output USD per 1M tokens (OpenAI API pricing table)"
+                ),
+                new CatalogRow(
+                        AiProvider.OPENAI,
+                        "gpt-4o",
+                        new BigDecimal("2.50"),
+                        new BigDecimal("10.00"),
+                        DEFAULT_VALID_FROM,
+                        REFERENCE_URL_OPENAI,
+                        "gpt-4o: Standard tier, input/output USD per 1M tokens (OpenAI API pricing table)"
+                ),
+                new CatalogRow(
+                        AiProvider.OPENAI,
+                        "gpt-4.1",
+                        new BigDecimal("5.00"),
+                        new BigDecimal("15.00"),
+                        DEFAULT_VALID_FROM,
+                        REFERENCE_URL_OPENAI,
+                        "gpt-4.1: Standard tier, input/output USD per 1M tokens (OpenAI API pricing table)"
+                ),
+                new CatalogRow(
+                        AiProvider.OPENAI,
+                        "gpt-4.1-mini",
+                        new BigDecimal("0.30"),
+                        new BigDecimal("1.20"),
+                        DEFAULT_VALID_FROM,
+                        REFERENCE_URL_OPENAI,
+                        "gpt-4.1-mini: Standard tier, input/output USD per 1M tokens (OpenAI API pricing table)"
+                ),
+                new CatalogRow(
+                        AiProvider.OPENAI,
+                        "gpt-4.1-nano",
+                        new BigDecimal("0.10"),
+                        new BigDecimal("0.40"),
+                        DEFAULT_VALID_FROM,
+                        REFERENCE_URL_OPENAI,
+                        "gpt-4.1-nano: Standard tier, input/output USD per 1M tokens (OpenAI API pricing table)"
+                ),
+                new CatalogRow(
+                        AiProvider.OPENAI,
+                        "gpt-5.4",
+                        new BigDecimal("2.50"),
+                        new BigDecimal("15.00"),
+                        DEFAULT_VALID_FROM,
+                        REFERENCE_URL_OPENAI,
+                        "gpt-5.4: Standard tier, input/output USD per 1M tokens (OpenAI API pricing table)"
+                ),
+                new CatalogRow(
+                        AiProvider.OPENAI,
+                        "gpt-5.4-mini",
+                        new BigDecimal("0.75"),
+                        new BigDecimal("4.50"),
+                        DEFAULT_VALID_FROM,
+                        REFERENCE_URL_OPENAI,
+                        "gpt-5.4-mini: Standard tier, input/output USD per 1M tokens (OpenAI API pricing table)"
                 ),
                 new CatalogRow(
                         AiProvider.OPENAI,
@@ -122,7 +176,7 @@ public final class OfficialProviderModelPriceCatalog {
                         new BigDecimal("1.25"),
                         DEFAULT_VALID_FROM,
                         REFERENCE_URL_OPENAI,
-                        "GPT-5.4 nano: input/output USD per 1M tokens (openai.com API pricing, Standard)"
+                        "gpt-5.4-nano: Standard tier, input/output USD per 1M tokens (OpenAI API pricing table)"
                 ),
                 new CatalogRow(
                         AiProvider.ANTHROPIC,

--- a/services/billing-service/src/main/java/com/eevee/billingservice/service/BillingRecordedService.java
+++ b/services/billing-service/src/main/java/com/eevee/billingservice/service/BillingRecordedService.java
@@ -7,6 +7,7 @@ import com.eevee.billingservice.repository.BillingProcessedEventRepository;
 import com.eevee.billingservice.repository.ProviderModelPriceRepository;
 import com.eevee.usage.events.TokenUsage;
 import com.eevee.usage.events.UsageRecordedEvent;
+import com.eevee.usage.events.AiProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
@@ -20,12 +21,14 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 @Service
 public class BillingRecordedService {
 
     private static final Logger log = LoggerFactory.getLogger(BillingRecordedService.class);
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final Pattern OPENAI_DATED_SNAPSHOT_SUFFIX = Pattern.compile("^(?<base>.+)-\\d{4}-\\d{2}-\\d{2}$");
 
     private final BillingProcessedEventRepository processedEventRepository;
     private final ProviderModelPriceRepository priceRepository;
@@ -157,6 +160,9 @@ public class BillingRecordedService {
                 .stream()
                 .findFirst()
                 .orElse(null);
+        if (price == null) {
+            price = resolveAliasedPrice(event.provider(), model, occurredAt);
+        }
 
         BigDecimal cost = ExpenditureCostCalculator.compute(event.tokenUsage(), price);
         ExpenditureCostCalculator.NormalizedTokens tokens = ExpenditureCostCalculator.normalizeTokens(event.tokenUsage());
@@ -182,6 +188,50 @@ public class BillingRecordedService {
             return tu.model().trim();
         }
         return null;
+    }
+
+    /**
+     * OpenAI models may include dated snapshot suffixes (ex: {@code gpt-5.4-mini-2026-03-17}).
+     * Billing pricing is keyed by exact (provider, model), so we resolve against the base model
+     * and persist a compatible alias price row for future events.
+     */
+    private ProviderModelPriceEntity resolveAliasedPrice(AiProvider provider, String model, Instant at) {
+        if (provider != AiProvider.OPENAI || model == null || model.isBlank()) {
+            return null;
+        }
+        var m = OPENAI_DATED_SNAPSHOT_SUFFIX.matcher(model);
+        if (!m.matches()) {
+            return null;
+        }
+        String base = m.group("base");
+        if (base == null || base.isBlank() || base.equals(model)) {
+            return null;
+        }
+
+        ProviderModelPriceEntity basePrice = priceRepository
+                .findActivePrices(provider, base, at, PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .orElse(null);
+        if (basePrice == null) {
+            return null;
+        }
+
+        Instant validFrom = basePrice.getValidFrom();
+        Instant validTo = basePrice.getValidTo();
+        boolean exists = priceRepository.existsByProviderAndModelAndValidFromAndValidTo(provider, model, validFrom, validTo);
+        if (!exists) {
+            priceRepository.save(new ProviderModelPriceEntity(
+                    provider,
+                    model,
+                    validFrom,
+                    validTo,
+                    basePrice.getInputUsdPerMillionTokens(),
+                    basePrice.getOutputUsdPerMillionTokens()
+            ));
+            log.info("Seeded OpenAI snapshot model price alias baseModel={} snapshotModel={}", base, model);
+        }
+        return basePrice;
     }
 
     private record BillableComputation(

--- a/services/billing-service/web/src/components/expenditure/expenditure-dashboard.tsx
+++ b/services/billing-service/web/src/components/expenditure/expenditure-dashboard.tsx
@@ -20,6 +20,8 @@ const PROVIDERS: { value: AiProviderCode; label: string }[] = [
   { value: "ANTHROPIC", label: "Anthropic" },
 ];
 
+const MAX_RANGE_DAYS = 400;
+
 function expenditureApiPath(path: string): string {
   const base = (process.env.NEXT_PUBLIC_BASE_PATH ?? "").replace(/\/$/, "");
   const normalized = path.startsWith("/") ? path : `/${path}`;
@@ -58,7 +60,8 @@ async function fetchTeamMemberUserIds(teamId: string): Promise<string[]> {
     cache: "no-store",
   });
   if (!res.ok) {
-    return [];
+    const text = await res.text().catch(() => "");
+    throw new Error(text || `팀 멤버 조회 실패 (HTTP ${res.status})`);
   }
   const json: unknown = await res.json();
   if (typeof json !== "object" || json === null) return [];
@@ -95,18 +98,52 @@ export function ExpenditureDashboard() {
   const [provider, setProvider] = useState<AiProviderCode>("GOOGLE");
   const [apiKeys, setApiKeys] = useState<ApiKeySeen[]>([]);
   const [apiKeyId, setApiKeyId] = useState<string>("");
-  const [range] = useState(() => rangeLastDays(30));
+  const [rangePreset, setRangePreset] = useState<"last7" | "last30" | "last90" | "thisMonth" | "custom">("last30");
+  const [customFrom, setCustomFrom] = useState<string>(() => rangeLastDays(30).from);
+  const [customTo, setCustomTo] = useState<string>(() => rangeLastDays(30).to);
   const [summary, setSummary] = useState<ExpenditureSummary | null>(null);
   const [daily, setDaily] = useState<DailyPoint[]>([]);
   const [monthly, setMonthly] = useState<MonthlyPoint[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [meUserId, setMeUserId] = useState<string | null>(null);
 
   const [teams, setTeams] = useState<MyTeam[]>([]);
   const [selectedTeamId, setSelectedTeamId] = useState("");
   const [teamRollup, setTeamRollup] = useState<TeamMonthRollup | null>(null);
   const [teamLoading, setTeamLoading] = useState(false);
   const [teamsLoading, setTeamsLoading] = useState(false);
+  const [teamMonth, setTeamMonth] = useState<string>(() => currentMonthStartKst().slice(0, 7));
+
+  const range = useMemo(() => {
+    if (rangePreset === "last7") return rangeLastDays(7);
+    if (rangePreset === "last30") return rangeLastDays(30);
+    if (rangePreset === "last90") return rangeLastDays(90);
+    if (rangePreset === "thisMonth") {
+      return { from: currentMonthStartKst(), to: rangeLastDays(1).to };
+    }
+    return { from: customFrom, to: customTo };
+  }, [customFrom, customTo, rangePreset]);
+
+  const rangeUi = useMemo(() => {
+    const iso = /^\d{4}-\d{2}-\d{2}$/;
+    if (!iso.test(range.from) || !iso.test(range.to)) {
+      return { ok: false as const, message: "날짜 형식이 올바르지 않습니다 (YYYY-MM-DD)" };
+    }
+    const fromD = new Date(`${range.from}T00:00:00Z`);
+    const toD = new Date(`${range.to}T00:00:00Z`);
+    if (Number.isNaN(fromD.getTime()) || Number.isNaN(toD.getTime())) {
+      return { ok: false as const, message: "날짜 값이 올바르지 않습니다" };
+    }
+    if (fromD.getTime() > toD.getTime()) {
+      return { ok: false as const, message: "from 날짜가 to 날짜보다 이후입니다" };
+    }
+    const diffDays = Math.floor((toD.getTime() - fromD.getTime()) / (24 * 60 * 60 * 1000)) + 1;
+    if (diffDays > MAX_RANGE_DAYS) {
+      return { ok: false as const, message: `최대 ${MAX_RANGE_DAYS}일 범위까지 조회할 수 있습니다` };
+    }
+    return { ok: true as const, days: diffDays };
+  }, [range.from, range.to]);
 
   const loadApiKeys = useCallback(async () => {
     const q = new URLSearchParams();
@@ -130,11 +167,24 @@ export function ExpenditureDashboard() {
     });
   }, [loadApiKeys]);
 
+  useEffect(() => {
+    void fetchJson<{ userId: string }>(expenditureApiPath("/api/expenditure/me"))
+      .then((r) => setMeUserId(typeof r.userId === "string" && r.userId.length > 0 ? r.userId : null))
+      .catch(() => setMeUserId(null));
+  }, []);
+
   const loadSeries = useCallback(async () => {
     if (!apiKeyId) {
       setSummary(null);
       setDaily([]);
       setMonthly([]);
+      return;
+    }
+    if (!rangeUi.ok) {
+      setSummary(null);
+      setDaily([]);
+      setMonthly([]);
+      setError(rangeUi.message);
       return;
     }
     setLoading(true);
@@ -165,7 +215,7 @@ export function ExpenditureDashboard() {
     } finally {
       setLoading(false);
     }
-  }, [apiKeyId, provider, range.from, range.to]);
+  }, [apiKeyId, provider, range.from, range.to, rangeUi]);
 
   useEffect(() => {
     void loadSeries();
@@ -217,12 +267,10 @@ export function ExpenditureDashboard() {
       const userIds = await fetchTeamMemberUserIds(tid);
       if (userIds.length === 0) {
         setTeamRollup(null);
-        setError(
-          "팀 멤버를 불러오지 못했습니다. 단일 오리진(예: identity :3000)에서 지출을 열었는지, 팀 권한이 있는지 확인하세요."
-        );
+        setError("팀에 멤버가 없습니다.");
         return;
       }
-      const monthStart = currentMonthStartKst();
+      const monthStart = `${teamMonth}-01`;
       const raw = await fetchJsonPost<{
         totalCostUsd: number;
         byUser: { userId: string; costUsd: number }[];
@@ -236,11 +284,15 @@ export function ExpenditureDashboard() {
       });
     } catch (e: unknown) {
       setTeamRollup(null);
-      setError(e instanceof Error ? e.message : "팀 집계를 불러오지 못했습니다");
+      setError(
+        e instanceof Error
+          ? e.message
+          : "팀 집계를 불러오지 못했습니다 (단일 오리진/권한/게이트웨이 설정을 확인하세요)"
+      );
     } finally {
       setTeamLoading(false);
     }
-  }, [selectedTeamId]);
+  }, [selectedTeamId, teamMonth]);
 
   const budgetUi = useMemo(() => {
     const total = summary?.totalCostUsd ?? null;
@@ -289,6 +341,18 @@ export function ExpenditureDashboard() {
         <p className="text-sm text-muted-foreground">
           프로바이더와 API 키를 선택한 뒤 기간별 비용을 확인합니다. 표시 금액은 실제 결제가 아니라 사용 로그·단가 기준 추정(USD)입니다.
         </p>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <span>사용자: {meUserId ?? "—"}</span>
+          <span className="opacity-60">•</span>
+          <span>
+            예산 연동:{" "}
+            {summary?.monthlyBudgetUsd != null
+              ? "표시됨"
+              : summary
+                ? "미표시 (Identity 연동 꺼짐/미설정/예산 없음 가능)"
+                : "—"}
+          </span>
+        </div>
       </header>
 
       {viewMode === "personal" && apiKeyId && budgetUi ? (
@@ -405,6 +469,18 @@ export function ExpenditureDashboard() {
                 )}
               </select>
             </label>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="text-muted-foreground">월</span>
+              <input
+                className="h-9 w-[160px] rounded-md border border-input bg-background px-2 text-sm"
+                type="month"
+                value={teamMonth}
+                onChange={(e) => {
+                  setTeamMonth(e.target.value);
+                  setTeamRollup(null);
+                }}
+              />
+            </label>
             <button
               type="button"
               className="h-9 rounded-md border border-border bg-background px-3 text-sm hover:bg-muted disabled:opacity-50"
@@ -422,7 +498,7 @@ export function ExpenditureDashboard() {
               {teamLoading ? "불러오는 중…" : "집계"}
             </button>
           </div>
-          <p className="text-xs text-muted-foreground">집계 월 시작일(KST): {currentMonthStartKst()}</p>
+          <p className="text-xs text-muted-foreground">집계 월 시작일: {teamMonth}-01 (KST 기준 월)</p>
           {teamRollup ? (
             <div className="space-y-3">
               <p className="text-lg font-semibold tabular-nums">
@@ -486,8 +562,73 @@ export function ExpenditureDashboard() {
                 )}
               </select>
             </label>
-            <div className="text-xs text-muted-foreground">
-              기간: {range.from} ~ {range.to} (30일)
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">기간</p>
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <button
+                    type="button"
+                    className={`h-8 rounded-md border border-border px-2 text-xs ${rangePreset === "last7" ? "bg-muted font-medium" : "bg-background hover:bg-muted"}`}
+                    onClick={() => setRangePreset("last7")}
+                  >
+                    최근 7일
+                  </button>
+                  <button
+                    type="button"
+                    className={`h-8 rounded-md border border-border px-2 text-xs ${rangePreset === "last30" ? "bg-muted font-medium" : "bg-background hover:bg-muted"}`}
+                    onClick={() => setRangePreset("last30")}
+                  >
+                    최근 30일
+                  </button>
+                  <button
+                    type="button"
+                    className={`h-8 rounded-md border border-border px-2 text-xs ${rangePreset === "last90" ? "bg-muted font-medium" : "bg-background hover:bg-muted"}`}
+                    onClick={() => setRangePreset("last90")}
+                  >
+                    최근 90일
+                  </button>
+                  <button
+                    type="button"
+                    className={`h-8 rounded-md border border-border px-2 text-xs ${rangePreset === "thisMonth" ? "bg-muted font-medium" : "bg-background hover:bg-muted"}`}
+                    onClick={() => setRangePreset("thisMonth")}
+                  >
+                    이번 달
+                  </button>
+                  <button
+                    type="button"
+                    className={`h-8 rounded-md border border-border px-2 text-xs ${rangePreset === "custom" ? "bg-muted font-medium" : "bg-background hover:bg-muted"}`}
+                    onClick={() => setRangePreset("custom")}
+                  >
+                    직접 선택
+                  </button>
+                </div>
+              </div>
+              {rangePreset === "custom" ? (
+                <div className="flex flex-wrap items-end gap-2">
+                  <label className="flex flex-col gap-1 text-sm">
+                    <span className="text-xs text-muted-foreground">from</span>
+                    <input
+                      className="h-8 w-[150px] rounded-md border border-input bg-background px-2 text-xs"
+                      type="date"
+                      value={customFrom}
+                      onChange={(e) => setCustomFrom(e.target.value)}
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1 text-sm">
+                    <span className="text-xs text-muted-foreground">to</span>
+                    <input
+                      className="h-8 w-[150px] rounded-md border border-input bg-background px-2 text-xs"
+                      type="date"
+                      value={customTo}
+                      onChange={(e) => setCustomTo(e.target.value)}
+                    />
+                  </label>
+                </div>
+              ) : null}
+              <div className="text-xs text-muted-foreground">
+                {range.from} ~ {range.to}
+                {rangeUi.ok ? ` (${rangeUi.days}일)` : ""}
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- N/A

## 작업 내용
- **해당 서비스**: Billing (`services/billing-service` backend + `services/billing-service/web`)
- OpenAI 텍스트 모델 단가 seed 카탈로그 확장
- Expenditure 대시보드 기간 선택(프리셋 + 커스텀 from/to) UI 추가 및 `from/to` 쿼리 반영
- Identity 예산 연동에서 이메일 기반 `{userId}` 템플릿 URL 인코딩 안정화
- 상단 바에 현재 userId(email) 및 예산 연동 상태 표시
- 팀 모드(월 롤업) 구현 상태 확인 및 UX/검증 보강 포인트 점검

## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- **OpenAI 단가 seed 확장**
  - `OfficialProviderModelPriceCatalog.seedRows()`에 OpenAI 주요 텍스트 모델 단가(USD / 1M input/output tokens)를 broad 범위로 추가
  - 최소 포함(확정 단가)
    - `gpt-5.4`: input 2.50 / output 15.00
    - `gpt-5.4-mini`: input 0.75 / output 4.50
    - `gpt-5.4-nano`: input 0.20 / output 1.25
  - 단가 출처: `openai.com/api/pricing`, `developers.openai.com/api/docs/pricing` (as-of/URL 메타 갱신)
  - 로컬/개발에서 기존 DB가 채워져 있을 경우 `BILLING_PRICING_SEED_MISSING=true`로 누락 row만 보강(멱등)

- **기간 지정 조회 UX**
  - `ExpenditureDashboard`에 기간 선택 UI 추가
    - 프리셋: 최근 7/30/90일, 이번 달
    - 커스텀: `from/to` 날짜 입력 + 유효성(빈값/역전/최대일수 초과) 프런트 선검증
  - 선택된 range를 쿼리(`from`, `to`)에 반영해 `summary/daily/monthly` 재조회
  - 범위 초과 등 400 에러 메시지를 사용자에게 이해 가능한 형태로 노출

- **Identity 예산 연동 안정화 + 상단 바**
  - `IdentityBudgetClient`에서 `{userId}` 치환 시 URL-safe 인코딩 적용(이메일 `@`, `+` 등 포함 케이스 안정화)
  - 상단 바에 현재 `userId(email)` 및 예산 연동 상태 표시
    - (필요 시) backend `GET /api/v1/expenditure/me`로 `{ userId: string }` 제공

- **팀 모드 점검**
  - 백엔드: `POST /api/v1/expenditure/team/month-rollup` 존재 확인
  - web: 팀 목록/멤버 로드 후 userIds로 롤업 호출 흐름 존재 확인
  - 보강 포인트 점검: 월 시작일(해당 월 1일) 처리, 멤버 0명 메시지, 팀 서비스 실패 시 에러/폴백

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
- Seed 확인
  - `BILLING_PRICING_SEED_MISSING=true`로 기동 후 `provider_model_price`에 `OPENAI/gpt-5.4-mini` 등 row 생성 확인
- 기간 조회
  - 프리셋/커스텀 날짜 변경 시 `summary/daily/monthly`가 동일 `from/to`로 재조회되는지 확인
  - 최대 범위 초과 시 “최대 N일” 형태로 안내되는지 확인
- Identity 예산
  - 이메일 기반 템플릿 설정 시 `summary.monthlyBudgetUsd` 노출 확인
  - 이메일에 `@` 포함 시에도 호출이 깨지지 않는지(인코딩) 확인
- 팀 모드
  - 팀 선택 → 멤버 로드 → 롤업 호출 → 사용자별/총합 표시 정상 확인

## 리뷰 요구사항
- 예산 연동 상태 문구(꺼짐/설정 누락/예산 없음(404) 등)가 사용자가 오해하지 않게 충분히 명확한지 확인 부탁드립니다.
- 기간 선택 UX에서 `from/to` 유효성 및 최대 범위 제한 안내가 자연스러운지 봐주세요.