### PR TITLE
Fix/notification service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,13 @@ GATEWAY_BILLING_URI=http://host.docker.internal:8095
 # Docker Compose: notification-service 호스트 포트(좌측). 컨테이너 내부 포트는 8096 고정.
 # 로컬에서 8096이 다른 프로세스에 의해 점유되는 경우가 흔해 기본값을 18096으로 둔다.
 NOTIFICATION_SERVICE_PORT=18096
+# Compose `notification-service` → RabbitMQ 팀 도메인 큐 소비 (team-service 기본 exchange/routing 과 맞춤: team.events / team-member-added)
+# 끄려면: TEAM_EVENTS_CONSUMER_ENABLED=false
+# TEAM_EVENTS_CONSUMER_ENABLED=true
+# TEAM_EVENTS_QUEUE_NAME=notification.team.events
+# TEAM_EVENTS_ASSERT_TOPOLOGY=true
+# TEAM_EVENTS_EXCHANGE_NAME=team.events
+# TEAM_EVENTS_BINDING_KEYS=team-member-added
 # notification-service 내부 시크릿(선택) — 비워두면 test-send는 self-only (내 사용자에게만)
 NOTIFICATION_INTERNAL_SECRET=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,12 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-guest}
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   redis:
     image: redis:7-alpine
@@ -131,8 +137,10 @@ services:
       args:
         BACKEND_NODE_DEPS_IMAGE: ${BACKEND_NODE_DEPS_IMAGE:-backend-node-deps:local}
     depends_on:
-      - postgres-notification
-      - rabbitmq
+      postgres-notification:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
     environment:
       DATABASE_URL: postgresql://${NOTIFICATION_POSTGRES_USER:-notification_app}:${NOTIFICATION_POSTGRES_PASSWORD:-notification_app}@postgres-notification:5432/${NOTIFICATION_POSTGRES_DB:-notification_db}
       PORT: 8096
@@ -151,7 +159,8 @@ services:
     build:
       context: ./services/proxy-service
     depends_on:
-      - rabbitmq
+      rabbitmq:
+        condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: docker
       PROXY_KEY_SERVICE_BASE_URL: ${PROXY_KEY_SERVICE_BASE_URL:-http://host.docker.internal:8090}
@@ -303,7 +312,7 @@ services:
       postgres-team:
         condition: service_healthy
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
     # Published host port: TEAM_SERVICE_HOST_PORT (not TEAM_SERVICE_PORT — see .env.example).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,10 +132,18 @@ services:
         BACKEND_NODE_DEPS_IMAGE: ${BACKEND_NODE_DEPS_IMAGE:-backend-node-deps:local}
     depends_on:
       - postgres-notification
+      - rabbitmq
     environment:
       DATABASE_URL: postgresql://${NOTIFICATION_POSTGRES_USER:-notification_app}:${NOTIFICATION_POSTGRES_PASSWORD:-notification_app}@postgres-notification:5432/${NOTIFICATION_POSTGRES_DB:-notification_db}
       PORT: 8096
       NOTIFICATION_INTERNAL_SECRET: ${NOTIFICATION_INTERNAL_SECRET:-}
+      # team-service TeamDomainEventPublisher: exchange team.events, routing key team-member-added (application.properties)
+      RABBITMQ_URL: amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASSWORD:-guest}@rabbitmq:5672
+      TEAM_EVENTS_CONSUMER_ENABLED: ${TEAM_EVENTS_CONSUMER_ENABLED:-true}
+      TEAM_EVENTS_QUEUE_NAME: ${TEAM_EVENTS_QUEUE_NAME:-notification.team.events}
+      TEAM_EVENTS_ASSERT_TOPOLOGY: ${TEAM_EVENTS_ASSERT_TOPOLOGY:-true}
+      TEAM_EVENTS_EXCHANGE_NAME: ${TEAM_EVENTS_EXCHANGE_NAME:-team.events}
+      TEAM_EVENTS_BINDING_KEYS: ${TEAM_EVENTS_BINDING_KEYS:-team-member-added}
     ports:
       - "${NOTIFICATION_SERVICE_PORT:-8096}:8096"
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 # <Team Project> AI Usage & Billing Platform (MSA) 아키텍처 문서
-버전: 0.6
+버전: 0.6.1
 
 ---
 
@@ -8,6 +8,7 @@
 - **MSA 이론 배경**(일반 개념·특징·API Gateway 패턴): [`docs/msa-architecture-theory.md`](msa-architecture-theory.md)
   - 본 문서(`architecture.md`)는 **이 팀 프로젝트의 구조·스택·서비스 분해**를 다룬다. 위 이론 문서는 구현과 무관한 **일반 설명**을 위한 참고 자료이다.
 - **이벤트 소비·발행 흐름**(Proxy `UsageRecordedEvent` → usage·billing 소비, Billing `UsageCostFinalizedEvent` → usage 등): 본 문서 **§6**, 공유 타입·AMQP는 [`libs/usage-events`](../libs/usage-events) · 상세는 [`docs/billing-service-overview-20260412.md`](billing-service-overview-20260412.md)(부록 A 포함)
+- **팀 도메인 이벤트 → 인앱 알림**: Team Service 발행 `team.events` / notification-service 소비·인앱 저장 — 본 문서 **§4.9·§6**, 페이로드 계약은 [`docs/contracts/web-team-bff.md`](contracts/web-team-bff.md) §6.2
 - **사용량·집계·대시보드 관점**: 본 문서 **§6·§11**, 다이어그램은 [`docs/c4-architecture-diagrams.md`](c4-architecture-diagrams.md)
 - **서비스별 DB 구성·서비스 간 데이터 전달**(물리/논리 PostgreSQL, 타 서비스 DB 직접 접근 금지, API vs RabbitMQ, 조회 성능): [`docs/msa-database-and-service-integration.md`](msa-database-and-service-integration.md)
 
@@ -199,6 +200,7 @@
   - **(1차) 인앱 알림의 진실 공급원(Source of truth)** 을 **notification-service의 PostgreSQL(`notification_db`)** 로 둔다.
     - 알림 목록·읽음 처리·테스트 발송(설정 화면에서 호출) 등은 **notification-service API**가 담당한다.
     - 사용자 세션/식별은 Identity `web`의 쿠키 기반 인증을 유지하고, **Notification `web` BFF가 서버에서 세션을 확인**한 뒤 내부 호출로 전달한다(§10.2, §13).
+  - **팀 도메인 이벤트 → 인앱(비동기):** **team-service**가 RabbitMQ TopicExchange **`team.events`** 로 발행하는 팀 도메인 이벤트(본문·헤더 `eventType`, 페이로드 정본은 [`docs/contracts/web-team-bff.md`](contracts/web-team-bff.md) §6.2·Java `TeamDomainOutboundEvent`)를 **notification-service**가 큐에서 소비해 `InAppNotification` 행을 생성한다. `type` 필드는 `team:{eventType}` 형태를 사용한다. 동일 이벤트 재전송 시 중복 행 방지를 위해 **`NotificationDelivery.dedupeKey`**(채널 `in-app`)로 멱등 처리한다. `TEAM_INVITATION_ACCEPTED`는 초대한 사용자에게, `TEAM_MEMBER_JOINED`는 **참여한 사용자(`receiverId`)에게만** 인앱을 생성해 초대자에게 수락 알림과 중복되지 않게 한다. 구현·환경 변수·로컬 Compose는 **`services/notification-service/README.md`** 를 본다.
   - 외부 채널(Slack/Email)·이벤트 기반 알림은 **발행 측(Billing/Quota 등) 코드가 생긴 뒤** 연결한다(“타 서비스 코드 변경 금지” 전제에서는 후속 스프린트로 둔다).
 
 ### 4.10 Team Service
@@ -267,6 +269,9 @@
 - `billing-updated`(선택)
   - 발행 주체: Billing Service
   - 소비 주체: Analytics Service
+- 팀 도메인 이벤트(`TEAM_CREATED`, `TEAM_INVITE_CREATED`, … — **12종**, [`TeamEventTypes`](../services/team-service/src/main/java/com/zerobugfreinds/team_service/event/TeamEventTypes.java))
+  - 발행 주체: **Team Service** — exchange **`team.events`**, routing key **`team-member-added`**(기본, `application.properties`로 조정 가능)
+  - 소비 주체: **notification-service** — 큐 **`notification.team.events`**(기본) 등으로 구독·인앱 생성(§4.9, §6.2 토폴로지)
 
 ### 6.2 브로커 및 연동
 - **브로커**: **RabbitMQ** (Kafka 등은 본 프로젝트 범위에서 사용하지 않는다).
@@ -285,6 +290,9 @@
   - publish exchange/routing key: `billing.events` / `usage.cost.finalized`
 - Team/Identity 계정 삭제 이벤트
   - queue 예: `team.account-deletion.requested.queue`, `identity.account-deletion.ack.queue`
+- Team 도메인(팀 생성·초대·API 키 등)
+  - publish: **Team Service** — exchange **`team.events`**, routing key **`team-member-added`**
+  - consume: **notification-service** — queue **`notification.team.events`**(기본; `TEAM_EVENTS_QUEUE_NAME`로 변경 가능), 바인딩은 배포/Compose에서 `team.events`와 합의. 로컬 루트 `docker-compose.yml`의 `notification-service`는 `rabbitmq`에 의존하고 `RABBITMQ_URL`·소비자 플래그 등을 주입한다.
 
 ---
 

--- a/docs/contracts/web-notification-bff.md
+++ b/docs/contracts/web-notification-bff.md
@@ -1,7 +1,7 @@
 # Web(Next.js) ↔ Notification Service — Notification BFF 계약
 
-버전: 1.0  
-관련: [web-split-boundary.md](./web-split-boundary.md), [web-identity-bff.md](./web-identity-bff.md)(세션), [`docker/web-edge/nginx.conf`](../../docker/web-edge/nginx.conf), [architecture.md](../architecture.md) §4.9·§10.2·§13
+버전: 1.1  
+관련: [web-split-boundary.md](./web-split-boundary.md), [web-identity-bff.md](./web-identity-bff.md)(세션), [`docker/web-edge/nginx.conf`](../../docker/web-edge/nginx.conf), [architecture.md](../architecture.md) §4.9·§6·§10.2·§13, [web-team-bff.md](./web-team-bff.md) §6.2(팀 도메인 이벤트 스키마)
 
 **소스 트리:** Notification `web`(UI+BFF)의 **정본**은 `services/notification-service/web/` 이다. Notification 백엔드(Nest+Prisma)는 `services/notification-service/` 이다.
 
@@ -79,4 +79,12 @@ Notification `web`은 Next `basePath=/notifications`를 사용한다.
 
 - Notification 백엔드(Nest) 엔드포인트/헤더 계약을 바꾸면 **본 문서**와 `web-split-boundary.md`를 함께 갱신한다.
 - 단일 도메인 라우팅 규칙 변경(접두 추가/변경)은 `docker/web-edge/nginx.conf`와 `docs/architecture.md` §10.2를 함께 갱신한다.
+
+---
+
+## 6. 인앱 데이터의 다른 유입 경로(비동기)
+
+- 본 문서 §1~§4는 **브라우저 → BFF → notification-service HTTP** 경로만 다룬다.
+- **팀 도메인 이벤트**는 team-service가 RabbitMQ로 발행하고, notification-service가 **별도 소비자**로 큐에서 받아 `InAppNotification`을 추가한다(페이로드·`eventType` 정본은 [web-team-bff.md](./web-team-bff.md) §6.2). UI는 동일 `in-app-notifications` API로 목록을 조회하면 된다.
+- 아키텍처 요약: [`architecture.md`](../architecture.md) §4.9·§6.
 

--- a/docs/contracts/web-team-bff.md
+++ b/docs/contracts/web-team-bff.md
@@ -180,6 +180,7 @@
 - 주요 `eventType` 값: `TEAM_CREATED`, `TEAM_INVITE_CREATED`, `TEAM_INVITATION_ACCEPTED`, `TEAM_INVITATION_REJECTED`, `TEAM_MEMBER_JOINED`, `TEAM_MEMBER_REMOVED`, `TEAM_DELETED`, `TEAM_API_KEY_REGISTERED`, `TEAM_API_KEY_UPDATED`, `TEAM_API_KEY_DELETED`, `TEAM_API_KEY_DELETION_SCHEDULED`, `TEAM_API_KEY_DELETION_CANCELLED`.
 - 하위 호환: `TEAM_INVITE_CREATED` 페이로드에 기존 `invitationId`, `receiverId`, `inviterId`, `createdAt` 필드가 유지된다. `TEAM_MEMBER_JOINED`에 `receiverId`, `inviterId`, `createdAt`(레거시)가 유지된다.
 - 목적: notification 등이 알림·감사 로그를 비동기로 처리할 수 있도록 전달
+- **소비(인앱):** **notification-service**(`services/notification-service/src/team-events/`)가 RabbitMQ 큐를 구독해 위 이벤트별로 `InAppNotification`을 생성하고, `NotificationDelivery.dedupeKey`로 멱등을 보장한다. `TEAM_MEMBER_JOINED`는 제품 규칙상 **참여 사용자(`receiverId`)에게만** 인앱을 생성한다(초대자는 `TEAM_INVITATION_ACCEPTED`로 별도 통지). 상세·환경 변수는 [`services/notification-service/README.md`](../../services/notification-service/README.md), 아키텍처 요약은 [`architecture.md`](../architecture.md) §4.9·§6.
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: link:../../packages/ui
       '@module-federation/nextjs-mf':
         specifier: ^8.8.64
-        version: 8.8.64(@rspack/core@1.7.11(@swc/helpers@0.5.21))(next@15.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(node-fetch@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-jsx@5.1.7(react@19.2.4))(typescript@5.9.3)(webpack@5.97.1)
+        version: 8.8.64(@rspack/core@1.7.11(@swc/helpers@0.5.21))(next@15.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-jsx@5.1.7(@babel/core@7.29.0)(react@19.2.4))(typescript@5.9.3)(webpack@5.97.1)
       lucide-react:
         specifier: ^1.6.0
         version: 1.7.0(react@19.2.4)
@@ -338,6 +338,12 @@ importers:
       '@prisma/client':
         specifier: ^5.22.0
         version: 5.22.0(prisma@5.22.0)
+      '@types/amqplib':
+        specifier: ^0.10.6
+        version: 0.10.8
+      amqplib:
+        specifier: ^0.10.4
+        version: 0.10.9
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -350,6 +356,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.4.9
@@ -369,6 +378,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.2(@types/node@22.19.17)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1))
 
   services/notification-service/web:
     dependencies:
@@ -462,7 +474,7 @@ importers:
         version: link:../../../packages/ui
       '@module-federation/nextjs-mf':
         specifier: ^8.8.64
-        version: 8.8.64(@rspack/core@1.7.11(@swc/helpers@0.5.21))(next@15.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-jsx@5.1.7(react@19.2.4))(typescript@5.9.3)(webpack@5.97.1)
+        version: 8.8.64(@rspack/core@1.7.11(@swc/helpers@0.5.21))(next@15.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(node-fetch@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-jsx@5.1.7(react@19.2.4))(typescript@5.9.3)(webpack@5.97.1)
       lucide-react:
         specifier: ^1.6.0
         version: 1.7.0(react@19.2.4)
@@ -2607,6 +2619,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/amqplib@0.10.8':
+    resolution: {integrity: sha512-vtDp8Pk1wsE/AuQ8/Rgtm6KUZYqcnTgNvEHwzCkX8rL7AGsC6zqAfKAAJhUZXFhM/Pp++tbnUHiam/8vVpPztA==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -3021,6 +3036,10 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  amqplib@0.10.9:
+    resolution: {integrity: sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==}
+    engines: {node: '>=10'}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -3189,6 +3208,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer-more-ints@1.0.0:
+    resolution: {integrity: sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -5193,6 +5215,9 @@ packages:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -5338,6 +5363,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
@@ -5940,6 +5968,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -7036,7 +7067,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/nextjs-mf@8.8.64(@rspack/core@1.7.11(@swc/helpers@0.5.21))(next@15.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-jsx@5.1.7(react@19.2.4))(typescript@5.9.3)(webpack@5.97.1)':
+  '@module-federation/nextjs-mf@8.8.64(@rspack/core@1.7.11(@swc/helpers@0.5.21))(next@15.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-jsx@5.1.7(@babel/core@7.29.0)(react@19.2.4))(typescript@5.9.3)(webpack@5.97.1)':
     dependencies:
       '@module-federation/enhanced': 2.3.2(@rspack/core@1.7.11(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.97.1)
       '@module-federation/node': 2.7.40(@rspack/core@1.7.11(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.97.1)
@@ -8489,6 +8520,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/amqplib@0.10.8':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/aria-query@5.0.4': {}
 
   '@types/body-parser@1.19.6':
@@ -8962,6 +8997,11 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  amqplib@0.10.9:
+    dependencies:
+      buffer-more-ints: 1.0.0
+      url-parse: 1.5.10
+
   ansi-colors@4.1.3: {}
 
   ansi-escapes@4.3.2:
@@ -9165,6 +9205,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
+
+  buffer-more-ints@1.0.0: {}
 
   buffer@5.7.1:
     dependencies:
@@ -11312,6 +11354,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  querystringify@2.2.0: {}
+
   queue-microtask@1.2.3: {}
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -11520,6 +11564,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  requires-port@1.0.0: {}
 
   reselect@5.1.1: {}
 
@@ -12260,6 +12306,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:

--- a/services/notification-service/.env.example
+++ b/services/notification-service/.env.example
@@ -6,5 +6,33 @@ DATABASE_URL="postgresql://notification_app:notification_app@localhost:5436/noti
 # HTTP (기본 8096 — billing-service 기본 8095와 구분)
 PORT=8096
 
-# RabbitMQ — 소비자 구현 시 (docs/architecture.md §6)
-# RABBITMQ_URL=amqp://guest:guest@localhost:5672
+# RabbitMQ — 팀 도메인 이벤트 인앱 알림 소비자 (docs/architecture.md §6)
+# 로컬/스테이징에서 켜려면 브로커 URL과 아래 플래그를 설정한다. 운영에서는 인프라가
+# `team.events`(또는 합의한 exchange)에 큐를 바인딩하고, 이 서비스는 동일 큐 이름으로 구독한다.
+RABBITMQ_URL=amqp://guest:guest@localhost:5672
+
+# `false`: HTTP만 — 호스트에서 브로커 없이 띄울 때(기본 예시).
+# `true`: 큐 소비. 루트 docker-compose.yml `notification-service` 는 기본으로 소비자 켜고
+# `rabbitmq` 컨테이너·team-service 와 동일 exchange/routing(team.events / team-member-added)에 맞춘다.
+TEAM_EVENTS_CONSUMER_ENABLED=false
+
+# 브로커에 선언된 큐 이름과 일치해야 한다(배포 시 인프라/team-service와 합의).
+TEAM_EVENTS_QUEUE_NAME=notification.team.events
+
+# 인앱 카피 기본 언어: en | ko
+TEAM_EVENTS_DEFAULT_LOCALE=en
+
+# prefetch (미설정 시 10)
+# TEAM_EVENTS_PREFETCH=10
+
+# `true`일 때만 exchange/queue 바인딩을 이 프로세스에서 assert(로컬 개발용).
+# 운영에서 RabbitMQ 토폴로지를 인프라가 관리하면 false를 권장한다.
+TEAM_EVENTS_ASSERT_TOPOLOGY=false
+
+# assert 토폴로지 사용 시: topic exchange 이름(예: team.events)
+# TEAM_EVENTS_EXCHANGE_NAME=team.events
+
+# 콤마 구분 라우팅 키. team-service 기본 발행: `team-member-added`(application.properties).
+# 소비자 기본은 `#`(모든 키); Compose 프로파일은 team-service 와 맞추려면 아래를 연다.
+# TEAM_EVENTS_BINDING_KEYS=team-member-added
+

--- a/services/notification-service/Dockerfile
+++ b/services/notification-service/Dockerfile
@@ -34,6 +34,9 @@ COPY --from=deps /repo/services/notification-service/package.json ./services/not
 COPY --from=deps /repo/services/notification-service/node_modules ./services/notification-service/node_modules
 
 COPY services/notification-service ./services/notification-service
+# 호스트 소스 COPY 가 서비스 디렉터리의 node_modules(심볼릭 링크)를 덮어쓰므로 워크스페이스 링크를 다시 맞춘다.
+WORKDIR /repo
+RUN pnpm install --frozen-lockfile --ignore-scripts
 WORKDIR /repo/services/notification-service
 RUN pnpm run prisma:generate
 RUN pnpm run build

--- a/services/notification-service/README.md
+++ b/services/notification-service/README.md
@@ -13,3 +13,18 @@
 - OpenAPI: `GET /api/docs`
 
 Cursor 규칙: `.cursor/rules/notification-backend-node.mdc`
+
+## 팀 도메인 이벤트 (RabbitMQ)
+
+notification-service는 선택적으로 **팀 도메인 이벤트**(`TEAM_CREATED`, `TEAM_INVITE_CREATED` 등)를 소비해 **인앱 알림**을 만든다. 저장소 밖에서 배포하는 경우 다음을 인프라/플랫폼 팀과 맞춘다.
+
+1. **브로커 URL**을 비밀/설정으로 주입한다 (`RABBITMQ_URL`).
+2. **큐**를 생성하고, team-service가 발행하는 **exchange**(`TEAM_EVENTS_EXCHANGE_NAME`, 예: `team.events`)에 **라우팅 키**로 바인딩한다. 이 서비스는 `TEAM_EVENTS_QUEUE_NAME`(기본 `notification.team.events`)을 구독한다.
+3. 로컬에서 토폴로지를 앱이 직접 만들도록 할 수 있다 (`TEAM_EVENTS_ASSERT_TOPOLOGY=true`, exchange + `TEAM_EVENTS_BINDING_KEYS`). 운영에서는 보통 인프라가 큐·바인딩을 소유하고, 앱은 **assert를 끈다**(`false`).
+4. 브로커 없이 HTTP만 쓰려면 `TEAM_EVENTS_CONSUMER_ENABLED=false`를 둔다.
+
+루트 `docker compose --profile web` 의 `notification-service` 는 `rabbitmq`에 의존하고, 기본으로 `RABBITMQ_URL`·소비자·`TEAM_EVENTS_ASSERT_TOPOLOGY`를 켜며 team-service 와 동일한 `team.events` / `team-member-added` 바인딩을 assert한다(`.env`에서 `TEAM_EVENTS_CONSUMER_ENABLED` 등으로 덮어쓸 수 있음).
+
+환경 변수 전체는 `services/notification-service/.env.example`을 본다.
+
+**제품 규칙:** `TEAM_INVITATION_ACCEPTED`는 초대한 사람에게, `TEAM_MEMBER_JOINED`는 **참여한 사용자(`receiverId`)에게만** 인앱을 생성한다. 초대자는 수락 알림만 받고, 동일 흐름에서 `TEAM_MEMBER_JOINED`로 중복 행이 생기지 않는다.

--- a/services/notification-service/README.md
+++ b/services/notification-service/README.md
@@ -14,6 +14,8 @@
 
 Cursor 규칙: `.cursor/rules/notification-backend-node.mdc`
 
+문서 연계: 팀 이벤트 스키마·exchange 요약은 [`docs/contracts/web-team-bff.md`](../../docs/contracts/web-team-bff.md) §6.2, 플랫폼 아키텍처·브로커 토폴로지는 [`docs/architecture.md`](../../docs/architecture.md) §4.9·§6.
+
 ## 팀 도메인 이벤트 (RabbitMQ)
 
 notification-service는 선택적으로 **팀 도메인 이벤트**(`TEAM_CREATED`, `TEAM_INVITE_CREATED` 등)를 소비해 **인앱 알림**을 만든다. 저장소 밖에서 배포하는 경우 다음을 인프라/플랫폼 팀과 맞춘다.

--- a/services/notification-service/package.json
+++ b/services/notification-service/package.json
@@ -10,7 +10,9 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate deploy",
     "prisma:migrate:dev": "prisma migrate dev",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.15",
@@ -21,14 +23,18 @@
     "@prisma/client": "^5.22.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "amqplib": "^0.10.4",
+    "@types/amqplib": "^0.10.6",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.4.9",
     "@nestjs/schematics": "^10.2.3",
     "@types/express": "^4.17.21",
     "@types/node": "^22.10.0",
+    "vitest": "^4.1.1",
     "prisma": "^5.22.0",
     "typescript": "^5.7.2"
   }

--- a/services/notification-service/src/app.module.ts
+++ b/services/notification-service/src/app.module.ts
@@ -4,6 +4,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { InAppNotificationsModule } from './in-app-notifications/in-app-notifications.module';
 import { PrismaModule } from './prisma/prisma.module';
+import { TeamEventsModule } from './team-events/team-events.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { PrismaModule } from './prisma/prisma.module';
     }),
     PrismaModule,
     InAppNotificationsModule,
+    TeamEventsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/services/notification-service/src/team-events/team-dedupe-keys.spec.ts
+++ b/services/notification-service/src/team-events/team-dedupe-keys.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { buildInAppDedupeKey } from './team-dedupe-keys';
+import type { TeamDomainEventPayload } from './team-domain-event.schema';
+
+describe('buildInAppDedupeKey', () => {
+  it('builds per-invitation keys for invite flows', () => {
+    const payload = {
+      eventType: 'TEAM_INVITATION_ACCEPTED',
+      teamId: '1',
+      teamName: 'Acme',
+      actorUserId: 'accepter',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      recipientUserIds: ['inviter'],
+      invitationId: 'inv-42',
+    } as TeamDomainEventPayload;
+
+    const key = buildInAppDedupeKey(
+      'TEAM_INVITATION_ACCEPTED',
+      payload,
+      'inviter',
+    );
+    expect(key).toContain('inv-42');
+    expect(key).toContain('inviter');
+  });
+
+  it('scopes TEAM_MEMBER_JOINED by team and receiver', () => {
+    const payload = {
+      eventType: 'TEAM_MEMBER_JOINED',
+      teamId: '7',
+      teamName: 'Acme',
+      actorUserId: 'joiner',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      recipientUserIds: ['inviter', 'joiner'],
+      receiverId: 'joiner',
+      inviterId: 'inviter',
+    } as TeamDomainEventPayload;
+
+    const key = buildInAppDedupeKey('TEAM_MEMBER_JOINED', payload, 'joiner');
+    expect(key).toContain('TEAM_MEMBER_JOINED');
+    expect(key).toContain('7');
+    expect(key).toContain('joiner');
+  });
+});

--- a/services/notification-service/src/team-events/team-dedupe-keys.ts
+++ b/services/notification-service/src/team-events/team-dedupe-keys.ts
@@ -1,0 +1,53 @@
+import type { TeamDomainEventPayload } from './team-domain-event.schema';
+import type { TeamEventType } from './team-event-types';
+
+const IN_APP_CHANNEL_SCOPE = 'in-app';
+
+/**
+ * Stable, retry-safe dedupe keys per recipient. Must stay aligned with team-service payloads.
+ */
+export function buildInAppDedupeKey(
+  eventType: TeamEventType,
+  payload: TeamDomainEventPayload,
+  recipientUserId: string,
+): string | null {
+  const teamId = payload.teamId;
+  switch (eventType) {
+    case 'TEAM_CREATED':
+      return `${IN_APP_CHANNEL_SCOPE}:team:${eventType}:${teamId}:${recipientUserId}`;
+    case 'TEAM_INVITE_CREATED': {
+      const id = payload.invitationId;
+      if (!id) return null;
+      return `${IN_APP_CHANNEL_SCOPE}:team:${eventType}:${id}:${recipientUserId}`;
+    }
+    case 'TEAM_MEMBER_JOINED': {
+      const receiverId = payload.receiverId;
+      if (!receiverId) return null;
+      return `${IN_APP_CHANNEL_SCOPE}:team:${eventType}:${teamId}:${receiverId}:${recipientUserId}`;
+    }
+    case 'TEAM_INVITATION_ACCEPTED':
+    case 'TEAM_INVITATION_REJECTED': {
+      const id = payload.invitationId;
+      if (!id) return null;
+      return `${IN_APP_CHANNEL_SCOPE}:team:${eventType}:${id}:${recipientUserId}`;
+    }
+    case 'TEAM_MEMBER_REMOVED': {
+      const removed = payload.removedUserId;
+      if (!removed) return null;
+      return `${IN_APP_CHANNEL_SCOPE}:team:${eventType}:${teamId}:${removed}:${recipientUserId}`;
+    }
+    case 'TEAM_DELETED':
+      return `${IN_APP_CHANNEL_SCOPE}:team:${eventType}:${teamId}:${recipientUserId}`;
+    case 'TEAM_API_KEY_REGISTERED':
+    case 'TEAM_API_KEY_UPDATED':
+    case 'TEAM_API_KEY_DELETED':
+    case 'TEAM_API_KEY_DELETION_SCHEDULED':
+    case 'TEAM_API_KEY_DELETION_CANCELLED': {
+      const keyId = payload.apiKeyId;
+      if (keyId === undefined || keyId === null) return null;
+      return `${IN_APP_CHANNEL_SCOPE}:team:${eventType}:${teamId}:${String(keyId)}:${recipientUserId}`;
+    }
+    default:
+      return null;
+  }
+}

--- a/services/notification-service/src/team-events/team-domain-event.schema.spec.ts
+++ b/services/notification-service/src/team-events/team-domain-event.schema.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { parseTeamDomainEventJson, safeParseTeamDomainEventJson } from './team-domain-event.schema';
+
+describe('parseTeamDomainEventJson', () => {
+  it('parses a minimal TEAM_CREATED payload', () => {
+    const raw = {
+      eventType: 'TEAM_CREATED',
+      teamId: '1',
+      teamName: 'Acme',
+      actorUserId: 'u-owner',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      recipientUserIds: ['u-owner'],
+    };
+    const parsed = parseTeamDomainEventJson(raw);
+    expect(parsed.eventType).toBe('TEAM_CREATED');
+    expect(parsed.recipientUserIds).toEqual(['u-owner']);
+  });
+
+  it('rejects unknown eventType', () => {
+    const raw = {
+      eventType: 'UNKNOWN',
+      teamId: '1',
+      actorUserId: 'u',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      recipientUserIds: [],
+    };
+    const parsed = safeParseTeamDomainEventJson(raw);
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/services/notification-service/src/team-events/team-domain-event.schema.ts
+++ b/services/notification-service/src/team-events/team-domain-event.schema.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { isTeamEventType, type TeamEventType } from './team-event-types';
+
+const instantLike = z.union([
+  z.string(),
+  z.coerce.date(),
+]);
+
+const eventTypeField = z
+  .string()
+  .refine((v): v is TeamEventType => isTeamEventType(v), { message: 'Unknown eventType' });
+
+/** Parsed payload after validation — mirrors team-service `TeamDomainOutboundEvent` JSON. */
+export type TeamDomainEventPayload = z.infer<typeof teamDomainEventSchema>;
+
+const teamDomainEventSchema = z
+  .object({
+    eventType: eventTypeField,
+    teamId: z.string(),
+    teamName: z.string().nullable().optional(),
+    actorUserId: z.string(),
+    occurredAt: instantLike,
+    recipientUserIds: z.array(z.string()),
+    invitationId: z.string().optional(),
+    receiverId: z.string().optional(),
+    inviterId: z.string().optional(),
+    createdAt: instantLike.optional(),
+    removedUserId: z.string().optional(),
+    memberUserIdsSnapshot: z.array(z.string()).optional(),
+    apiKeyId: z.union([z.number(), z.bigint()]).optional(),
+    provider: z.string().optional(),
+    alias: z.string().optional(),
+    deletionGraceDays: z.number().int().optional(),
+    permanentDeletionAt: instantLike.optional(),
+  })
+  .passthrough();
+
+export function parseTeamDomainEventJson(raw: unknown): TeamDomainEventPayload {
+  return teamDomainEventSchema.parse(raw);
+}
+
+export function safeParseTeamDomainEventJson(
+  raw: unknown,
+): z.SafeParseReturnType<unknown, TeamDomainEventPayload> {
+  return teamDomainEventSchema.safeParse(raw);
+}

--- a/services/notification-service/src/team-events/team-event-types.ts
+++ b/services/notification-service/src/team-events/team-event-types.ts
@@ -1,0 +1,21 @@
+/** Mirrors `TeamEventTypes` in team-service (Java). */
+export const TEAM_EVENT_TYPES = [
+  'TEAM_CREATED',
+  'TEAM_INVITE_CREATED',
+  'TEAM_MEMBER_JOINED',
+  'TEAM_INVITATION_ACCEPTED',
+  'TEAM_INVITATION_REJECTED',
+  'TEAM_MEMBER_REMOVED',
+  'TEAM_DELETED',
+  'TEAM_API_KEY_REGISTERED',
+  'TEAM_API_KEY_UPDATED',
+  'TEAM_API_KEY_DELETED',
+  'TEAM_API_KEY_DELETION_SCHEDULED',
+  'TEAM_API_KEY_DELETION_CANCELLED',
+] as const;
+
+export type TeamEventType = (typeof TEAM_EVENT_TYPES)[number];
+
+export function isTeamEventType(value: string): value is TeamEventType {
+  return (TEAM_EVENT_TYPES as readonly string[]).includes(value);
+}

--- a/services/notification-service/src/team-events/team-events.consumer.ts
+++ b/services/notification-service/src/team-events/team-events.consumer.ts
@@ -1,0 +1,192 @@
+import {
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { Channel, ConsumeMessage } from 'amqplib';
+import * as amqp from 'amqplib';
+import { isTeamEventType } from './team-event-types';
+import { safeParseTeamDomainEventJson } from './team-domain-event.schema';
+import { TeamInAppNotificationHandlerService } from './team-in-app-notification-handler.service';
+
+type AmqpConnection = Awaited<ReturnType<typeof amqp.connect>>;
+
+@Injectable()
+export class TeamEventsConsumer
+  implements OnApplicationBootstrap, OnModuleDestroy
+{
+  private readonly logger = new Logger(TeamEventsConsumer.name);
+  private connection: AmqpConnection | null = null;
+  private channel: Channel | null = null;
+  private consumerTag: string | null = null;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly handler: TeamInAppNotificationHandlerService,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    const enabled = this.config.get<string>('TEAM_EVENTS_CONSUMER_ENABLED', 'false');
+    if (enabled !== 'true' && enabled !== '1') {
+      this.logger.log('Team events consumer disabled (TEAM_EVENTS_CONSUMER_ENABLED)');
+      return;
+    }
+
+    const url = this.config.get<string>('RABBITMQ_URL');
+    if (!url?.trim()) {
+      this.logger.warn(
+        'TEAM_EVENTS_CONSUMER_ENABLED is true but RABBITMQ_URL is empty — consumer not started',
+      );
+      return;
+    }
+
+    const queue = this.config.get<string>(
+      'TEAM_EVENTS_QUEUE_NAME',
+      'notification.team.events',
+    );
+    const prefetch = Number(this.config.get<string>('TEAM_EVENTS_PREFETCH', '10')) || 10;
+    const assertTopology =
+      this.config.get<string>('TEAM_EVENTS_ASSERT_TOPOLOGY', 'false') === 'true' ||
+      this.config.get<string>('TEAM_EVENTS_ASSERT_TOPOLOGY', 'false') === '1';
+    const exchange = this.config.get<string>('TEAM_EVENTS_EXCHANGE_NAME');
+    const bindingKeysRaw = this.config.get<string>('TEAM_EVENTS_BINDING_KEYS', '#');
+    const bindingKeys = bindingKeysRaw
+      .split(',')
+      .map((k) => k.trim())
+      .filter(Boolean);
+
+    try {
+      const conn = await amqp.connect(url);
+      this.connection = conn;
+      const ch = await conn.createChannel();
+      this.channel = ch;
+      await ch.prefetch(prefetch);
+
+      if (assertTopology && exchange?.trim()) {
+        await ch.assertExchange(exchange.trim(), 'topic', { durable: true });
+      }
+
+      await ch.assertQueue(queue, { durable: true });
+
+      if (assertTopology && exchange?.trim()) {
+        for (const key of bindingKeys) {
+          await ch.bindQueue(queue, exchange.trim(), key);
+        }
+      }
+
+      const { consumerTag } = await ch.consume(
+        queue,
+        (msg: ConsumeMessage | null) => void this.onMessage(msg),
+        { noAck: false },
+      );
+      this.consumerTag = consumerTag;
+
+      this.logger.log(
+        `Team events consumer started (queue=${queue}${exchange ? `, exchange=${exchange}` : ''})`,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to start team events consumer: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw err;
+    }
+  }
+
+  private async onMessage(msg: ConsumeMessage | null): Promise<void> {
+    const ch = this.channel;
+    if (!msg || !ch) return;
+
+    const ack = (): void => {
+      ch.ack(msg);
+    };
+
+    const nackRequeue = (): void => {
+      ch.nack(msg, false, true);
+    };
+
+    let body: unknown;
+    try {
+      const text = msg.content.toString('utf8');
+      body = JSON.parse(text) as unknown;
+    } catch {
+      this.logger.warn('Invalid JSON in team event message — acking');
+      ack();
+      return;
+    }
+
+    const eventTypeRaw =
+      typeof body === 'object' && body !== null && 'eventType' in body
+        ? (body as { eventType?: unknown }).eventType
+        : undefined;
+
+    if (typeof eventTypeRaw !== 'string' || !isTeamEventType(eventTypeRaw)) {
+      this.logger.warn(`Unknown or missing eventType — acking (eventType=${String(eventTypeRaw)})`);
+      ack();
+      return;
+    }
+
+    const parsed = safeParseTeamDomainEventJson(body);
+    if (!parsed.success) {
+      this.logger.warn(
+        `Team event payload validation failed — acking: ${parsed.error.message}`,
+      );
+      ack();
+      return;
+    }
+
+    const payload = parsed.data;
+
+    try {
+      const result = await this.handler.handleTeamDomainEvent(
+        payload.eventType,
+        payload,
+      );
+      this.logger.log(
+        JSON.stringify({
+          msg: 'team_event_processed',
+          eventType: payload.eventType,
+          teamId: payload.teamId,
+          createdCount: result.createdCount,
+          skippedCount: result.skippedCount,
+        }),
+      );
+      ack();
+    } catch (err) {
+      this.logger.error(
+        `team_event_processing_failed eventType=${payload.eventType} teamId=${payload.teamId} ${err instanceof Error ? err.message : String(err)}`,
+      );
+      nackRequeue();
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    const ch = this.channel;
+    const conn = this.connection;
+    if (ch && this.consumerTag) {
+      try {
+        await ch.cancel(this.consumerTag);
+      } catch {
+        /* ignore */
+      }
+    }
+    if (ch) {
+      try {
+        await ch.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.channel = null;
+    this.consumerTag = null;
+    if (conn) {
+      try {
+        await conn.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.connection = null;
+  }
+}

--- a/services/notification-service/src/team-events/team-events.module.ts
+++ b/services/notification-service/src/team-events/team-events.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TeamEventsConsumer } from './team-events.consumer';
+import { TeamInAppNotificationHandlerService } from './team-in-app-notification-handler.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [TeamInAppNotificationHandlerService, TeamEventsConsumer],
+})
+export class TeamEventsModule {}

--- a/services/notification-service/src/team-events/team-in-app-notification-handler.service.ts
+++ b/services/notification-service/src/team-events/team-in-app-notification-handler.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../prisma/prisma.service';
+import { buildInAppDedupeKey } from './team-dedupe-keys';
+import type { TeamDomainEventPayload } from './team-domain-event.schema';
+import type { TeamEventType } from './team-event-types';
+import {
+  buildTeamNotificationCopy,
+  type NotificationLocale,
+} from './team-notification-templates';
+import { getEffectiveRecipientUserIds } from './team-recipient-user-ids';
+
+const IN_APP_CHANNEL = 'in-app';
+const DELIVERY_STATUS = 'delivered';
+
+@Injectable()
+export class TeamInAppNotificationHandlerService {
+  private readonly logger = new Logger(TeamInAppNotificationHandlerService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+  ) {}
+
+  private getLocale(): NotificationLocale {
+    const raw = this.config.get<string>('TEAM_EVENTS_DEFAULT_LOCALE', 'en');
+    return raw === 'ko' ? 'ko' : 'en';
+  }
+
+  async handleTeamDomainEvent(
+    eventType: TeamEventType,
+    payload: TeamDomainEventPayload,
+  ): Promise<{ createdCount: number; skippedCount: number }> {
+    const recipients = getEffectiveRecipientUserIds(eventType, payload);
+    let createdCount = 0;
+    let skippedCount = 0;
+
+    const notificationType = `team:${eventType}`;
+    const locale = this.getLocale();
+
+    for (const userId of recipients) {
+      const dedupeKey = buildInAppDedupeKey(eventType, payload, userId);
+      if (!dedupeKey) {
+        this.logger.warn(
+          `Skipping recipient — missing fields for dedupe (eventType=${eventType}, userId=${userId})`,
+        );
+        skippedCount += 1;
+        continue;
+      }
+
+      const copy = buildTeamNotificationCopy(eventType, payload, userId, locale);
+
+      try {
+        await this.prisma.$transaction(async (tx) => {
+          await tx.notificationDelivery.create({
+            data: {
+              dedupeKey,
+              channel: IN_APP_CHANNEL,
+              status: DELIVERY_STATUS,
+              payload: {
+                eventType,
+                teamId: payload.teamId,
+                recipientUserId: userId,
+              } as Prisma.InputJsonValue,
+            },
+          });
+
+          await tx.inAppNotification.create({
+            data: {
+              userId,
+              title: copy.title,
+              body: copy.body,
+              type: notificationType,
+            },
+          });
+        });
+        createdCount += 1;
+      } catch (e) {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+          skippedCount += 1;
+          continue;
+        }
+        throw e;
+      }
+    }
+
+    return { createdCount, skippedCount };
+  }
+}

--- a/services/notification-service/src/team-events/team-notification-templates.spec.ts
+++ b/services/notification-service/src/team-events/team-notification-templates.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { buildTeamNotificationCopy } from './team-notification-templates';
+import type { TeamDomainEventPayload } from './team-domain-event.schema';
+
+describe('buildTeamNotificationCopy', () => {
+  it('renders TEAM_INVITE_CREATED in English', () => {
+    const payload = {
+      eventType: 'TEAM_INVITE_CREATED',
+      teamId: '1',
+      teamName: 'Acme',
+      actorUserId: 'inviter',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      recipientUserIds: ['invitee'],
+      invitationId: 'inv-1',
+      receiverId: 'invitee',
+      inviterId: 'inviter',
+    } as TeamDomainEventPayload;
+
+    const copy = buildTeamNotificationCopy(
+      'TEAM_INVITE_CREATED',
+      payload,
+      'invitee',
+      'en',
+    );
+    expect(copy.title).toBe('Team invitation');
+    expect(copy.body).toContain('Acme');
+  });
+
+  it('renders TEAM_MEMBER_JOINED in Korean', () => {
+    const payload = {
+      eventType: 'TEAM_MEMBER_JOINED',
+      teamId: '1',
+      teamName: 'Acme',
+      actorUserId: 'joiner',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      recipientUserIds: ['inviter', 'joiner'],
+      receiverId: 'joiner',
+      inviterId: 'inviter',
+    } as TeamDomainEventPayload;
+
+    const copy = buildTeamNotificationCopy(
+      'TEAM_MEMBER_JOINED',
+      payload,
+      'joiner',
+      'ko',
+    );
+    expect(copy.title).toBe('팀 참여');
+    expect(copy.body).toContain('Acme');
+  });
+});

--- a/services/notification-service/src/team-events/team-notification-templates.ts
+++ b/services/notification-service/src/team-events/team-notification-templates.ts
@@ -1,0 +1,178 @@
+import type { TeamDomainEventPayload } from './team-domain-event.schema';
+import type { TeamEventType } from './team-event-types';
+
+export type NotificationLocale = 'en' | 'ko';
+
+export interface TeamNotificationCopy {
+  title: string;
+  body: string;
+}
+
+function teamLabel(payload: TeamDomainEventPayload): string {
+  return payload.teamName?.trim() || payload.teamId;
+}
+
+function formatUserId(userId: string | undefined): string {
+  if (!userId) return '—';
+  return userId.length > 12 ? `${userId.slice(0, 8)}…` : userId;
+}
+
+/** Title/body for in-app notifications. Korean + English strings. */
+export function buildTeamNotificationCopy(
+  eventType: TeamEventType,
+  payload: TeamDomainEventPayload,
+  recipientUserId: string,
+  locale: NotificationLocale,
+): TeamNotificationCopy {
+  const team = teamLabel(payload);
+  const actor = formatUserId(payload.actorUserId);
+
+  const en = (): TeamNotificationCopy => {
+    switch (eventType) {
+      case 'TEAM_CREATED':
+        return {
+          title: 'Team created',
+          body: `You created team "${team}".`,
+        };
+      case 'TEAM_INVITE_CREATED':
+        return {
+          title: 'Team invitation',
+          body: `You were invited to join "${team}".`,
+        };
+      case 'TEAM_MEMBER_JOINED':
+        return {
+          title: 'Joined team',
+          body: `You joined "${team}".`,
+        };
+      case 'TEAM_INVITATION_ACCEPTED':
+        return {
+          title: 'Invitation accepted',
+          body: `Your invitation to "${team}" was accepted.`,
+        };
+      case 'TEAM_INVITATION_REJECTED':
+        return {
+          title: 'Invitation declined',
+          body: `Your invitation to "${team}" was declined.`,
+        };
+      case 'TEAM_MEMBER_REMOVED':
+        return {
+          title: 'Removed from team',
+          body: `You were removed from "${team}".`,
+        };
+      case 'TEAM_DELETED':
+        return {
+          title: 'Team deleted',
+          body: `Team "${team}" was deleted.`,
+        };
+      case 'TEAM_API_KEY_REGISTERED':
+        return {
+          title: 'API key registered',
+          body: `An API key was registered for "${team}" (${formatProvider(payload)}).`,
+        };
+      case 'TEAM_API_KEY_UPDATED':
+        return {
+          title: 'API key updated',
+          body: `An API key was updated for "${team}" (${formatProvider(payload)}).`,
+        };
+      case 'TEAM_API_KEY_DELETED':
+        return {
+          title: 'API key deleted',
+          body: `An API key was deleted for "${team}" (${formatProvider(payload)}).`,
+        };
+      case 'TEAM_API_KEY_DELETION_SCHEDULED':
+        return {
+          title: 'API key deletion scheduled',
+          body: `Deletion was scheduled for an API key on "${team}" (${formatProvider(payload)}).`,
+        };
+      case 'TEAM_API_KEY_DELETION_CANCELLED':
+        return {
+          title: 'API key deletion cancelled',
+          body: `Scheduled deletion was cancelled for an API key on "${team}" (${formatProvider(payload)}).`,
+        };
+    }
+  };
+
+  const ko = (): TeamNotificationCopy => {
+    switch (eventType) {
+      case 'TEAM_CREATED':
+        return {
+          title: '팀 생성됨',
+          body: `"${team}" 팀을 생성했습니다.`,
+        };
+      case 'TEAM_INVITE_CREATED':
+        return {
+          title: '팀 초대',
+          body: `"${team}" 팀에 초대되었습니다.`,
+        };
+      case 'TEAM_MEMBER_JOINED':
+        return {
+          title: '팀 참여',
+          body: `"${team}" 팀에 참여했습니다.`,
+        };
+      case 'TEAM_INVITATION_ACCEPTED':
+        return {
+          title: '초대 수락',
+          body: `"${team}" 팀 초대가 수락되었습니다.`,
+        };
+      case 'TEAM_INVITATION_REJECTED':
+        return {
+          title: '초대 거절',
+          body: `"${team}" 팀 초대가 거절되었습니다.`,
+        };
+      case 'TEAM_MEMBER_REMOVED':
+        return {
+          title: '팀에서 제외됨',
+          body: `"${team}" 팀에서 제외되었습니다.`,
+        };
+      case 'TEAM_DELETED':
+        return {
+          title: '팀 삭제됨',
+          body: `"${team}" 팀이 삭제되었습니다.`,
+        };
+      case 'TEAM_API_KEY_REGISTERED':
+        return {
+          title: 'API 키 등록',
+          body: `"${team}" 팀에 API 키가 등록되었습니다 (${formatProviderKo(payload)}).`,
+        };
+      case 'TEAM_API_KEY_UPDATED':
+        return {
+          title: 'API 키 변경',
+          body: `"${team}" 팀의 API 키가 변경되었습니다 (${formatProviderKo(payload)}).`,
+        };
+      case 'TEAM_API_KEY_DELETED':
+        return {
+          title: 'API 키 삭제',
+          body: `"${team}" 팀의 API 키가 삭제되었습니다 (${formatProviderKo(payload)}).`,
+        };
+      case 'TEAM_API_KEY_DELETION_SCHEDULED':
+        return {
+          title: 'API 키 삭제 예약',
+          body: `"${team}" 팀 API 키 삭제가 예약되었습니다 (${formatProviderKo(payload)}).`,
+        };
+      case 'TEAM_API_KEY_DELETION_CANCELLED':
+        return {
+          title: 'API 키 삭제 취소',
+          body: `"${team}" 팀 API 키의 삭제 예약이 취소되었습니다 (${formatProviderKo(payload)}).`,
+        };
+    }
+  };
+
+  // `recipientUserId` reserved for future per-recipient phrasing (e.g. actor vs viewer).
+  void recipientUserId;
+  void actor;
+  return locale === 'ko' ? ko() : en();
+}
+
+function formatProvider(payload: TeamDomainEventPayload): string {
+  const p = payload.provider?.trim();
+  const a = payload.alias?.trim();
+  if (p && a) return `${p} / ${a}`;
+  return p || a || 'provider';
+}
+
+function formatProviderKo(payload: TeamDomainEventPayload): string {
+  const p = payload.provider?.trim();
+  const a = payload.alias?.trim();
+  if (p && a) return `${p} / ${a}`;
+  return p || a || '제공자';
+}

--- a/services/notification-service/src/team-events/team-recipient-user-ids.spec.ts
+++ b/services/notification-service/src/team-events/team-recipient-user-ids.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { getEffectiveRecipientUserIds } from './team-recipient-user-ids';
+import type { TeamDomainEventPayload } from './team-domain-event.schema';
+
+describe('getEffectiveRecipientUserIds', () => {
+  it('for TEAM_MEMBER_JOINED only notifies receiverId (inviter is not duplicated vs invitation accepted)', () => {
+    const payload = {
+      eventType: 'TEAM_MEMBER_JOINED',
+      teamId: '1',
+      teamName: 'Acme',
+      actorUserId: 'joiner',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      recipientUserIds: ['inviter', 'joiner'],
+      receiverId: 'joiner',
+      inviterId: 'inviter',
+    } as TeamDomainEventPayload;
+
+    expect(getEffectiveRecipientUserIds('TEAM_MEMBER_JOINED', payload)).toEqual([
+      'joiner',
+    ]);
+  });
+
+  it('passes through recipientUserIds for TEAM_INVITATION_ACCEPTED', () => {
+    const payload = {
+      eventType: 'TEAM_INVITATION_ACCEPTED',
+      teamId: '1',
+      teamName: 'Acme',
+      actorUserId: 'accepter',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      recipientUserIds: ['inviter'],
+      invitationId: 'inv-1',
+    } as TeamDomainEventPayload;
+
+    expect(getEffectiveRecipientUserIds('TEAM_INVITATION_ACCEPTED', payload)).toEqual([
+      'inviter',
+    ]);
+  });
+});

--- a/services/notification-service/src/team-events/team-recipient-user-ids.ts
+++ b/services/notification-service/src/team-events/team-recipient-user-ids.ts
@@ -1,0 +1,21 @@
+import type { TeamDomainEventPayload } from './team-domain-event.schema';
+import type { TeamEventType } from './team-event-types';
+
+/**
+ * Effective in-app recipients per product rules.
+ *
+ * `TEAM_MEMBER_JOINED` publishes `recipientUserIds` as [inviter, joined]. The inviter is already
+ * notified by `TEAM_INVITATION_ACCEPTED`, so we only surface `TEAM_MEMBER_JOINED` to the joined
+ * user (`receiverId`) to avoid duplicate in-app rows for the inviter.
+ */
+export function getEffectiveRecipientUserIds(
+  eventType: TeamEventType,
+  payload: TeamDomainEventPayload,
+): string[] {
+  if (eventType === 'TEAM_MEMBER_JOINED') {
+    const receiver = payload.receiverId;
+    if (receiver) return [receiver];
+    return [];
+  }
+  return payload.recipientUserIds ?? [];
+}

--- a/services/notification-service/vitest.config.ts
+++ b/services/notification-service/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+  },
+});


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #(팀 이벤트 인앱 알림 이슈 번호)

## 작업 내용
- **해당 서비스**: **Notification** (`services/notification-service/`) + 루트 인프라(`docker-compose.yml`)

team-service가 RabbitMQ(`team.events` / 라우팅 키 `team-member-added`)로 발행하는 팀 도메인 이벤트(12종)를 **notification-service**가 소비해 `InAppNotification`을 자동 생성하고, `NotificationDelivery.dedupeKey`로 멱등 처리한다. `TEAM_INVITATION_ACCEPTED`와 `TEAM_MEMBER_JOINED`가 겹칠 때 초대자 쪽 중복 인앱을 피하도록 수신자 규칙을 적용했다. 로컬 Compose·문서·단위 테스트를 함께 맞춤.

## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용

### 백엔드 (Nest)
- `amqplib`, `zod` 등 의존성 및 `src/team-events/` 모듈: 큐 소비, 본문 `eventType` 기준 zod 검증, 이벤트별 EN/KO 제목·본문 템플릿, `type` = `team:{eventType}`.
- 수신자: `TEAM_MEMBER_JOINED`는 `receiverId`만 인앱(초대자는 `TEAM_INVITATION_ACCEPTED`만).
- 멱등: 트랜잭션에서 `NotificationDelivery` 삽입 후 `InAppNotification` 생성, `dedupeKey` 유니크 충돌 시 스킵.
- `TEAM_EVENTS_CONSUMER_ENABLED` 등 환경 변수로 소비자 on/off.

### Docker / Compose
- `notification-service` Dockerfile: 소스 `COPY` 후 `pnpm install`로 워크스페이스 링크 복구(이미지 내 `nest build` 실패 방지).
- `docker-compose.yml`: `notification-service`에 `RABBITMQ_URL`·팀 이벤트 env, `depends_on: rabbitmq` + **`rabbitmq` healthcheck** 및 **`service_healthy`**; `proxy-service`·`team-service`도 RabbitMQ 준비 후 기동.

### 문서
- `docs/architecture.md`, `docs/contracts/web-team-bff.md`, `docs/contracts/web-notification-bff.md`, `services/notification-service/README.md` 등에 팀 이벤트 → 인앱 흐름 반영.

### 테스트
- `services/notification-service`: Vitest 단위 테스트(파서·템플릿·dedupe·수신자 규칙).

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부 — **해당 없음**
- [x] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부 — **소비(Consume)** — notification-service 팀 도메인 큐
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부 — **기존 `InAppNotification` / `NotificationDelivery` 사용(마이그레이션 추가 없음)**

## 📸 스크린샷 / 테스트 결과 (선택)
- `pnpm test` (notification-service), `pnpm run build` / Docker 이미지 빌드 통과 시 기재

## 리뷰 요구사항
- 운영 RabbitMQ에서 **큐·exchange·바인딩**을 인프라가 관리하는 경우 `TEAM_EVENTS_ASSERT_TOPOLOGY=false` 등 팀 합의 필요.
- Nest 부팅 시 RabbitMQ 연결 실패 시 현재는 **throw로 프로세스 종료** — 향후 재시도·데그레이드 정책 여부 검토 가능.