### PR TITLE
feat: api key 삭제시 로그 보존 선택 가능, 이벤트 발행

### DIFF
--- a/libs/identity-events/src/main/java/com/zerobugfreinds/identity/events/ExternalApiKeyDeletedEvent.java
+++ b/libs/identity-events/src/main/java/com/zerobugfreinds/identity/events/ExternalApiKeyDeletedEvent.java
@@ -1,0 +1,55 @@
+package com.zerobugfreinds.identity.events;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+/**
+ * 개인 외부 API Key가 물리 삭제될 때 usage-service 등이 소비하는 표준형 이벤트.
+ * team-service 의 {@code TeamApiKeyDeletedEvent} 필드 구성(식별·시각·유형 문자열)에 맞춘다.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ExternalApiKeyDeletedEvent(
+		@JsonProperty("eventType")
+		String eventType,
+
+		@JsonProperty("userId")
+		Long userId,
+
+		@JsonProperty("apiKeyId")
+		Long apiKeyId,
+
+		@JsonProperty("occurredAt")
+		@JsonFormat(shape = JsonFormat.Shape.STRING)
+		Instant occurredAt,
+
+		@JsonProperty("retainLogs")
+		boolean retainLogs,
+
+		@JsonProperty("provider")
+		String provider,
+
+		@JsonProperty("alias")
+		String alias
+) {
+	public static ExternalApiKeyDeletedEvent of(
+			Long userId,
+			Long apiKeyId,
+			Instant occurredAt,
+			boolean retainLogs,
+			String provider,
+			String alias
+	) {
+		return new ExternalApiKeyDeletedEvent(
+				IdentityExternalApiKeyEventTypes.EXTERNAL_API_KEY_DELETED,
+				userId,
+				apiKeyId,
+				occurredAt,
+				retainLogs,
+				provider,
+				alias
+		);
+	}
+}

--- a/libs/identity-events/src/main/java/com/zerobugfreinds/identity/events/ExternalApiKeyStatusChangedEvent.java
+++ b/libs/identity-events/src/main/java/com/zerobugfreinds/identity/events/ExternalApiKeyStatusChangedEvent.java
@@ -6,7 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 
 /**
- * Event published when external API key metadata or lifecycle status changes.
+ * Event published when external API key metadata or lifecycle status changes
+ * (등록·수정·삭제 예약·취소). 물리 삭제 완료는 {@link ExternalApiKeyDeletedEvent} 로 별도 발행한다.
  * Budget fields are intentionally excluded.
  */
 public record ExternalApiKeyStatusChangedEvent(

--- a/libs/identity-events/src/main/java/com/zerobugfreinds/identity/events/IdentityExternalApiKeyEventTypes.java
+++ b/libs/identity-events/src/main/java/com/zerobugfreinds/identity/events/IdentityExternalApiKeyEventTypes.java
@@ -1,0 +1,13 @@
+package com.zerobugfreinds.identity.events;
+
+/**
+ * 개인 외부 API Key 관련 AMQP 페이로드의 {@code eventType} 상수.
+ * team-service {@code TeamEventTypes} 와 동일한 문자열 상수 패턴을 따른다.
+ */
+public final class IdentityExternalApiKeyEventTypes {
+
+	public static final String EXTERNAL_API_KEY_DELETED = "EXTERNAL_API_KEY_DELETED";
+
+	private IdentityExternalApiKeyEventTypes() {
+	}
+}

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "../cn"
+
+function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input bg-background shadow-xs outline-none transition-shadow",
+        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+        "dark:bg-input/30 dark:data-[state=checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,6 @@
 export { cn } from "./cn"
 export { Button, buttonVariants } from "./components/button"
+export { Checkbox } from "./components/checkbox"
 export { Input } from "./components/input"
 export { Label } from "./components/label"
 export {

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
@@ -80,14 +80,16 @@ public class ExternalApiKeyController {
 
 	/**
 	 * 삭제 요청: {@code gracePeriodDays=0}이면 즉시 물리 삭제. 그 외에는 유예(기본 7일) 후 스케줄러가 행을 제거하며 유예 중 취소 가능.
+	 * 즉시 삭제 시 {@code retainLogs=false}이면 usage 쪽에 해당 키의 사용 로그·메타데이터 정리를 요청한다(미지정 시 보존).
 	 */
 	@DeleteMapping("/external-keys/{id}")
 	public ResponseEntity<ApiResponse<ExternalApiKeyRegisterResponse>> requestDeletion(
 			@AuthenticationPrincipal IdentityUserPrincipal principal,
 			@PathVariable("id") Long id,
-			@RequestParam(name = "gracePeriodDays", required = false) Integer gracePeriodDays
+			@RequestParam(name = "gracePeriodDays", required = false) Integer gracePeriodDays,
+			@RequestParam(name = "retainLogs", defaultValue = "true") boolean retainLogs
 	) {
-		ExternalApiKeyEntity saved = externalApiKeyService.requestDeletion(principal.userId(), id, gracePeriodDays);
+		ExternalApiKeyEntity saved = externalApiKeyService.requestDeletion(principal.userId(), id, gracePeriodDays, retainLogs);
 		boolean immediate = gracePeriodDays != null && gracePeriodDays == 0;
 		String message = immediate
 				? "API 키가 즉시 영구 삭제되었습니다."

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/mq/ExternalApiKeyStatusChangedEventPublisher.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/mq/ExternalApiKeyStatusChangedEventPublisher.java
@@ -3,6 +3,7 @@ package com.zerobugfreinds.identity_service.mq;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.zerobugfreinds.identity.events.ExternalApiKeyDeletedEvent;
 import com.zerobugfreinds.identity.events.ExternalApiKeyStatusChangedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +14,11 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
- * Publishes external API key status events to RabbitMQ only after transaction commit.
+ * Publishes identity external API key messages to RabbitMQ only after transaction commit.
+ * <ul>
+ *     <li>{@link ExternalApiKeyStatusChangedEvent} — 등록·수정·삭제 예약·취소 등 상태 동기화</li>
+ *     <li>{@link ExternalApiKeyDeletedEvent} — 물리 삭제(즉시 또는 유예 만료), usage 로그 보존 여부 포함</li>
+ * </ul>
  */
 @Component
 public class ExternalApiKeyStatusChangedEventPublisher {
@@ -37,23 +42,35 @@ public class ExternalApiKeyStatusChangedEventPublisher {
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void onExternalApiKeyStatusChanged(ExternalApiKeyStatusChangedEvent event) {
-		publish(event);
+		publishJson(event, "ExternalApiKeyStatusChangedEvent", event.keyId(), event.userId(), event.status());
 	}
 
-	void publish(ExternalApiKeyStatusChangedEvent event) {
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onExternalApiKeyDeleted(ExternalApiKeyDeletedEvent event) {
+		publishJson(
+				event,
+				"ExternalApiKeyDeletedEvent",
+				event.apiKeyId(),
+				event.userId(),
+				event.retainLogs()
+		);
+	}
+
+	private void publishJson(Object payload, String label, Object apiKeyOrKeyId, Long userId, Object statusOrRetain) {
 		try {
-			String json = EVENT_JSON.writeValueAsString(event);
+			String json = EVENT_JSON.writeValueAsString(payload);
 			rabbitTemplate.convertAndSend(exchange, routingKey, json);
 			log.info(
-					"Published ExternalApiKeyStatusChangedEvent keyId={} userId={} status={} exchange={} routingKey={}",
-					event.keyId(),
-					event.userId(),
-					event.status(),
+					"Published {} apiKeyIdOrKeyId={} userId={} detail={} exchange={} routingKey={}",
+					label,
+					apiKeyOrKeyId,
+					userId,
+					statusOrRetain,
 					exchange,
 					routingKey
 			);
 		} catch (JsonProcessingException e) {
-			throw new IllegalStateException("ExternalApiKeyStatusChangedEvent serialization failed", e);
+			throw new IllegalStateException(label + " serialization failed", e);
 		}
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
@@ -1,6 +1,7 @@
 package com.zerobugfreinds.identity_service.service;
 
 import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
+import com.zerobugfreinds.identity.events.ExternalApiKeyDeletedEvent;
 import com.zerobugfreinds.identity.events.ExternalApiKeyStatus;
 import com.zerobugfreinds.identity.events.ExternalApiKeyStatusChangedEvent;
 import com.zerobugfreinds.identity_service.dto.InternalApiKeyResponse;
@@ -262,7 +263,7 @@ public class ExternalApiKeyService {
 	 * 삭제 요청: 유예 기간 후 {@link #purgeExpiredKeys()} 가 행을 제거한다.
 	 */
 	@Transactional
-	public ExternalApiKeyEntity requestDeletion(Long userId, Long externalKeyId, Integer gracePeriodDays) {
+	public ExternalApiKeyEntity requestDeletion(Long userId, Long externalKeyId, Integer gracePeriodDays, boolean retainLogs) {
 		if (userId == null || externalKeyId == null) {
 			throw new IllegalArgumentException("userId와 externalKeyId는 필수입니다");
 		}
@@ -275,7 +276,7 @@ public class ExternalApiKeyService {
 		Instant now = Instant.now();
 		if (days == 0) {
 			log.info("[AUDIT] external_api_key_immediately_deleted userId={} keyId={}", userId, entity.getId());
-			publishExternalApiKeyStatusChanged(entity, ExternalApiKeyStatus.DELETED);
+			publishExternalApiKeyDeleted(entity, retainLogs);
 			externalApiKeyRepository.delete(entity);
 			return entity;
 		}
@@ -320,7 +321,7 @@ public class ExternalApiKeyService {
 					e.getId(),
 					e.getProvider().name()
 			);
-			publishExternalApiKeyStatusChanged(e, ExternalApiKeyStatus.DELETED);
+			publishExternalApiKeyDeleted(e, true);
 		}
 		externalApiKeyRepository.deleteAll(expired);
 		return expired.size();
@@ -333,6 +334,18 @@ public class ExternalApiKeyService {
 				entity.getUserId(),
 				entity.getProvider().name(),
 				status
+		);
+		applicationEventPublisher.publishEvent(event);
+	}
+
+	private void publishExternalApiKeyDeleted(ExternalApiKeyEntity entity, boolean retainLogs) {
+		ExternalApiKeyDeletedEvent event = ExternalApiKeyDeletedEvent.of(
+				entity.getUserId(),
+				entity.getId(),
+				Instant.now(),
+				retainLogs,
+				entity.getProvider().name(),
+				entity.getKeyAlias()
 		);
 		applicationEventPublisher.publishEvent(event);
 	}

--- a/services/identity-service/src/test/java/com/zerobugfreinds/identity_service/mq/ExternalApiKeyStatusChangedEventPublisherTest.java
+++ b/services/identity-service/src/test/java/com/zerobugfreinds/identity_service/mq/ExternalApiKeyStatusChangedEventPublisherTest.java
@@ -3,8 +3,13 @@ package com.zerobugfreinds.identity_service.mq;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.zerobugfreinds.identity.events.ExternalApiKeyDeletedEvent;
 import com.zerobugfreinds.identity.events.ExternalApiKeyStatus;
 import com.zerobugfreinds.identity.events.ExternalApiKeyStatusChangedEvent;
+import com.zerobugfreinds.identity.events.IdentityExternalApiKeyEventTypes;
+
+import java.time.Instant;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -37,7 +42,7 @@ class ExternalApiKeyStatusChangedEventPublisherTest {
 				"OPENAI",
 				ExternalApiKeyStatus.ACTIVE
 		);
-		publisher.publish(event);
+		publisher.onExternalApiKeyStatusChanged(event);
 
 		ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
 		verify(rabbitTemplate).convertAndSend(
@@ -55,5 +60,41 @@ class ExternalApiKeyStatusChangedEventPublisherTest {
 		assertThat(node.get("provider").asText()).isEqualTo("OPENAI");
 		assertThat(node.get("status").asText()).isEqualTo("ACTIVE");
 		assertThat(node.hasNonNull("occurredAt")).isTrue();
+	}
+
+	@Test
+	void publish_deleted_sendsTeamStylePayload() throws Exception {
+		ExternalApiKeyStatusChangedEventPublisher publisher = new ExternalApiKeyStatusChangedEventPublisher(
+				rabbitTemplate,
+				"identity.events",
+				"identity.external-api-key.status-changed"
+		);
+
+		ExternalApiKeyDeletedEvent deleted = ExternalApiKeyDeletedEvent.of(
+				99L,
+				10L,
+				Instant.parse("2026-04-15T12:00:00Z"),
+				false,
+				"OPENAI",
+				"Main key"
+		);
+		publisher.onExternalApiKeyDeleted(deleted);
+
+		ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+		verify(rabbitTemplate).convertAndSend(
+				eq("identity.events"),
+				eq("identity.external-api-key.status-changed"),
+				jsonCaptor.capture()
+		);
+
+		ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+		JsonNode node = mapper.readTree(jsonCaptor.getValue());
+		assertThat(node.get("eventType").asText()).isEqualTo(IdentityExternalApiKeyEventTypes.EXTERNAL_API_KEY_DELETED);
+		assertThat(node.get("userId").asLong()).isEqualTo(99L);
+		assertThat(node.get("apiKeyId").asLong()).isEqualTo(10L);
+		assertThat(node.get("retainLogs").asBoolean()).isFalse();
+		assertThat(node.hasNonNull("occurredAt")).isTrue();
+		assertThat(node.get("provider").asText()).isEqualTo("OPENAI");
+		assertThat(node.get("alias").asText()).isEqualTo("Main key");
 	}
 }

--- a/services/identity-service/web/src/app/api/auth/external-keys/[id]/route.test.ts
+++ b/services/identity-service/web/src/app/api/auth/external-keys/[id]/route.test.ts
@@ -61,6 +61,31 @@ describe("DELETE /api/auth/external-keys/[id] (route handler)", () => {
     expect(res.status).toBe(200)
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
+
+  it("forwards retainLogs with immediate deletion query", async () => {
+    process.env.IDENTITY_SERVICE_URL = "http://localhost:8080"
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe(
+        "http://localhost:8080/api/auth/external-keys/123?gracePeriodDays=0&retainLogs=false"
+      )
+      return new Response(JSON.stringify({ success: true, message: "ok", data: null }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const req = new Request(
+      "http://localhost/api/auth/external-keys/123?gracePeriodDays=0&retainLogs=false",
+      {
+        method: "DELETE",
+        headers: { cookie: "access_token=t", Accept: "application/json" },
+      }
+    )
+    const res = await DELETE(req, context)
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe("PUT /api/auth/external-keys/[id] (route handler)", () => {

--- a/services/identity-service/web/src/components/account/account-settings-view.tsx
+++ b/services/identity-service/web/src/components/account/account-settings-view.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { Eye, EyeOff } from "lucide-react"
+import { Checkbox, Label } from "@ai-usage/ui"
 
 import { apiFetch } from "@/lib/api/client-fetch"
 import type {
@@ -123,6 +124,7 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
   const [externalKeyDeletionModal, setExternalKeyDeletionModal] = React.useState<{
     keyId: number
     graceDaysInput: string
+    retainLogs: boolean
   } | null>(null)
 
   const [deletePassword, _setDeletePassword] = React.useState("")
@@ -267,7 +269,11 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
 
   function openExternalKeyDeletionModal(keyId: number) {
     setKeysError(null)
-    setExternalKeyDeletionModal({ keyId, graceDaysInput: String(DEFAULT_DELETION_GRACE_DAYS) })
+    setExternalKeyDeletionModal({
+      keyId,
+      graceDaysInput: String(DEFAULT_DELETION_GRACE_DAYS),
+      retainLogs: true,
+    })
   }
 
   function closeExternalKeyDeletionModal() {
@@ -281,12 +287,15 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
       setKeysError(GRACE_PERIOD_DELETION_HINT)
       return
     }
-    const { keyId } = externalKeyDeletionModal
-    const { graceDays } = parsed
+    const { keyId, retainLogs } = externalKeyDeletionModal
+    const { graceDays, immediate } = parsed
     setKeysError(null)
     setKeyActionId(keyId)
     try {
       const q = new URLSearchParams({ gracePeriodDays: String(graceDays) })
+      if (immediate) {
+        q.set("retainLogs", String(retainLogs))
+      }
       const { response, json } = await apiFetch<unknown>(
         `/api/auth/external-keys/${keyId}?${q.toString()}`,
         { method: "DELETE", credentials: "include", cache: "no-store", headers: { Accept: "application/json" } },
@@ -486,6 +495,30 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
                 <p className="text-xs text-destructive">{keysError}</p>
               ) : null}
             </div>
+            {deletionModalParsed?.valid && deletionModalParsed.immediate ? (
+              <div className="mt-4 flex gap-3 rounded-md border border-border bg-muted/30 p-3">
+                <Checkbox
+                  id="external-key-retain-logs"
+                  checked={externalKeyDeletionModal.retainLogs}
+                  onCheckedChange={(v) => {
+                    setKeysError(null)
+                    setExternalKeyDeletionModal((prev) =>
+                      prev ? { ...prev, retainLogs: v === true } : prev
+                    )
+                  }}
+                  disabled={keyActionId === externalKeyDeletionModal.keyId}
+                  className="mt-0.5"
+                />
+                <div className="min-w-0 space-y-1">
+                  <Label htmlFor="external-key-retain-logs" className="text-sm font-medium leading-snug">
+                    기존 API 사용 기록 보존
+                  </Label>
+                  <p className="text-xs text-muted-foreground leading-relaxed">
+                    체크 해제 시, 이 API Key로 발생한 모든 호출 로그와 통계가 영구적으로 삭제됩니다.
+                  </p>
+                </div>
+              </div>
+            ) : null}
             <div className="mt-5 flex flex-wrap justify-end gap-2">
               <button
                 type="button"


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #123 (진행 중인 이슈 번호가 있다면 적어주세요)

## 작업 내용
- **해당 서비스**: `Identity Service`, `Identity Web MFE`, `@ai-usage/ui`
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
개인 외부 API Key 즉시 삭제(`gracePeriodDays=0`) 시, 기존 사용량 로그를 보존할지 영구 삭제할지 사용자가 선택할 수 있는 기능을 추가했습니다. 이에 맞춰 상태 변경과 완전 삭제의 도메인 이벤트를 명확히 분리하여 아키텍처를 개선했습니다.

## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`) - *데이터 보존 정책 UI 및 백엔드 파라미터 추가*
- [ ] 버그 수정 (`fix`)
- [x] 리팩토링 (`refactor`) - *삭제 전용 도메인 이벤트 분리 (`ExternalApiKeyDeletedEvent`)*
- [x] 문서 업데이트 (`docs`) - *API 및 BFF 계약 문서 갱신*

## 📝 상세 내용
### 🎨 프론트엔드 (Identity Web & Shared UI)
- **공유 컴포넌트 추가**: `packages/ui`에 Radix 기반의 `Checkbox` 컴포넌트 추가 및 export.
- **삭제 모달 UI 개선**: 즉시 삭제 시 노출되는 '기존 API 사용 기록 보존' 체크박스 추가 (`retainLogs` 상태 관리, 기본값 `true`).
- **API Payload 변경**: `DELETE` 요청 시 `gracePeriodDays=0`인 경우 쿼리 파라미터로 `retainLogs`를 함께 전송.
- **BFF (Proxy)**: 변경 없이 upstream 전달 유지. 쿼리 전달에 대한 회귀 테스트(`route.test.ts`) 추가.

### 🛠 백엔드 (Identity Service)
- **이벤트 구조 리팩터링**: 기존 `status: DELETED`를 사용하던 로직을 폐기하고, 물리 삭제를 의미하는 `ExternalApiKeyDeletedEvent`로 명시적 분리 (team-service 규격과 통일).
- **Controller/Service 수정**: 
  - `DELETE /api/auth/external-keys/{id}`에 `retainLogs` 파라미터 추가 (`@RequestParam(defaultValue="true")`로 하위 호환성 보장).
  - 유예 만료로 인한 purge 시에도 `retainLogs=true`로 고정하여 동일 이벤트 발행.
- **이벤트 퍼블리셔**: `@TransactionalEventListener`를 두 개로 분리하여 `ExternalApiKeyStatusChangedEvent`와 `ExternalApiKeyDeletedEvent`를 동일 exchange로 라우팅.

### 📄 문서 (Contracts)
- `docs/contracts/web-identity-bff.md` 및 `docs/identity-auth-api-contract.md`에 `retainLogs` 파라미터 규격 보강.

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [x] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
  - *`ExternalApiKeyDeletedEvent` 신규 발행 (페이로드에 `retainLogs`, `provider`, `alias` 포함).*
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
*(체크박스가 추가된 API Key 삭제 모달 캡처를 첨부해 주세요)*
- `identity-service` 빌드 통과 및 이벤트 발행 통합 테스트(`ExternalApiKeyStatusChangedEventPublisherTest`) 통과 확인 완료.
- 
<img width="565" height="461" alt="image" src="https://github.com/user-attachments/assets/d9f45059-b9a7-41c0-9d5d-6abcd922ee50" />

현재 0일 때만 선택 가능 추후 수정 예정

## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- **Backend**: API Key의 단순 상태 변경(Status Changed)과 실제 데이터 생명주기 종료(Deleted)를 명확히 분리하기 위해 이벤트를 나누었습니다. 
- **Usage Service 담당자 (예나님)**: 
  - 기존에 `ExternalApiKeyStatusChangedEvent`에서 받던 `retainUsageLogs` 필드를 제거하고, 전용 이벤트인 **`ExternalApiKeyDeletedEvent`**(`eventType="EXTERNAL_API_KEY_DELETED"`)를 새로 발행하도록 수정했습니다.
  - 페이로드의 `retainLogs` 값이 `false`일 때만 usage DB의 로그와 메타데이터를 삭제 처리해 주시면 됩니다. (현재 제 권한 밖이라 `usage-service` 쪽 수신 로직은 롤백 후 넘겨드립니다!)