### PR TITLE
Feature/usagelog for deleted api key

### DIFF
--- a/services/usage-service/src/main/java/com/eevee/usageservice/consumer/ExternalApiKeyStatusChangedEventListener.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/consumer/ExternalApiKeyStatusChangedEventListener.java
@@ -1,7 +1,10 @@
 package com.eevee.usageservice.consumer;
 
 import com.eevee.usageservice.service.ApiKeyMetadataSyncService;
+import com.eevee.usageservice.mq.ExternalApiKeyDeletedEvent;
 import com.eevee.usageservice.mq.ExternalApiKeyStatusChangedEvent;
+import com.eevee.usageservice.mq.IdentityExternalApiKeyEventTypes;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +12,11 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+/**
+ * identity.events 의 외부 API Key 메시지를 소비한다.
+ * 동일 큐·라우팅 키로 {@link ExternalApiKeyStatusChangedEvent}(등록·별칭·상태)와
+ * {@link ExternalApiKeyDeletedEvent}(물리 삭제) JSON 이 모두 올 수 있다.
+ */
 @Component
 @ConditionalOnProperty(prefix = "usage.rabbit.identity-api-key", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class ExternalApiKeyStatusChangedEventListener {
@@ -29,10 +37,21 @@ public class ExternalApiKeyStatusChangedEventListener {
     @RabbitListener(queues = "${usage.rabbit.identity-api-key.queue}")
     public void onMessage(String json) {
         try {
-            ExternalApiKeyStatusChangedEvent event = objectMapper.readValue(json, ExternalApiKeyStatusChangedEvent.class);
-            apiKeyMetadataSyncService.upsertFromIdentity(event);
+            JsonNode root = objectMapper.readTree(json);
+            if (root.has("eventType")
+                    && IdentityExternalApiKeyEventTypes.EXTERNAL_API_KEY_DELETED.equals(root.get("eventType").asText())) {
+                ExternalApiKeyDeletedEvent deleted = objectMapper.treeToValue(root, ExternalApiKeyDeletedEvent.class);
+                apiKeyMetadataSyncService.handleExternalApiKeyDeleted(deleted);
+                return;
+            }
+            if (root.has("schemaVersion")) {
+                ExternalApiKeyStatusChangedEvent changed = objectMapper.readValue(json, ExternalApiKeyStatusChangedEvent.class);
+                apiKeyMetadataSyncService.upsertFromIdentity(changed);
+                return;
+            }
+            log.warn("Unrecognized identity external API key JSON (expected eventType={} or schemaVersion)", IdentityExternalApiKeyEventTypes.EXTERNAL_API_KEY_DELETED);
         } catch (Exception e) {
-            log.error("Failed to deserialize or upsert ExternalApiKeyStatusChangedEvent", e);
+            log.error("Failed to handle identity external API key event", e);
             throw new IllegalStateException("identity external api key event handling failed", e);
         }
     }

--- a/services/usage-service/src/main/java/com/eevee/usageservice/domain/UsageRecordedLogEntity.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/domain/UsageRecordedLogEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,7 +23,13 @@ import java.time.Instant;
 import java.util.UUID;
 
 @Entity
-@Table(name = "usage_recorded_log")
+@Table(
+        name = "usage_recorded_log",
+        indexes = {
+                @Index(name = "idx_url_team_occurred", columnList = "team_id, occurred_at"),
+                @Index(name = "idx_url_user_team_occurred", columnList = "user_id, team_id, occurred_at")
+        }
+)
 public class UsageRecordedLogEntity {
 
     @Id

--- a/services/usage-service/src/main/java/com/eevee/usageservice/mq/ExternalApiKeyDeletedEvent.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/mq/ExternalApiKeyDeletedEvent.java
@@ -1,0 +1,37 @@
+package com.eevee.usageservice.mq;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+/**
+ * identity-service 가 물리 삭제 시 발행하는 페이로드.
+ * {@code retainLogs} 가 JSON 에 없으면 null 로 두고, 소비 측에서 true(로그 유지)로 간주한다.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ExternalApiKeyDeletedEvent(
+        @JsonProperty("eventType")
+        String eventType,
+
+        @JsonProperty("userId")
+        Long userId,
+
+        @JsonProperty("apiKeyId")
+        Long apiKeyId,
+
+        @JsonProperty("occurredAt")
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        Instant occurredAt,
+
+        @JsonProperty("retainLogs")
+        Boolean retainLogs,
+
+        @JsonProperty("provider")
+        String provider,
+
+        @JsonProperty("alias")
+        String alias
+) {
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/mq/IdentityExternalApiKeyEventTypes.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/mq/IdentityExternalApiKeyEventTypes.java
@@ -1,0 +1,12 @@
+package com.eevee.usageservice.mq;
+
+/**
+ * identity-service AMQP 페이로드의 {@code eventType} 값 (identity-events 와 동일 문자열).
+ */
+public final class IdentityExternalApiKeyEventTypes {
+
+    public static final String EXTERNAL_API_KEY_DELETED = "EXTERNAL_API_KEY_DELETED";
+
+    private IdentityExternalApiKeyEventTypes() {
+    }
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/repository/UsageRecordedLogRepository.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/repository/UsageRecordedLogRepository.java
@@ -17,11 +17,17 @@ import java.util.UUID;
 
 public interface UsageRecordedLogRepository extends JpaRepository<UsageRecordedLogEntity, UUID> {
 
+    long countByApiKeyId(String apiKeyId);
+
     boolean existsByEventId(UUID eventId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update UsageRecordedLogEntity u set u.estimatedCost = :cost where u.eventId = :eventId")
     int updateEstimatedCostByEventId(@Param("eventId") UUID eventId, @Param("cost") BigDecimal cost);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from UsageRecordedLogEntity u where u.apiKeyId = :apiKeyId")
+    int deleteByApiKeyId(@Param("apiKeyId") String apiKeyId);
 
     @Query(
             value = """

--- a/services/usage-service/src/main/java/com/eevee/usageservice/service/ApiKeyMetadataSyncService.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/service/ApiKeyMetadataSyncService.java
@@ -2,9 +2,13 @@ package com.eevee.usageservice.service;
 
 import com.eevee.usageservice.domain.ApiKeyMetadataEntity;
 import com.eevee.usageservice.domain.ApiKeyStatus;
+import com.eevee.usageservice.mq.ExternalApiKeyDeletedEvent;
 import com.eevee.usageservice.mq.ExternalApiKeyStatus;
 import com.eevee.usageservice.mq.ExternalApiKeyStatusChangedEvent;
 import com.eevee.usageservice.repository.ApiKeyMetadataRepository;
+import com.eevee.usageservice.repository.UsageRecordedLogRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -14,10 +18,17 @@ import java.time.Instant;
 @Service
 public class ApiKeyMetadataSyncService {
 
-    private final ApiKeyMetadataRepository apiKeyMetadataRepository;
+    private static final Logger log = LoggerFactory.getLogger(ApiKeyMetadataSyncService.class);
 
-    public ApiKeyMetadataSyncService(ApiKeyMetadataRepository apiKeyMetadataRepository) {
+    private final ApiKeyMetadataRepository apiKeyMetadataRepository;
+    private final UsageRecordedLogRepository usageRecordedLogRepository;
+
+    public ApiKeyMetadataSyncService(
+            ApiKeyMetadataRepository apiKeyMetadataRepository,
+            UsageRecordedLogRepository usageRecordedLogRepository
+    ) {
         this.apiKeyMetadataRepository = apiKeyMetadataRepository;
+        this.usageRecordedLogRepository = usageRecordedLogRepository;
     }
 
     @Transactional
@@ -38,6 +49,48 @@ public class ApiKeyMetadataSyncService {
                 event.provider(),
                 alias,
                 mapStatus(event.status()),
+                updatedAt
+        );
+        apiKeyMetadataRepository.save(entity);
+    }
+
+    /**
+     * 물리 삭제 완료 이벤트: 기본은 메타데이터만 {@link ApiKeyStatus#DELETED} 로 맞추고 사용 로그는 유지한다.
+     * {@code retainLogs == false} 일 때만 해당 키의 사용 로그와 메타데이터 행을 삭제한다.
+     */
+    @Transactional
+    public void handleExternalApiKeyDeleted(ExternalApiKeyDeletedEvent event) {
+        if (event.apiKeyId() == null || event.userId() == null) {
+            throw new IllegalArgumentException("apiKeyId, userId are required");
+        }
+        String keyId = String.valueOf(event.apiKeyId());
+        String userId = String.valueOf(event.userId());
+        boolean retainLogs = event.retainLogs() == null || event.retainLogs();
+
+        if (!retainLogs) {
+            int removedLogs = usageRecordedLogRepository.deleteByApiKeyId(keyId);
+            apiKeyMetadataRepository.deleteById(keyId);
+            log.info(
+                    "External API key purged from usage (retainLogs=false) keyId={} userId={} removedLogs={}",
+                    keyId,
+                    userId,
+                    removedLogs
+            );
+            return;
+        }
+
+        Instant updatedAt = event.occurredAt() != null ? event.occurredAt() : Instant.now();
+        ApiKeyMetadataEntity entity = apiKeyMetadataRepository.findById(keyId)
+                .orElseGet(() -> ApiKeyMetadataEntity.create(keyId, userId));
+
+        String alias = StringUtils.hasText(event.alias()) ? event.alias().trim() : entity.getAlias();
+        String provider = StringUtils.hasText(event.provider()) ? event.provider().trim() : entity.getProvider();
+
+        entity.apply(
+                userId,
+                provider,
+                alias,
+                ApiKeyStatus.DELETED,
                 updatedAt
         );
         apiKeyMetadataRepository.save(entity);

--- a/services/usage-service/src/test/java/com/eevee/usageservice/integration/ExternalApiKeyStatusChangedPipelineIntegrationTest.java
+++ b/services/usage-service/src/test/java/com/eevee/usageservice/integration/ExternalApiKeyStatusChangedPipelineIntegrationTest.java
@@ -1,8 +1,13 @@
 package com.eevee.usageservice.integration;
 
+import com.eevee.usage.events.AiProvider;
+import com.eevee.usageservice.domain.UsageRecordedLogEntity;
+import com.eevee.usageservice.mq.ExternalApiKeyDeletedEvent;
 import com.eevee.usageservice.mq.ExternalApiKeyStatus;
 import com.eevee.usageservice.mq.ExternalApiKeyStatusChangedEvent;
+import com.eevee.usageservice.mq.IdentityExternalApiKeyEventTypes;
 import com.eevee.usageservice.repository.ApiKeyMetadataRepository;
+import com.eevee.usageservice.repository.UsageRecordedLogRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +24,9 @@ import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.UUID;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,6 +67,9 @@ class ExternalApiKeyStatusChangedPipelineIntegrationTest {
 
     @Autowired
     private ApiKeyMetadataRepository repository;
+
+    @Autowired
+    private UsageRecordedLogRepository usageRecordedLogRepository;
 
     @Autowired
     private AmqpAdmin amqpAdmin;
@@ -119,14 +129,14 @@ class ExternalApiKeyStatusChangedPipelineIntegrationTest {
                     assertThat(updated.getStatus().name()).isEqualTo("ACTIVE");
                 });
 
-        ExternalApiKeyStatusChangedEvent deleted = new ExternalApiKeyStatusChangedEvent(
-                1,
-                Instant.parse("2026-04-15T10:02:00Z"),
-                101L,
-                "GoogleTestKey1-Renamed",
+        ExternalApiKeyDeletedEvent deleted = new ExternalApiKeyDeletedEvent(
+                IdentityExternalApiKeyEventTypes.EXTERNAL_API_KEY_DELETED,
                 7L,
+                101L,
+                Instant.parse("2026-04-15T10:02:00Z"),
+                true,
                 "GOOGLE",
-                ExternalApiKeyStatus.DELETED
+                "GoogleTestKey1-Renamed"
         );
         rabbitTemplate.convertAndSend(
                 "identity.events",
@@ -139,6 +149,75 @@ class ExternalApiKeyStatusChangedPipelineIntegrationTest {
                     var deletedRow = repository.findById("101").orElseThrow();
                     assertThat(deletedRow.getAlias()).isEqualTo("GoogleTestKey1-Renamed");
                     assertThat(deletedRow.getStatus().name()).isEqualTo("DELETED");
+                });
+    }
+
+    @Test
+    void deletedEvent_retainLogsFalse_removesUsageLogsAndMetadata() throws Exception {
+        ExternalApiKeyStatusChangedEvent registered = new ExternalApiKeyStatusChangedEvent(
+                1,
+                Instant.parse("2026-04-16T10:00:00Z"),
+                303L,
+                "KeyToPurge",
+                9L,
+                "GOOGLE",
+                ExternalApiKeyStatus.ACTIVE
+        );
+        rabbitTemplate.convertAndSend(
+                "identity.events",
+                "identity.external-api-key.status-changed",
+                objectMapper.writeValueAsString(registered)
+        );
+        await().atMost(30, SECONDS).pollInterval(100, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .until(() -> repository.findById("303").isPresent());
+
+        UsageRecordedLogEntity log = new UsageRecordedLogEntity(
+                UUID.randomUUID(),
+                Instant.parse("2026-04-16T09:00:00Z"),
+                null,
+                "9",
+                null,
+                null,
+                "303",
+                "fp",
+                "managed",
+                AiProvider.GOOGLE,
+                "gemini",
+                1L,
+                1L,
+                2L,
+                0L,
+                null,
+                BigDecimal.ZERO,
+                "/p",
+                "h.example",
+                false,
+                true,
+                200,
+                Instant.now()
+        );
+        usageRecordedLogRepository.save(log);
+        assertThat(usageRecordedLogRepository.countByApiKeyId("303")).isEqualTo(1L);
+
+        ExternalApiKeyDeletedEvent purge = new ExternalApiKeyDeletedEvent(
+                IdentityExternalApiKeyEventTypes.EXTERNAL_API_KEY_DELETED,
+                9L,
+                303L,
+                Instant.parse("2026-04-16T12:00:00Z"),
+                false,
+                "GOOGLE",
+                "KeyToPurge"
+        );
+        rabbitTemplate.convertAndSend(
+                "identity.events",
+                "identity.external-api-key.status-changed",
+                objectMapper.writeValueAsString(purge)
+        );
+
+        await().atMost(30, SECONDS).pollInterval(100, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(repository.findById("303")).isEmpty();
+                    assertThat(usageRecordedLogRepository.countByApiKeyId("303")).isEqualTo(0L);
                 });
     }
 }

--- a/services/usage-service/web/src/components/usage/usage-log-panel.tsx
+++ b/services/usage-service/web/src/components/usage/usage-log-panel.tsx
@@ -9,7 +9,10 @@ import {
   Label,
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
   Tooltip,
@@ -37,6 +40,10 @@ function toApiKeyLabel(item: UsageLogApiKeyItemResponse): string {
   const alias = item.alias?.trim()
   if (!alias) return "별칭 없음"
   return item.status === "DELETED" ? `${alias} (삭제)` : alias
+}
+
+function isDeletedApiKeyItem(item: UsageLogApiKeyItemResponse): boolean {
+  return item.status === "DELETED"
 }
 
 function toLongOrZero(v: number | null | undefined): number {
@@ -105,6 +112,15 @@ export function UsageLogPanel() {
     successFilter === "true" ? "true" : successFilter === "false" ? "false" : undefined
   const reasoningPresenceParam =
     reasoningFilter === "present" ? "present" : reasoningFilter === "absent" ? "absent" : undefined
+
+  const activeApiKeyOptions = React.useMemo(
+    () => apiKeyOptions.filter((x) => !isDeletedApiKeyItem(x)),
+    [apiKeyOptions]
+  )
+  const deletedApiKeyOptions = React.useMemo(
+    () => apiKeyOptions.filter((x) => isDeletedApiKeyItem(x)),
+    [apiKeyOptions]
+  )
 
   React.useEffect(() => {
     let cancelled = false
@@ -206,13 +222,31 @@ export function UsageLogPanel() {
             <SelectTrigger id="log-apikey" className="w-full">
               <SelectValue placeholder="전체" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent className="max-h-[min(70vh,26rem)]">
               <SelectItem value={LOG_API_KEY_ALL}>전체</SelectItem>
-              {apiKeyOptions.map((item) => (
-                <SelectItem key={item.apiKeyId} value={item.apiKeyId}>
-                  {toApiKeyLabel(item)}
-                </SelectItem>
-              ))}
+              {activeApiKeyOptions.length > 0 ? (
+                <SelectGroup>
+                  <SelectLabel>사용 중</SelectLabel>
+                  {activeApiKeyOptions.map((item) => (
+                    <SelectItem key={item.apiKeyId} value={item.apiKeyId}>
+                      {toApiKeyLabel(item)}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              ) : null}
+              {deletedApiKeyOptions.length > 0 ? (
+                <>
+                  {activeApiKeyOptions.length > 0 ? <SelectSeparator /> : null}
+                  <SelectGroup>
+                    <SelectLabel>삭제됨 (로그 보존)</SelectLabel>
+                    {deletedApiKeyOptions.map((item) => (
+                      <SelectItem key={item.apiKeyId} value={item.apiKeyId}>
+                        {toApiKeyLabel(item)}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </>
+              ) : null}
             </SelectContent>
           </Select>
         </div>
@@ -303,11 +337,12 @@ export function UsageLogPanel() {
       ) : (
         <>
           <div className="overflow-x-auto rounded-md border border-border">
-            <table className="w-full min-w-[980px] text-left text-sm">
+            <table className="w-full min-w-[1060px] text-left text-sm">
               <thead className="border-b border-border bg-muted/40">
                 <tr>
                   <th className="px-3 py-2 font-medium">시각 (KST)</th>
                   <th className="px-3 py-2 font-medium">공급자</th>
+                  <th className="px-3 py-2 font-medium">별칭</th>
                   <th className="px-3 py-2 font-medium">모델</th>
                   <th className="px-3 py-2 font-medium">입력 토큰</th>
                   <th className="px-3 py-2 font-medium">
@@ -368,6 +403,9 @@ export function UsageLogPanel() {
                       {formatOccurredAtKst(row.occurredAt)}
                     </td>
                     <td className="px-3 py-2">{row.provider}</td>
+                    <td className="px-3 py-2 max-w-[200px] truncate" title={row.apiKeyAlias ?? undefined}>
+                      {row.apiKeyAlias ?? "—"}
+                    </td>
                     <td className="px-3 py-2 font-mono text-xs">{row.model}</td>
                     <td className="px-3 py-2 tabular-nums">{row.promptTokens ?? "—"}</td>
                     <td className="px-3 py-2">


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> N/A

## 작업 내용
- **해당 서비스**: Usage Serivce
> 삭제된 개인 api key 메타 데이터를 보내는 이벤트 발행 로직이 변경된 것에 따라 ExternalApiKeyDeletedEvent이벤트를 소비하여 usage_db에 저장되는 api key 메타 데이터를 업데이트하는 로직을 추가 및 변경했습니다. 
> 팀 단위 통계 조회 성능을 최적화하기 위한 DB 인덱스 설계 및 API Key 관리 편의성을 위한 UI 개선 작업을 진행했습니다.

  
## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [x] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
1. ExternalApiKeyDeletedEvent 이벤트 소비 로직 및 api_key_metadata 데이터 갱신 로직 리펙토링
- identity-service에서 API Key가 영구 삭제될 때는 ExternalApiKeyStatusChangedEvent 대신 **ExternalApiKeyDeletedEvent**라는 전용 이벤트가 eventType="EXTERNAL_API_KEY_DELETED"를 달고 발행되는 것으로 변경되었습니다.
- 그에 따라 기존에 api key가 삭제될 때 소비하던 이벤트를 **ExternalApiKeyDeletedEvent**에 따라 변경했습니다.
- **ExternalApiKeyDeletedEvent**이벤트의 페이로드 안에 **retainLogs**라는 boolean 필드가 false라면 usage_db의 usage_recorded_log엔티티에서 '삭제 대상 api key'에 해당하는 모든 사용량 로그를 삭제한 후, api_key_metadata 엔티티에서 '삭제 대상 api key' 행을 삭제하도록 변경했습니다. 
- **retainLogs**라는 boolean 필드의 값이 true라면, api_key_metadata엔티티에서 '삭제 대상 api key'의 status를 'deleted'로 변경만 하고 api key행이나 사용량 로그를 삭제하는 작업은 수행하지 않도록 변경했습니다. 

2. DB 성능 최적화 (Indexing Strategy)
- 팀 대시보드 조회용 복합 인덱스: (team_id, occurred_at) 인덱스를 추가하여 팀별 시간축 데이터 추출 성능을 개선했습니다.
- 팀원 상세 분석용 복합 인덱스: (user_id, team_id, occurred_at) 인덱스를 추가하여 특정 팀 내 개별 사용자의 활동 내역 조회를 가속화했습니다.
- 정합성 유지: 서비스 발생 시점인 occurred_at을 시간축 기준으로 삼아 통계 데이터의 신뢰성을 확보했습니다.

3. API Key 필터 드롭다운 고도화
- 상태 기반 그룹화: 'DELETED' 여부에 따라 '사용 중'과 '삭제됨' 그룹으로 분리하여 가시성을 높였습니다.
- 동적 UI 적용: 두 그룹 모두 존재 시에만 구분선(SelectSeparator)을 표시하며, 목록이 길어질 경우 스크롤이 가능하도록 뷰포트를 최적화했습니다.

4. 사용량 로그 테이블 개선
- 별칭 컬럼 추가: 로그 테이블에 apiKeyAlias 컬럼을 추가하여 데이터 식별성을 강화했습니다.
- 삭제 데이터 처리: 백엔드에서 처리된 '별칭 (삭제)' 형식을 그대로 유지하며, 긴 별칭은 truncate 처리하되 title 속성으로 전체 확인이 가능하게 구현했습니다.

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 
- [ ] **RabbitMQ**: 
- [x] **DB**: usage_db의 복합 인덱스 추가

## 📸 스크린샷 / 테스트 결과 (선택)
## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- usage_recorded_log 테이블에서 team_id가 nullable인 상태를 유지하며 개인/팀 로그가 통합 관리되고 있습니다. 인덱스 추가가 개인 로그 조회 성능에 미칠 영향이 없는지 한 번 더 확인 부탁드립니다.
- 프론트엔드 SelectContent의 최대 높이(max-h-[min(70vh,26rem)])가 다양한 해상도에서 적절하게 작동하는지 검토 부탁드립니다.
- dashboard/usagelog 화면에 진입하여 데이터를 조회할 때, 성능이 저하되는지 확인해주세요. 만약 성능이 저하된다면 read전용 DB를 복제하여 구축할 계획입니다. 
