### PR TITLE
Feature/api gateway proxy enforcement for team

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
       team: ${{ steps.filter.outputs.team }}
       notification: ${{ steps.filter.outputs.notification }}
       web_host: ${{ steps.filter.outputs.web_host }}
-      web_apps: ${{ steps.filter.outputs.web_apps }}
       web_mfe: ${{ steps.filter.outputs.web_mfe }}
       web_shared: ${{ steps.filter.outputs.web_shared }}
       workflows: ${{ steps.filter.outputs.workflows }}
@@ -72,12 +71,6 @@ jobs:
               - 'docker/backend-node-deps.Dockerfile'
             web_host:
               - 'apps/web/**'
-            web_apps:
-              - 'services/identity-service/web/**'
-              - 'services/usage-service/web/**'
-              - 'services/billing-service/web/**'
-              - 'services/team-service/web/**'
-              - 'services/notification-service/web/**'
             web_mfe:
               - 'services/usage-service/web-mfe/**'
               - 'services/team-service/web-mfe/**'
@@ -114,7 +107,7 @@ jobs:
     name: Build identity-service
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.identity == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.identity == 'true' || needs.changes.outputs.web_shared == 'true' || needs.changes.outputs.workflows == 'true'
     defaults:
       run:
         working-directory: services/identity-service
@@ -130,6 +123,31 @@ jobs:
         run: chmod +x ./gradlew
       - name: Build and test
         run: ./gradlew build --no-daemon
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Reset pnpm store metadata
+        run: pnpm store prune
+        working-directory: .
+      - name: Install workspace
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+      # ESLint: omit --max-warnings so only errors fail the step; warnings do not stop CI
+      - name: Lint / test / build (identity-web)
+        run: |
+          pnpm --filter identity-web run lint
+          pnpm --filter identity-web test
+          pnpm run build:identity-web
+        working-directory: .
+      - name: Docker deps base image (shared pnpm install layer)
+        run: docker build -f docker/web-node-deps.Dockerfile -t web-node-deps:ci .
+        working-directory: .
+      - name: Docker image (identity-web, standalone)
+        run: docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f services/identity-service/web/Dockerfile -t identity-web:ci .
+        working-directory: .
 
   proxy-gateway-service:
     name: Build proxy-gateway-service
@@ -162,7 +180,7 @@ jobs:
     name: Build usage-service
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.usage == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.usage == 'true' || needs.changes.outputs.web_shared == 'true' || needs.changes.outputs.workflows == 'true'
     defaults:
       run:
         working-directory: services/usage-service
@@ -178,12 +196,37 @@ jobs:
         run: chmod +x ./gradlew
       - name: Build and test
         run: ./gradlew build --no-daemon
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Reset pnpm store metadata
+        run: pnpm store prune
+        working-directory: .
+      - name: Install workspace
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+      # ESLint: omit --max-warnings so only errors fail the step; warnings do not stop CI
+      - name: Lint / test / build (usage-web)
+        run: |
+          pnpm --filter usage-web run lint
+          pnpm --filter usage-web test
+          pnpm run build:usage-web
+        working-directory: .
+      - name: Docker deps base image (shared pnpm install layer)
+        run: docker build -f docker/web-node-deps.Dockerfile -t web-node-deps:ci .
+        working-directory: .
+      - name: Docker image (usage-web, standalone)
+        run: docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f services/usage-service/web/Dockerfile -t usage-web:ci .
+        working-directory: .
 
   billing-service:
     name: Build billing-service
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.billing == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.billing == 'true' || needs.changes.outputs.web_shared == 'true' || needs.changes.outputs.workflows == 'true'
     defaults:
       run:
         working-directory: services/billing-service
@@ -199,12 +242,37 @@ jobs:
         run: chmod +x ./gradlew
       - name: Build and test
         run: ./gradlew build --no-daemon
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Reset pnpm store metadata
+        run: pnpm store prune
+        working-directory: .
+      - name: Install workspace
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+      # ESLint: omit --max-warnings so only errors fail the step; warnings do not stop CI
+      - name: Lint / test / build (billing-web)
+        run: |
+          pnpm --filter billing-web run lint
+          pnpm --filter billing-web test
+          pnpm run build:billing-web
+        working-directory: .
+      - name: Docker deps base image (shared pnpm install layer)
+        run: docker build -f docker/web-node-deps.Dockerfile -t web-node-deps:ci .
+        working-directory: .
+      - name: Docker image (billing-web, standalone)
+        run: docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f services/billing-service/web/Dockerfile -t billing-web:ci .
+        working-directory: .
 
   team-service:
     name: Build team-service
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.team == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.team == 'true' || needs.changes.outputs.web_shared == 'true' || needs.changes.outputs.workflows == 'true'
     defaults:
       run:
         working-directory: services/team-service
@@ -220,12 +288,37 @@ jobs:
         run: chmod +x ./gradlew
       - name: Build and test
         run: ./gradlew build --no-daemon
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Reset pnpm store metadata
+        run: pnpm store prune
+        working-directory: .
+      - name: Install workspace
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+      # ESLint: omit --max-warnings so only errors fail the step; warnings do not stop CI
+      - name: Lint / test / build (team-web)
+        run: |
+          pnpm --filter team-web run lint
+          pnpm --filter team-web test
+          pnpm run build:team-web
+        working-directory: .
+      - name: Docker deps base image (shared pnpm install layer)
+        run: docker build -f docker/web-node-deps.Dockerfile -t web-node-deps:ci .
+        working-directory: .
+      - name: Docker image (team-web, standalone)
+        run: docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f services/team-service/web/Dockerfile -t team-web:ci .
+        working-directory: .
 
   notification-service:
     name: Build notification-service
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.notification == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.notification == 'true' || needs.changes.outputs.web_shared == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -240,10 +333,20 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build (Nest)
         run: pnpm --filter notification-service run build
+      # ESLint: omit --max-warnings so only errors fail the step; warnings do not stop CI
+      - name: Lint / test / build (notification-web)
+        run: |
+          pnpm --filter notification-web run lint
+          pnpm --filter notification-web test
+          pnpm --filter notification-web run build
       - name: Docker deps base image (notification backend)
         run: docker build -f docker/backend-node-deps.Dockerfile -t backend-node-deps:ci .
       - name: Docker image (notification-service)
         run: docker build --build-arg BACKEND_NODE_DEPS_IMAGE=backend-node-deps:ci -f services/notification-service/Dockerfile -t notification-service:ci .
+      - name: Docker deps base image (shared pnpm install layer)
+        run: docker build -f docker/web-node-deps.Dockerfile -t web-node-deps:ci .
+      - name: Docker image (notification-web, standalone)
+        run: docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f services/notification-service/web/Dockerfile -t notification-web:ci .
 
   web-host:
     name: Build web-host (apps/web)
@@ -276,54 +379,6 @@ jobs:
           node -e "const fs=require('node:fs');const p='apps/web/next.config.mjs';const c=fs.readFileSync(p,'utf8');for(const x of ['NextFederationPlugin','team@','usage@','remoteEntry.js']){if(!c.includes(x)){throw new Error('missing '+x+' in '+p)}}"
       - name: Docker image (web-host, standalone)
         run: docker build -f docker/web-node-deps.Dockerfile -t web-node-deps:ci . && docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f apps/web/Dockerfile -t web-host:ci .
-
-  web-apps:
-    name: Build web apps (services/*/web)
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.web_apps == 'true' || needs.changes.outputs.web_shared == 'true' || needs.changes.outputs.workflows == 'true'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      - name: Reset pnpm store metadata
-        run: pnpm store prune
-      - name: Install workspace
-        run: pnpm install --frozen-lockfile
-      # ESLint: omit --max-warnings so only errors fail the step; warnings do not stop CI
-      - name: Lint / test / build (service web apps)
-        run: |
-          pnpm --filter identity-web run lint
-          pnpm --filter usage-web run lint
-          pnpm --filter billing-web run lint
-          pnpm --filter team-web run lint
-          pnpm --filter notification-web run lint
-          pnpm --filter identity-web test
-          pnpm --filter usage-web test
-          pnpm --filter billing-web test
-          pnpm --filter team-web test
-          pnpm --filter notification-web test
-          pnpm --filter notification-web run build
-          pnpm run build:identity-web
-          pnpm run build:usage-web
-          pnpm run build:billing-web
-          pnpm run build:team-web
-      - name: Docker deps base image (shared pnpm install layer)
-        run: docker build -f docker/web-node-deps.Dockerfile -t web-node-deps:ci .
-      - name: Docker image (identity-web, standalone)
-        run: docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f services/identity-service/web/Dockerfile -t identity-web:ci .
-      - name: Docker image (usage-web, standalone)
-        run: docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f services/usage-service/web/Dockerfile -t usage-web:ci .
-      - name: Docker image (billing-web, standalone)
-        run: docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f services/billing-service/web/Dockerfile -t billing-web:ci .
-      - name: Docker image (team-web, standalone)
-        run: docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f services/team-service/web/Dockerfile -t team-web:ci .
-      - name: Docker image (notification-web, standalone)
-        run: docker build --build-arg WEB_NODE_DEPS_IMAGE=web-node-deps:ci -f services/notification-service/web/Dockerfile -t notification-web:ci .
 
   web-mfe:
     name: Build web-mfe remotes (usage/team)
@@ -377,7 +432,6 @@ jobs:
       - team-service
       - notification-service
       - web-host
-      - web-apps
       - web-mfe
     if: always()
     steps:
@@ -395,7 +449,7 @@ jobs:
             echo "compose-validate did not succeed: ${{ needs.compose-validate.result }}"
             exit 1
           fi
-          for name in identity-service proxy-gateway-service usage-service billing-service team-service notification-service web-host web-apps web-mfe; do
+          for name in identity-service proxy-gateway-service usage-service billing-service team-service notification-service web-host web-mfe; do
             case "$name" in
               identity-service) v="${{ needs.identity-service.result }}" ;;
               proxy-gateway-service) v="${{ needs.proxy-gateway-service.result }}" ;;
@@ -404,7 +458,6 @@ jobs:
               team-service) v="${{ needs.team-service.result }}" ;;
               notification-service) v="${{ needs.notification-service.result }}" ;;
               web-host) v="${{ needs['web-host'].result }}" ;;
-              web-apps) v="${{ needs['web-apps'].result }}" ;;
               web-mfe) v="${{ needs['web-mfe'].result }}" ;;
             esac
             if [[ "$v" == "failure" || "$v" == "cancelled" ]]; then

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
@@ -143,6 +143,7 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
     private Mono<Void> forwardWithJwt(ServerWebExchange exchange, WebFilterChain chain, JwtAuthenticationToken jwtAuth) {
         Jwt jwt = jwtAuth.getToken();
         ServerHttpRequest.Builder req = exchange.getRequest().mutate();
+        sanitizeTrustHeaders(req);
         req.header(HDR_USER, jwt.getSubject());
         String platformUserId = jwt.getClaimAsString("userId");
         if (platformUserId != null && !platformUserId.isBlank()) {
@@ -167,13 +168,33 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
             return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing X-User-Id"));
         }
         ServerHttpRequest.Builder req = exchange.getRequest().mutate();
+        sanitizeTrustHeaders(req);
+        req.header(HDR_USER, userId);
         copyCorrelation(exchange, req);
         String platformUserId = exchange.getRequest().getHeaders().getFirst(HDR_PLATFORM_USER);
         if (platformUserId != null && !platformUserId.isBlank()) {
             req.header(HDR_PLATFORM_USER, platformUserId);
         }
+        String org = exchange.getRequest().getHeaders().getFirst(HDR_ORG);
+        if (org != null && !org.isBlank()) {
+            req.header(HDR_ORG, org);
+        }
+        String team = exchange.getRequest().getHeaders().getFirst(HDR_TEAM);
+        if (team != null && !team.isBlank()) {
+            req.header(HDR_TEAM, team);
+        }
         attachGatewayAuth(req);
         return chain.filter(exchange.mutate().request(req.build()).build());
+    }
+
+    private void sanitizeTrustHeaders(ServerHttpRequest.Builder req) {
+        req.headers(headers -> {
+            headers.remove(HDR_USER);
+            headers.remove(HDR_PLATFORM_USER);
+            headers.remove(HDR_ORG);
+            headers.remove(HDR_TEAM);
+            headers.remove(HDR_GATEWAY_AUTH);
+        });
     }
 
     private void copyCorrelation(ServerWebExchange exchange, ServerHttpRequest.Builder req) {

--- a/services/api-gateway-service/src/test/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilterTest.java
+++ b/services/api-gateway-service/src/test/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilterTest.java
@@ -201,6 +201,74 @@ class ProxyTrustHeadersWebFilterTest {
     }
 
     @Test
+    void jwtMode_sanitizesSpoofedTrustHeadersAndReinjectsVerifiedValues() {
+        gatewayProperties.setDevMode(false);
+        Jwt jwt = Jwt.withTokenValue("dummy")
+                .header("alg", "HS256")
+                .subject("verified-user@example.com")
+                .claim("userId", "314")
+                .claim("team_id", "team-1")
+                .build();
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/v1/ai/proxy/openai/chat")
+                .header("X-User-Id", "spoofed@example.com")
+                .header("X-Platform-User-Id", "999")
+                .header("X-Team-Id", "evil-team")
+                .header("X-Gateway-Auth", "evil-secret")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        AtomicReference<String> userIdSeen = new AtomicReference<>();
+        AtomicReference<String> platformUserIdSeen = new AtomicReference<>();
+        AtomicReference<String> teamIdSeen = new AtomicReference<>();
+        AtomicReference<String> gatewayAuthSeen = new AtomicReference<>();
+        WebFilterChain chain = ex -> {
+            userIdSeen.set(ex.getRequest().getHeaders().getFirst("X-User-Id"));
+            platformUserIdSeen.set(ex.getRequest().getHeaders().getFirst("X-Platform-User-Id"));
+            teamIdSeen.set(ex.getRequest().getHeaders().getFirst("X-Team-Id"));
+            gatewayAuthSeen.set(ex.getRequest().getHeaders().getFirst("X-Gateway-Auth"));
+            return Mono.empty();
+        };
+
+        ProxyTrustHeadersWebFilter filter = new ProxyTrustHeadersWebFilter(gatewayProperties);
+
+        StepVerifier.create(filter.applyTrustHeaders(exchange, chain, auth))
+                .verifyComplete();
+
+        assertThat(userIdSeen.get()).isEqualTo("verified-user@example.com");
+        assertThat(platformUserIdSeen.get()).isEqualTo("314");
+        assertThat(teamIdSeen.get()).isEqualTo("team-1");
+        assertThat(gatewayAuthSeen.get()).isNull();
+    }
+
+    @Test
+    void jwtTeamIdIsNotForwardedWhenClaimMissing() {
+        gatewayProperties.setDevMode(false);
+        Jwt jwt = Jwt.withTokenValue("dummy")
+                .header("alg", "HS256")
+                .subject("user@example.com")
+                .build();
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/v1/usage/dashboard/summary")
+                .header("X-Team-Id", "spoofed-team")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        AtomicReference<String> teamIdSeen = new AtomicReference<>();
+        WebFilterChain chain = ex -> {
+            teamIdSeen.set(ex.getRequest().getHeaders().getFirst("X-Team-Id"));
+            return Mono.empty();
+        };
+
+        ProxyTrustHeadersWebFilter filter = new ProxyTrustHeadersWebFilter(gatewayProperties);
+
+        StepVerifier.create(filter.applyTrustHeaders(exchange, chain, auth))
+                .verifyComplete();
+
+        assertThat(teamIdSeen.get()).isNull();
+    }
+
+    @Test
     void devMode_forwardsInboundXUserId_whenSecurityContextIsAnonymous() {
         AnonymousAuthenticationToken anon = new AnonymousAuthenticationToken(
                 "anon-key",
@@ -251,6 +319,33 @@ class ProxyTrustHeadersWebFilterTest {
                 .verifyComplete();
 
         assertThat(platformUserIdSeen.get()).isEqualTo("99");
+    }
+
+    @Test
+    void devMode_forwardsInboundTeamHeader_whenPresent() {
+        AnonymousAuthenticationToken anon = new AnonymousAuthenticationToken(
+                "anon-key",
+                "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")
+        );
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/v1/usage/dashboard/summary")
+                .header("X-User-Id", "bff-session@local.dev")
+                .header("X-Team-Id", "team-local")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        AtomicReference<String> teamIdSeen = new AtomicReference<>();
+        WebFilterChain chain = ex -> {
+            teamIdSeen.set(ex.getRequest().getHeaders().getFirst("X-Team-Id"));
+            return Mono.empty();
+        };
+
+        ProxyTrustHeadersWebFilter filter = new ProxyTrustHeadersWebFilter(gatewayProperties);
+
+        StepVerifier.create(filter.applyTrustHeaders(exchange, chain, anon))
+                .verifyComplete();
+
+        assertThat(teamIdSeen.get()).isEqualTo("team-local");
     }
 
     @Test

--- a/services/proxy-service/src/main/java/com/eevee/proxyservice/config/ProxyProperties.java
+++ b/services/proxy-service/src/main/java/com/eevee/proxyservice/config/ProxyProperties.java
@@ -56,6 +56,7 @@ public class ProxyProperties {
     public static class KeyService {
         private String baseUrl = "http://localhost:8090";
         private String internalToken = "";
+        private String teamPath = "/internal/teams/{teamId}/api-keys/{provider}";
         private String mockKey = "";
         private String mockKeyOpenai = "";
         private String mockKeyGoogle = "";
@@ -75,6 +76,14 @@ public class ProxyProperties {
 
         public void setInternalToken(String internalToken) {
             this.internalToken = internalToken;
+        }
+
+        public String getTeamPath() {
+            return teamPath;
+        }
+
+        public void setTeamPath(String teamPath) {
+            this.teamPath = teamPath;
         }
 
         public String getMockKey() {

--- a/services/proxy-service/src/main/java/com/eevee/proxyservice/key/ApiKeyClient.java
+++ b/services/proxy-service/src/main/java/com/eevee/proxyservice/key/ApiKeyClient.java
@@ -42,18 +42,25 @@ public class ApiKeyClient {
      * @param keyLookupUserId numeric platform user id when available, else gateway subject (e.g. email)
      */
     public Mono<ResolvedApiKey> resolveApiKey(String keyLookupUserId, AiProvider provider) {
-        String cacheKey = keyLookupUserId + ":" + provider.pathSegment();
+        return resolveApiKey(keyLookupUserId, null, provider);
+    }
+
+    public Mono<ResolvedApiKey> resolveApiKey(String keyLookupUserId, String teamId, AiProvider provider) {
+        String scope = (teamId != null && !teamId.isBlank()) ? "team:" + teamId : "user:" + keyLookupUserId;
+        String cacheKey = scope + ":" + provider.pathSegment();
         return Mono.fromCallable(() -> cache.get(cacheKey))
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
     private ResolvedApiKey loadKeyBlocking(String cacheKey) {
-        int idx = cacheKey.indexOf(':');
-        if (idx <= 0) {
+        int firstIdx = cacheKey.indexOf(':');
+        int secondIdx = cacheKey.indexOf(':', firstIdx + 1);
+        if (firstIdx <= 0 || secondIdx <= firstIdx + 1) {
             throw new IllegalStateException("invalid cache key");
         }
-        String keyLookupUserId = cacheKey.substring(0, idx);
-        String segment = cacheKey.substring(idx + 1);
+        String scope = cacheKey.substring(0, firstIdx);
+        String subjectId = cacheKey.substring(firstIdx + 1, secondIdx);
+        String segment = cacheKey.substring(secondIdx + 1);
         AiProvider provider = AiProvider.fromPathSegment(segment);
 
         String mock = resolveMockKey(provider);
@@ -63,19 +70,35 @@ public class ApiKeyClient {
 
         String token = proxyProperties.getKeyService().getInternalToken();
         try {
-            KeyResponse body = keyServiceWebClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path("/internal/api-keys/{provider}")
-                            .queryParam("userId", keyLookupUserId)
-                            .build(provider.pathSegment()))
-                    .headers(h -> {
-                        if (token != null && !token.isBlank()) {
-                            h.setBearerAuth(token);
-                        }
-                    })
-                    .retrieve()
-                    .bodyToMono(KeyResponse.class)
-                    .block(Duration.ofSeconds(10));
+            KeyResponse body;
+            if ("team".equals(scope)) {
+                body = keyServiceWebClient.get()
+                        .uri(uriBuilder -> uriBuilder
+                                .path(proxyProperties.getKeyService().getTeamPath())
+                                .build(subjectId, provider.pathSegment()))
+                        .headers(h -> {
+                            if (token != null && !token.isBlank()) {
+                                h.setBearerAuth(token);
+                            }
+                        })
+                        .retrieve()
+                        .bodyToMono(KeyResponse.class)
+                        .block(Duration.ofSeconds(10));
+            } else {
+                body = keyServiceWebClient.get()
+                        .uri(uriBuilder -> uriBuilder
+                                .path("/internal/api-keys/{provider}")
+                                .queryParam("userId", subjectId)
+                                .build(provider.pathSegment()))
+                        .headers(h -> {
+                            if (token != null && !token.isBlank()) {
+                                h.setBearerAuth(token);
+                            }
+                        })
+                        .retrieve()
+                        .bodyToMono(KeyResponse.class)
+                        .block(Duration.ofSeconds(10));
+            }
             if (body == null || body.plainKey() == null || body.plainKey().isBlank()) {
                 throw new IllegalStateException("key service returned empty key");
             }

--- a/services/proxy-service/src/main/java/com/eevee/proxyservice/relay/ProxyRelayService.java
+++ b/services/proxy-service/src/main/java/com/eevee/proxyservice/relay/ProxyRelayService.java
@@ -77,7 +77,7 @@ public class ProxyRelayService {
         ProviderHandler handler = providerRegistry.get(provider);
 
         return userContextResolver.fromExchange(exchange)
-                .flatMap(ctx -> apiKeyClient.resolveApiKey(ctx.keyLookupUserId(), provider)
+                .flatMap(ctx -> apiKeyClient.resolveApiKey(ctx.keyLookupUserId(), ctx.teamId(), provider)
                         .flatMap(resolvedApiKey -> forward(exchange, ctx, handler, provider, remainder, resolvedApiKey)));
     }
 

--- a/services/proxy-service/src/main/java/com/eevee/proxyservice/security/UserContextResolver.java
+++ b/services/proxy-service/src/main/java/com/eevee/proxyservice/security/UserContextResolver.java
@@ -34,15 +34,13 @@ public class UserContextResolver {
             String correlationId
     ) {
         String platformUserId = firstNonBlankHeader(exchange, HDR_PLATFORM_USER);
+        String org = firstNonBlankHeader(exchange, HDR_ORG);
+        String team = firstNonBlankHeader(exchange, HDR_TEAM);
         if (auth != null && auth.isAuthenticated() && auth.getPrincipal() instanceof String userId) {
-            String org = exchange.getRequest().getHeaders().getFirst(HDR_ORG);
-            String team = exchange.getRequest().getHeaders().getFirst(HDR_TEAM);
             return Mono.just(new UserContext(userId, platformUserId, org, team, correlationId));
         }
         String userId = exchange.getRequest().getHeaders().getFirst(HDR_USER);
         if (userId != null && !userId.isBlank()) {
-            String org = exchange.getRequest().getHeaders().getFirst(HDR_ORG);
-            String team = exchange.getRequest().getHeaders().getFirst(HDR_TEAM);
             return Mono.just(new UserContext(userId, platformUserId, org, team, correlationId));
         }
         return Mono.error(new IllegalStateException("Missing X-User-Id (from Gateway)"));

--- a/services/proxy-service/src/main/resources/application.yml
+++ b/services/proxy-service/src/main/resources/application.yml
@@ -27,6 +27,7 @@ proxy:
   key-service:
     base-url: http://localhost:8090
     internal-token: ""
+    team-path: /internal/teams/{teamId}/api-keys/{provider}
     mock-key-openai: ${PROXY_OPENAI_TEST_API_KEY:}
     mock-key-google: ${PROXY_GOOGLE_TEST_API_KEY:}
     mock-key: ${PROXY_MOCK_KEY_FALLBACK:}

--- a/services/proxy-service/src/test/java/com/eevee/proxyservice/key/ApiKeyClientMockKeyTest.java
+++ b/services/proxy-service/src/test/java/com/eevee/proxyservice/key/ApiKeyClientMockKeyTest.java
@@ -53,6 +53,19 @@ class ApiKeyClientMockKeyTest {
         assertThat(google.plainKey()).isEqualTo("legacy-only");
     }
 
+    @Test
+    void resolveApiKey_acceptsTeamScope() {
+        ProxyProperties props = baseProps();
+        props.getKeyService().setMockKey("legacy-only");
+
+        ApiKeyClient client = new ApiKeyClient(props);
+        ApiKeyClient.ResolvedApiKey teamScoped = client.resolveApiKey("user-1", "team-22", AiProvider.OPENAI).block();
+
+        assertThat(teamScoped).isNotNull();
+        assertThat(teamScoped.plainKey()).isEqualTo("legacy-only");
+        assertThat(teamScoped.keySource()).isEqualTo("mock");
+    }
+
     private static ProxyProperties baseProps() {
         ProxyProperties props = new ProxyProperties();
         props.getKeyService().setBaseUrl("http://localhost:0");

--- a/services/proxy-service/src/test/java/com/eevee/proxyservice/security/UserContextResolverTest.java
+++ b/services/proxy-service/src/test/java/com/eevee/proxyservice/security/UserContextResolverTest.java
@@ -42,4 +42,21 @@ class UserContextResolverTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    void blankOrgAndTeamHeaders_areNormalizedToNull() {
+        MockServerHttpRequest request = MockServerHttpRequest.get("/proxy/google/")
+                .header("X-User-Id", "a@b.com")
+                .header("X-Org-Id", "   ")
+                .header("X-Team-Id", "")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+        StepVerifier.create(resolver.fromExchange(exchange))
+                .assertNext(ctx -> {
+                    assertThat(ctx.organizationId()).isNull();
+                    assertThat(ctx.teamId()).isNull();
+                })
+                .verifyComplete();
+    }
 }

--- a/services/usage-service/src/main/java/com/eevee/usageservice/config/UsageRabbitProperties.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/config/UsageRabbitProperties.java
@@ -26,6 +26,7 @@ public class UsageRabbitProperties {
      * {@link UsageCostEventAmqp#TOPIC_EXCHANGE_NAME} / {@link UsageCostEventAmqp#ROUTING_KEY_COST_FINALIZED}.
      */
     private IdentityApiKey identityApiKey = new IdentityApiKey();
+    private TeamApiKey teamApiKey = new TeamApiKey();
 
     private CostFinalized costFinalized = new CostFinalized();
 
@@ -64,6 +65,16 @@ public class UsageRabbitProperties {
     public void setIdentityApiKey(IdentityApiKey identityApiKey) {
         if (identityApiKey != null) {
             this.identityApiKey = identityApiKey;
+        }
+    }
+
+    public TeamApiKey getTeamApiKey() {
+        return teamApiKey;
+    }
+
+    public void setTeamApiKey(TeamApiKey teamApiKey) {
+        if (teamApiKey != null) {
+            this.teamApiKey = teamApiKey;
         }
     }
 
@@ -118,6 +129,45 @@ public class UsageRabbitProperties {
         private String exchange = UsageCostEventAmqp.TOPIC_EXCHANGE_NAME;
         private String routingKey = UsageCostEventAmqp.ROUTING_KEY_COST_FINALIZED;
         private String queue = UsageCostEventAmqp.SUGGESTED_USAGE_SERVICE_QUEUE;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getExchange() {
+            return exchange;
+        }
+
+        public void setExchange(String exchange) {
+            this.exchange = exchange;
+        }
+
+        public String getRoutingKey() {
+            return routingKey;
+        }
+
+        public void setRoutingKey(String routingKey) {
+            this.routingKey = routingKey;
+        }
+
+        public String getQueue() {
+            return queue;
+        }
+
+        public void setQueue(String queue) {
+            this.queue = queue;
+        }
+    }
+
+    public static class TeamApiKey {
+        private boolean enabled = true;
+        private String exchange = "team.events";
+        private String routingKey = "team-member-added";
+        private String queue = "usage-service.team.api-key.queue";
 
         public boolean isEnabled() {
             return enabled;

--- a/services/usage-service/src/main/java/com/eevee/usageservice/config/UsageTeamApiKeyRabbitConfiguration.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/config/UsageTeamApiKeyRabbitConfiguration.java
@@ -1,0 +1,35 @@
+package com.eevee.usageservice.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(prefix = "usage.rabbit.team-api-key", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class UsageTeamApiKeyRabbitConfiguration {
+
+    @Bean
+    public TopicExchange usageTeamApiKeyExchange(UsageRabbitProperties props) {
+        return new TopicExchange(props.getTeamApiKey().getExchange(), true, false);
+    }
+
+    @Bean
+    public Queue usageTeamApiKeyQueue(UsageRabbitProperties props) {
+        return new Queue(props.getTeamApiKey().getQueue(), true);
+    }
+
+    @Bean
+    public Binding usageTeamApiKeyBinding(
+            Queue usageTeamApiKeyQueue,
+            TopicExchange usageTeamApiKeyExchange,
+            UsageRabbitProperties props
+    ) {
+        return BindingBuilder.bind(usageTeamApiKeyQueue)
+                .to(usageTeamApiKeyExchange)
+                .with(props.getTeamApiKey().getRoutingKey());
+    }
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/consumer/TeamApiKeyChangedEventListener.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/consumer/TeamApiKeyChangedEventListener.java
@@ -1,0 +1,55 @@
+package com.eevee.usageservice.consumer;
+
+import com.eevee.usageservice.domain.ApiKeyStatus;
+import com.eevee.usageservice.mq.TeamApiKeyChangedEvent;
+import com.eevee.usageservice.mq.TeamApiKeyEventTypes;
+import com.eevee.usageservice.service.ApiKeyMetadataSyncService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "usage.rabbit.team-api-key", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class TeamApiKeyChangedEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(TeamApiKeyChangedEventListener.class);
+
+    private final ObjectMapper objectMapper;
+    private final ApiKeyMetadataSyncService apiKeyMetadataSyncService;
+
+    public TeamApiKeyChangedEventListener(
+            ObjectMapper objectMapper,
+            ApiKeyMetadataSyncService apiKeyMetadataSyncService
+    ) {
+        this.objectMapper = objectMapper;
+        this.apiKeyMetadataSyncService = apiKeyMetadataSyncService;
+    }
+
+    @RabbitListener(queues = "${usage.rabbit.team-api-key.queue}")
+    public void onMessage(String json) {
+        try {
+            TeamApiKeyChangedEvent event = objectMapper.readValue(json, TeamApiKeyChangedEvent.class);
+            if (event.eventType() == null || event.eventType().isBlank()) {
+                log.warn("Skipping team api key event without eventType");
+                return;
+            }
+            switch (event.eventType()) {
+                case TeamApiKeyEventTypes.TEAM_API_KEY_REGISTERED,
+                     TeamApiKeyEventTypes.TEAM_API_KEY_UPDATED,
+                     TeamApiKeyEventTypes.TEAM_API_KEY_DELETION_CANCELLED ->
+                        apiKeyMetadataSyncService.upsertFromTeam(event, ApiKeyStatus.ACTIVE);
+                case TeamApiKeyEventTypes.TEAM_API_KEY_DELETION_SCHEDULED ->
+                        apiKeyMetadataSyncService.upsertFromTeam(event, ApiKeyStatus.DELETION_REQUESTED);
+                case TeamApiKeyEventTypes.TEAM_API_KEY_DELETED ->
+                        apiKeyMetadataSyncService.upsertFromTeam(event, ApiKeyStatus.DELETED);
+                default -> log.debug("Ignoring non team-api-key eventType={}", event.eventType());
+            }
+        } catch (Exception e) {
+            log.error("Failed to handle team API key event", e);
+            throw new IllegalStateException("team api key event handling failed", e);
+        }
+    }
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/mq/TeamApiKeyChangedEvent.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/mq/TeamApiKeyChangedEvent.java
@@ -1,0 +1,31 @@
+package com.eevee.usageservice.mq;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+public record TeamApiKeyChangedEvent(
+        @JsonProperty("eventType")
+        String eventType,
+
+        @JsonProperty("teamId")
+        String teamId,
+
+        @JsonProperty("actorUserId")
+        String actorUserId,
+
+        @JsonProperty("occurredAt")
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        Instant occurredAt,
+
+        @JsonProperty("apiKeyId")
+        Long apiKeyId,
+
+        @JsonProperty("provider")
+        String provider,
+
+        @JsonProperty("alias")
+        String alias
+) {
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/mq/TeamApiKeyEventTypes.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/mq/TeamApiKeyEventTypes.java
@@ -1,0 +1,13 @@
+package com.eevee.usageservice.mq;
+
+public final class TeamApiKeyEventTypes {
+
+    public static final String TEAM_API_KEY_REGISTERED = "TEAM_API_KEY_REGISTERED";
+    public static final String TEAM_API_KEY_UPDATED = "TEAM_API_KEY_UPDATED";
+    public static final String TEAM_API_KEY_DELETED = "TEAM_API_KEY_DELETED";
+    public static final String TEAM_API_KEY_DELETION_SCHEDULED = "TEAM_API_KEY_DELETION_SCHEDULED";
+    public static final String TEAM_API_KEY_DELETION_CANCELLED = "TEAM_API_KEY_DELETION_CANCELLED";
+
+    private TeamApiKeyEventTypes() {
+    }
+}

--- a/services/usage-service/src/main/java/com/eevee/usageservice/service/ApiKeyMetadataSyncService.java
+++ b/services/usage-service/src/main/java/com/eevee/usageservice/service/ApiKeyMetadataSyncService.java
@@ -5,6 +5,7 @@ import com.eevee.usageservice.domain.ApiKeyStatus;
 import com.eevee.usageservice.mq.ExternalApiKeyDeletedEvent;
 import com.eevee.usageservice.mq.ExternalApiKeyStatus;
 import com.eevee.usageservice.mq.ExternalApiKeyStatusChangedEvent;
+import com.eevee.usageservice.mq.TeamApiKeyChangedEvent;
 import com.eevee.usageservice.repository.ApiKeyMetadataRepository;
 import com.eevee.usageservice.repository.UsageRecordedLogRepository;
 import org.slf4j.Logger;
@@ -49,6 +50,30 @@ public class ApiKeyMetadataSyncService {
                 event.provider(),
                 alias,
                 mapStatus(event.status()),
+                updatedAt
+        );
+        apiKeyMetadataRepository.save(entity);
+    }
+
+    @Transactional
+    public void upsertFromTeam(TeamApiKeyChangedEvent event, ApiKeyStatus status) {
+        if (event.apiKeyId() == null || !StringUtils.hasText(event.teamId()) || status == null) {
+            throw new IllegalArgumentException("apiKeyId, teamId, status are required");
+        }
+        String keyId = String.valueOf(event.apiKeyId());
+        String ownerRef = "team:" + event.teamId().trim();
+        Instant updatedAt = event.occurredAt() != null ? event.occurredAt() : Instant.now();
+
+        ApiKeyMetadataEntity entity = apiKeyMetadataRepository.findById(keyId)
+                .orElseGet(() -> ApiKeyMetadataEntity.create(keyId, ownerRef));
+
+        String alias = StringUtils.hasText(event.alias()) ? event.alias().trim() : entity.getAlias();
+        String provider = StringUtils.hasText(event.provider()) ? event.provider().trim() : entity.getProvider();
+        entity.apply(
+                ownerRef,
+                provider,
+                alias,
+                status,
                 updatedAt
         );
         apiKeyMetadataRepository.save(entity);

--- a/services/usage-service/src/main/resources/application.yml
+++ b/services/usage-service/src/main/resources/application.yml
@@ -44,6 +44,11 @@ usage:
       exchange: ${USAGE_RABBIT_IDENTITY_API_KEY_EXCHANGE:identity.events}
       routing-key: ${USAGE_RABBIT_IDENTITY_API_KEY_ROUTING_KEY:identity.external-api-key.status-changed}
       queue: ${USAGE_RABBIT_IDENTITY_API_KEY_QUEUE:usage-service.identity.external-api-key.queue}
+    team-api-key:
+      enabled: ${USAGE_RABBIT_TEAM_API_KEY_ENABLED:true}
+      exchange: ${USAGE_RABBIT_TEAM_API_KEY_EXCHANGE:team.events}
+      routing-key: ${USAGE_RABBIT_TEAM_API_KEY_ROUTING_KEY:team-member-added}
+      queue: ${USAGE_RABBIT_TEAM_API_KEY_QUEUE:usage-service.team.api-key.queue}
     cost-finalized:
       enabled: ${USAGE_RABBIT_COST_FINALIZED_ENABLED:true}
       exchange: ${USAGE_RABBIT_COST_FINALIZED_EXCHANGE:billing.events}

--- a/services/usage-service/src/test/java/com/eevee/usageservice/integration/ExternalApiKeyStatusChangedPipelineIntegrationTest.java
+++ b/services/usage-service/src/test/java/com/eevee/usageservice/integration/ExternalApiKeyStatusChangedPipelineIntegrationTest.java
@@ -6,6 +6,7 @@ import com.eevee.usageservice.mq.ExternalApiKeyDeletedEvent;
 import com.eevee.usageservice.mq.ExternalApiKeyStatus;
 import com.eevee.usageservice.mq.ExternalApiKeyStatusChangedEvent;
 import com.eevee.usageservice.mq.IdentityExternalApiKeyEventTypes;
+import com.eevee.usageservice.mq.TeamApiKeyEventTypes;
 import com.eevee.usageservice.repository.ApiKeyMetadataRepository;
 import com.eevee.usageservice.repository.UsageRecordedLogRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -77,10 +78,15 @@ class ExternalApiKeyStatusChangedPipelineIntegrationTest {
     @Value("${usage.rabbit.identity-api-key.queue}")
     private String identityApiKeyQueueName;
 
+    @Value("${usage.rabbit.team-api-key.queue}")
+    private String teamApiKeyQueueName;
+
     @BeforeEach
     void waitForQueueDeclarations() {
         await().atMost(20, SECONDS).pollInterval(200, java.util.concurrent.TimeUnit.MILLISECONDS)
                 .until(() -> amqpAdmin.getQueueProperties(identityApiKeyQueueName) != null);
+        await().atMost(20, SECONDS).pollInterval(200, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .until(() -> amqpAdmin.getQueueProperties(teamApiKeyQueueName) != null);
     }
 
     @Test
@@ -218,6 +224,68 @@ class ExternalApiKeyStatusChangedPipelineIntegrationTest {
                 .untilAsserted(() -> {
                     assertThat(repository.findById("303")).isEmpty();
                     assertThat(usageRecordedLogRepository.countByApiKeyId("303")).isEqualTo(0L);
+                });
+    }
+
+    @Test
+    void teamApiKeyEvents_areConsumedAndMetadataStatusIsUpdated() throws Exception {
+        String registerPayload = """
+                {
+                  "eventType": "%s",
+                  "teamId": "22",
+                  "actorUserId": "owner-1",
+                  "occurredAt": "2026-04-17T10:00:00Z",
+                  "apiKeyId": 505,
+                  "provider": "OPENAI",
+                  "alias": "TeamOpenAiKey"
+                }
+                """.formatted(TeamApiKeyEventTypes.TEAM_API_KEY_REGISTERED);
+        rabbitTemplate.convertAndSend("team.events", "team-member-added", registerPayload);
+
+        await().atMost(30, SECONDS).pollInterval(100, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    var active = repository.findById("505").orElseThrow();
+                    assertThat(active.getUserId()).isEqualTo("team:22");
+                    assertThat(active.getAlias()).isEqualTo("TeamOpenAiKey");
+                    assertThat(active.getStatus().name()).isEqualTo("ACTIVE");
+                });
+
+        String scheduledPayload = """
+                {
+                  "eventType": "%s",
+                  "teamId": "22",
+                  "actorUserId": "owner-1",
+                  "occurredAt": "2026-04-17T10:05:00Z",
+                  "apiKeyId": 505,
+                  "provider": "OPENAI",
+                  "alias": "TeamOpenAiKey"
+                }
+                """.formatted(TeamApiKeyEventTypes.TEAM_API_KEY_DELETION_SCHEDULED);
+        rabbitTemplate.convertAndSend("team.events", "team-member-added", scheduledPayload);
+
+        await().atMost(30, SECONDS).pollInterval(100, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    var deletionRequested = repository.findById("505").orElseThrow();
+                    assertThat(deletionRequested.getStatus().name()).isEqualTo("DELETION_REQUESTED");
+                });
+
+        String deletedPayload = """
+                {
+                  "eventType": "%s",
+                  "teamId": "22",
+                  "actorUserId": "owner-1",
+                  "occurredAt": "2026-04-17T10:10:00Z",
+                  "apiKeyId": 505,
+                  "provider": "OPENAI",
+                  "alias": "TeamOpenAiKey"
+                }
+                """.formatted(TeamApiKeyEventTypes.TEAM_API_KEY_DELETED);
+        rabbitTemplate.convertAndSend("team.events", "team-member-added", deletedPayload);
+
+        await().atMost(30, SECONDS).pollInterval(100, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    var deleted = repository.findById("505").orElseThrow();
+                    assertThat(deleted.getStatus().name()).isEqualTo("DELETED");
                 });
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> N/A

## 작업 내용
- **해당 서비스**: Proxy-Service, Usage-Service, CI (GitHub Actions)
> API Gateway와 Proxy 간의 보안 신뢰 경계를 강화하고, 팀(Team) 단위 API 키 및 컨텍스트 정규화 로직을 구축했습니다. 또한, MSA 구조에 최적화되도록 CI 파이프라인을 전면 개편했습니다.

  
## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [x] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
1. 보안 및 컨텍스트 정규화 (Proxy)
- 신뢰 헤더 위변조 차단: 클라이언트가 선주입한 X-User-Id, X-Team-Id 등의 헤더를 제거 후, 검증된 값만 재주입하도록 ProxyTrustHeadersWebFilter 강화.
- Team 컨텍스트 정규화: UserContextResolver에서 팀 ID 공백 값을 null로 정규화하여 개인/팀 호출을 명확히 구분.
- 캐시 오염 방지: ApiKeyClient 캐시 키에 team|user 스코프를 포함하여 권한 문맥 간 데이터 혼선 차단.

2. 팀 단위 API 키 상태 동기화 (Usage)
- 메시지 큐 연동: team.events 기반 Queue/Binding 신설 및 5가지 이벤트 타입(등록/수정/삭제 등) 소비 로직 구현.
- 상태 전이 검증: 팀 키의 ACTIVE → DELETED 상태 전이 시나리오에 대한 통합 테스트 보강.

3. CI 파이프라인 개편 (GitHub Actions)
- 통합 Job 해체: 거대한 web-apps Job을 제거하고 각 서비스 Job(Identity, Usage 등) 내부로 웹 빌드/테스트 단계를 통합.
- 경로 기반 최적화: 변경된 서비스의 코드만 빌드되도록 설정하여 CI 대기 시간 단축 및 자원 최적화.
- 구조 보존: web_host 및 web_mfe 관련 필수 검증 로직은 유지하여 MFE 아키텍처 준수.

## 🔗 인프라 및 통신 체크
- [x] **Redis**: ApiKeyClient 캐시 키 스코프(team/user) 추가로 인한 캐시 로직 변경.
- [x] **RabbitMQ**: usage-service 내 팀 API 키 이벤트 소비(Consume) 로직 및 설정 추가.
- [ ] **DB**: 

## 📸 스크린샷 / 테스트 결과 (선택)

## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- Proxy에서 헤더를 먼저 제거하고 다시 주입하는 방식이 Gateway와의 신뢰 관계를 충분히 보장하는지 검토 부탁드립니다.
- CI 개편 후 각 서비스의 Job이 의도한 대로 독립적으로 동작하는지, 특히 web_shared 변경 시 영향받는 서비스들이 잘 트리거되는지 확인이 필요합니다.
