### PR TITLE
feat(auth): implement active team context and api-key sync flow

### DIFF
--- a/docs/identity-team-token-event-implementation-20260426.md
+++ b/docs/identity-team-token-event-implementation-20260426.md
@@ -1,0 +1,142 @@
+# Identity-Team Token/Event Implementation Notes (2026-04-26)
+
+## 1. 목적
+
+- Identity-Team 경계에서 팀 컨텍스트 전환(`active_team_id`)과 Team API Key 상태 동기화 이벤트의 신뢰성(Outbox)을 동시에 정비한 작업 이력을 기록한다.
+- 운영/테스트 시 확인할 핵심 포인트(토큰 갱신, 내부 검증, Rabbit 릴레이, 회귀 테스트)를 한 문서에 모은다.
+
+---
+
+## 2. 핵심 변경 요약
+
+### 2.1 Identity: JWT/토큰 전환
+
+- `JwtTokenProvider`에 `active_team_id` 클레임 지원 추가.
+- 로그인/팀 전환 응답을 `TokenResponse(access + refresh)` 구조로 통일.
+- `/api/auth/switch-team` + `/api/auth/token/switch-team`에서 팀 전환 후 토큰 pair 재발급.
+- 팀 전환 시 기존 refresh 토큰 무효화 후 신규 refresh 토큰 저장(DB).
+
+### 2.2 Team: 멤버십 내부 검증 API
+
+- `GET /internal/v1/teams/{teamId}/members/{userId}/verify` 추가.
+- 응답 DTO: `InternalTeamMembershipVerifyResponse` (`isValid` 포함).
+
+### 2.3 Identity: TEAM_MEMBER_REMOVED 대응
+
+- Rabbit 리스너 추가로 `TEAM_MEMBER_REMOVED` 이벤트 수신.
+- 해당 사용자 refresh 토큰 삭제(세션 재발급 차단).
+- 보안 감사 로그(`warn`) 기록.
+
+### 2.4 Team: Team API Key 상태 이벤트 + Outbox
+
+- `TeamApiKeyStatusChangedEvent` 계약 DTO 반영(`schemaVersion`, `eventId`, `status`, `retainLogs` 포함).
+- `TeamApiKeyService`의 등록/수정/삭제 성공 직후 `ApplicationEventPublisher`로 상태 이벤트 발행.
+- `TeamEventOutbox`/`TeamEventOutboxRepository` 추가.
+- `@TransactionalEventListener(AFTER_COMMIT)` 기반 릴레이:
+  - Outbox 선저장
+  - Rabbit 발송
+  - 성공 시 `published=true`
+  - 실패 시 `published=false` 유지(재시도 대상)
+
+### 2.5 Frontend(team-web): 팀 전환 후 토큰 즉시 갱신
+
+- `POST /api/auth/token/switch-team` BFF 라우트 추가.
+- Identity switch-team 성공 시 새 `access_token` 쿠키 즉시 갱신.
+- 팀 선택 UI(`team-management-view.tsx`)에서 팀 전환 API 호출 연결.
+
+---
+
+## 3. 상세 변경 파일
+
+### 3.1 Identity 서비스
+
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/security/JwtTokenProvider.java`
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/AuthController.java`
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/UserService.java`
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/TeamMembershipVerificationClient.java`
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/RefreshTokenRevocationService.java`
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/mq/TeamMemberRemovedEventListener.java`
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/TeamMemberRemovedRabbitConfig.java`
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/RefreshTokenEntity.java`
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/RefreshTokenRepository.java`
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/TokenResponse.java`
+- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/SwitchTeamRequest.java`
+- `services/identity-service/src/main/resources/application.properties`
+- `services/identity-service/src/test/java/com/zerobugfreinds/identity_service/controller/AuthSwitchTeamE2ETest.java`
+- `services/identity-service/build.gradle` (test 의존성 추가)
+
+### 3.2 Team 서비스
+
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/InternalTeamController.java`
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamService.java`
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/InternalTeamMembershipVerifyResponse.java`
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/event/TeamDomainOutboundEvent.java`
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/event/TeamApiKeyStatus.java`
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/event/TeamEventTypes.java`
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java`
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/entity/TeamEventOutbox.java`
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamEventOutboxRepository.java`
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/mq/TeamApiKeyStatusChangedEventRelay.java`
+- `services/team-service/src/main/java/com/zerobugfreinds/team_service/config/TeamApiKeyStatusEventRabbitConstants.java`
+- `services/team-service/src/main/resources/application.properties`
+
+### 3.3 Team Web(BFF/화면)
+
+- `services/team-service/web/src/app/api/auth/token/switch-team/route.ts`
+- `services/team-service/web/src/components/team/team-management-view.tsx`
+
+### 3.4 계약 문서
+
+- `docs/contracts/team-api-key-event-contract.md`
+
+---
+
+## 4. API/이벤트 계약 포인트
+
+### 4.1 Switch Team API
+
+- 엔드포인트:
+  - `POST /api/auth/switch-team`
+  - `POST /api/auth/token/switch-team` (호환 경로)
+- 요청: `targetTeamId`
+- 처리:
+  - Authorization의 JWT 사용자와 인증 principal 일치 검증
+  - team-service 내부 API로 멤버십 검증
+  - 성공 시 새 access/refresh 재발급
+
+### 4.2 Team API Key 상태 동기화 이벤트
+
+- 이벤트 타입: `TEAM_API_KEY_STATUS_CHANGED`
+- 핵심 필드:
+  - `schemaVersion`, `eventId`, `eventType`, `occurredAt`
+  - `teamId`, `teamApiKeyId`, `alias`, `provider`, `status`, `retainLogs`
+- 라우팅:
+  - exchange: `team.api-key.exchange`
+  - routingKey: `team.api-key.status.changed`
+
+---
+
+## 5. 테스트/검증
+
+### 5.1 수행된 검증
+
+- `identity-service` 컴파일 성공
+- `team-service` 컴파일 성공
+- `AuthSwitchTeamE2ETest` 실행 성공
+  - 로그인 -> 팀 전환 -> JWT `active_team_id` 단언
+  - 개인 external key 등록/조회 회귀 확인
+
+### 5.2 참고
+
+- `team-service/web` lint는 로컬 환경의 ESLint plugin dependency(`semver`) 누락으로 실행 실패 가능성이 확인되었다.
+- 이는 기능 코드 자체와 별개로 개발 환경 의존성 상태 이슈다.
+
+---
+
+## 6. 운영 관점 체크리스트
+
+- `identity.team-service.internal-base-url`가 환경에 맞게 설정되어 있는지 확인.
+- team 이벤트 구독 큐/라우팅 설정(`identity.team-member-removed.*`)이 배포 환경과 일치하는지 확인.
+- outbox 재시도 스케줄러 도입 전에는 `published=false` 레코드 모니터링이 필요.
+- 게이트웨이에서 `active_team_id -> X-Team-Id` 헤더 주입 로직이 배포 브랜치에 반영되어야 최종 전파가 완성된다.
+

--- a/services/identity-service/build.gradle
+++ b/services/identity-service/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'com.h2database:h2'
 }
 

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/RestClientConfig.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.zerobugfreinds.identity_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient.Builder restClientBuilder() {
+        return RestClient.builder();
+    }
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/TeamMemberRemovedRabbitConfig.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/TeamMemberRemovedRabbitConfig.java
@@ -1,0 +1,41 @@
+package com.zerobugfreinds.identity_service.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * team-service 도메인 이벤트 중 TEAM_MEMBER_REMOVED 수신용 큐 바인딩.
+ */
+@Configuration
+public class TeamMemberRemovedRabbitConfig {
+
+    @Bean
+    public TopicExchange teamDomainEventExchange(
+            @Value("${identity.team-event.exchange:team.events}") String exchangeName
+    ) {
+        return new TopicExchange(exchangeName, true, false);
+    }
+
+    @Bean
+    public Queue identityTeamMemberRemovedQueue(
+            @Value("${identity.team-member-removed.queue:identity.team.member-removed.queue}") String queueName
+    ) {
+        return new Queue(queueName, true);
+    }
+
+    @Bean
+    public Binding identityTeamMemberRemovedBinding(
+            Queue identityTeamMemberRemovedQueue,
+            TopicExchange teamDomainEventExchange,
+            @Value("${identity.team-member-removed.routing-key:team-member-added}") String routingKey
+    ) {
+        return BindingBuilder.bind(identityTeamMemberRemovedQueue)
+                .to(teamDomainEventExchange)
+                .with(routingKey);
+    }
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/AuthController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/AuthController.java
@@ -4,11 +4,12 @@ import com.zerobugfreinds.identity_service.common.ApiResponse;
 import com.zerobugfreinds.identity_service.dto.DeleteAccountRequest;
 import com.zerobugfreinds.identity_service.dto.ForgotPasswordRequest;
 import com.zerobugfreinds.identity_service.dto.LoginRequest;
-import com.zerobugfreinds.identity_service.dto.LoginResponse;
 import com.zerobugfreinds.identity_service.dto.ResetPasswordRequest;
 import com.zerobugfreinds.identity_service.dto.SessionResponse;
 import com.zerobugfreinds.identity_service.dto.SignupRequest;
 import com.zerobugfreinds.identity_service.dto.SignupResponse;
+import com.zerobugfreinds.identity_service.dto.SwitchTeamRequest;
+import com.zerobugfreinds.identity_service.dto.TokenResponse;
 import com.zerobugfreinds.identity_service.exception.AuthContractViolationException;
 import com.zerobugfreinds.identity_service.security.IdentityUserPrincipal;
 import com.zerobugfreinds.identity_service.service.AccountDeletionService;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 /**
  * Authentication HTTP API.
@@ -73,8 +75,8 @@ public class AuthController {
 	}
 
 	@PostMapping("/login")
-	public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
-		LoginResponse body = userService.login(request);
+	public ResponseEntity<ApiResponse<TokenResponse>> login(@Valid @RequestBody LoginRequest request) {
+		TokenResponse body = userService.login(request);
 		if (!"Bearer".equals(body.tokenType())) {
 			throw new AuthContractViolationException("Token type contract violation");
 		}
@@ -102,6 +104,18 @@ public class AuthController {
 		return ResponseEntity.ok()
 				.header(HttpHeaders.CACHE_CONTROL, "no-store")
 				.body(ApiResponse.ok("Signed out. Clear auth cookie on BFF.", null));
+	}
+
+	@PostMapping({"/switch-team", "/token/switch-team"})
+	public ResponseEntity<ApiResponse<TokenResponse>> switchTeam(
+			@AuthenticationPrincipal IdentityUserPrincipal principal,
+			@RequestHeader(HttpHeaders.AUTHORIZATION) String authorization,
+			@Valid @RequestBody SwitchTeamRequest request
+	) {
+		TokenResponse body = userService.switchTeam(principal.userId(), request.targetTeamId(), authorization);
+		return ResponseEntity.ok()
+				.cacheControl(CacheControl.noStore().mustRevalidate())
+				.body(ApiResponse.ok("Team context switched", body));
 	}
 
 	/**

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/InternalTeamMembershipVerifyResponse.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/InternalTeamMembershipVerifyResponse.java
@@ -1,0 +1,11 @@
+package com.zerobugfreinds.identity_service.dto;
+
+/**
+ * team-service 내부 멤버십 검증 응답.
+ */
+public record InternalTeamMembershipVerifyResponse(
+        Long teamId,
+        String userId,
+        boolean isValid
+) {
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/SwitchTeamRequest.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/SwitchTeamRequest.java
@@ -1,0 +1,12 @@
+package com.zerobugfreinds.identity_service.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 팀 컨텍스트 전환 요청.
+ */
+public record SwitchTeamRequest(
+        @NotNull(message = "targetTeamId는 필수입니다")
+        Long targetTeamId
+) {
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/TokenResponse.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/TokenResponse.java
@@ -1,0 +1,13 @@
+package com.zerobugfreinds.identity_service.dto;
+
+/**
+ * 액세스/리프레시 토큰 세트 응답.
+ */
+public record TokenResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType,
+        long expiresInSeconds,
+        long refreshExpiresInSeconds
+) {
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/RefreshTokenEntity.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/entity/RefreshTokenEntity.java
@@ -1,0 +1,51 @@
+package com.zerobugfreinds.identity_service.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+/**
+ * 사용자별 리프레시 토큰 저장소(서버측 무효화/회전용).
+ */
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "token_hash", nullable = false, length = 64)
+    private String tokenHash;
+
+    @Column(name = "active_team_id")
+    private Long activeTeamId;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    protected RefreshTokenEntity() {
+    }
+
+    public static RefreshTokenEntity issue(Long userId, String tokenHash, Long activeTeamId, Instant expiresAt) {
+        RefreshTokenEntity entity = new RefreshTokenEntity();
+        entity.userId = userId;
+        entity.tokenHash = tokenHash;
+        entity.activeTeamId = activeTeamId;
+        entity.expiresAt = expiresAt;
+        entity.createdAt = Instant.now();
+        return entity;
+    }
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/mq/TeamMemberRemovedEventListener.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/mq/TeamMemberRemovedEventListener.java
@@ -1,0 +1,57 @@
+package com.zerobugfreinds.identity_service.mq;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.zerobugfreinds.identity_service.service.RefreshTokenRevocationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * TEAM_MEMBER_REMOVED 이벤트를 수신해 사용자 토큰을 무효화한다.
+ */
+@Component
+public class TeamMemberRemovedEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(TeamMemberRemovedEventListener.class);
+    private static final String TEAM_MEMBER_REMOVED = "TEAM_MEMBER_REMOVED";
+    private static final ObjectMapper JSON = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private final RefreshTokenRevocationService refreshTokenRevocationService;
+
+    public TeamMemberRemovedEventListener(RefreshTokenRevocationService refreshTokenRevocationService) {
+        this.refreshTokenRevocationService = refreshTokenRevocationService;
+    }
+
+    @RabbitListener(queues = "${identity.team-member-removed.queue:identity.team.member-removed.queue}")
+    public void onTeamDomainEvent(String body) {
+        try {
+            TeamMemberRemovedEvent event = JSON.readValue(body, TeamMemberRemovedEvent.class);
+            if (!TEAM_MEMBER_REMOVED.equals(event.eventType())) {
+                return;
+            }
+            Long removedUserId = parseUserId(event.removedUserId());
+            refreshTokenRevocationService.revokeAllByUserId(removedUserId, event.teamId(), event.occurredAt());
+        } catch (Exception ex) {
+            log.error("Invalid team domain event payload for TEAM_MEMBER_REMOVED: {}", ex.getMessage());
+            throw new AmqpRejectAndDontRequeueException(ex);
+        }
+    }
+
+    private Long parseUserId(String rawUserId) {
+        if (rawUserId == null || rawUserId.isBlank()) {
+            throw new IllegalArgumentException("removedUserId가 비어 있습니다");
+        }
+        return Long.parseLong(rawUserId.trim());
+    }
+
+    private record TeamMemberRemovedEvent(
+            String eventType,
+            String teamId,
+            String removedUserId,
+            java.time.Instant occurredAt
+    ) {
+    }
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/RefreshTokenRepository.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.zerobugfreinds.identity_service.repository;
+
+import com.zerobugfreinds.identity_service.entity.RefreshTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, Long> {
+    void deleteAllByUserId(Long userId);
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/security/JwtTokenProvider.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/security/JwtTokenProvider.java
@@ -20,32 +20,66 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider {
 
+	private static final String CLAIM_USER_ID = "userId";
+	private static final String CLAIM_ROLE = "role";
+	private static final String CLAIM_ACTIVE_TEAM_ID = "active_team_id";
+	private static final String CLAIM_TOKEN_TYPE = "tokenType";
+	private static final String TOKEN_TYPE_REFRESH = "refresh";
+
 	private final SecretKey signingKey;
 	private final long accessTokenTtlSeconds;
+	private final long refreshTokenTtlSeconds;
 
 	public JwtTokenProvider(
 			@Value("${security.jwt.secret}") String secret,
-			@Value("${security.jwt.access-token-ttl-seconds:3600}") long accessTokenTtlSeconds
+			@Value("${security.jwt.access-token-ttl-seconds:3600}") long accessTokenTtlSeconds,
+			@Value("${security.jwt.refresh-token-ttl-seconds:1209600}") long refreshTokenTtlSeconds
 	) {
 		this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
 		this.accessTokenTtlSeconds = accessTokenTtlSeconds;
+		this.refreshTokenTtlSeconds = refreshTokenTtlSeconds;
 	}
 
 	/**
 	 * 로그인한 사용자 정보를 subject/claim 으로 담아 액세스 토큰을 발행한다.
 	 */
 	public String generateAccessToken(User user) {
+		return createAccessToken(user, null);
+	}
+
+	/**
+	 * 팀 컨텍스트(activeTeamId)를 포함한 액세스 토큰을 발행한다.
+	 */
+	public String createAccessToken(User user, Long activeTeamId) {
 		Instant now = Instant.now();
 		Instant expiresAt = now.plusSeconds(accessTokenTtlSeconds);
-
-		return Jwts.builder()
+		var builder = Jwts.builder()
 				.subject(user.getEmail())
-				.claim("userId", user.getId())
-				.claim("role", user.getRole().name())
+				.claim(CLAIM_USER_ID, user.getId())
+				.claim(CLAIM_ROLE, user.getRole().name())
 				.issuedAt(Date.from(now))
 				.expiration(Date.from(expiresAt))
-				.signWith(signingKey)
-				.compact();
+				.signWith(signingKey);
+		if (activeTeamId != null) {
+			builder.claim(CLAIM_ACTIVE_TEAM_ID, activeTeamId);
+		}
+		return builder.compact();
+	}
+
+	public String createRefreshToken(User user, Long activeTeamId) {
+		Instant now = Instant.now();
+		Instant expiresAt = now.plusSeconds(refreshTokenTtlSeconds);
+		var builder = Jwts.builder()
+				.subject(user.getEmail())
+				.claim(CLAIM_USER_ID, user.getId())
+				.claim(CLAIM_TOKEN_TYPE, TOKEN_TYPE_REFRESH)
+				.issuedAt(Date.from(now))
+				.expiration(Date.from(expiresAt))
+				.signWith(signingKey);
+		if (activeTeamId != null) {
+			builder.claim(CLAIM_ACTIVE_TEAM_ID, activeTeamId);
+		}
+		return builder.compact();
 	}
 
 	/**
@@ -65,5 +99,9 @@ public class JwtTokenProvider {
 
 	public long getAccessTokenTtlSeconds() {
 		return accessTokenTtlSeconds;
+	}
+
+	public long getRefreshTokenTtlSeconds() {
+		return refreshTokenTtlSeconds;
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/RefreshTokenRevocationService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/RefreshTokenRevocationService.java
@@ -1,0 +1,35 @@
+package com.zerobugfreinds.identity_service.service;
+
+import com.zerobugfreinds.identity_service.repository.RefreshTokenRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+/**
+ * 보안 이벤트 기반 리프레시 토큰 무효화 처리.
+ */
+@Service
+public class RefreshTokenRevocationService {
+
+    private static final Logger log = LoggerFactory.getLogger(RefreshTokenRevocationService.class);
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshTokenRevocationService(RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    @Transactional
+    public void revokeAllByUserId(Long userId, String sourceTeamId, Instant occurredAt) {
+        refreshTokenRepository.deleteAllByUserId(userId);
+        log.warn(
+                "Revoked refresh tokens due to TEAM_MEMBER_REMOVED userId={} teamId={} occurredAt={}",
+                userId,
+                sourceTeamId,
+                occurredAt
+        );
+    }
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/TeamMembershipVerificationClient.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/TeamMembershipVerificationClient.java
@@ -1,0 +1,44 @@
+package com.zerobugfreinds.identity_service.service;
+
+import com.zerobugfreinds.identity_service.common.ApiResponse;
+import com.zerobugfreinds.identity_service.dto.InternalTeamMembershipVerifyResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+/**
+ * team-service 내부 API를 호출해 팀 멤버십을 검증한다.
+ */
+@Component
+public class TeamMembershipVerificationClient {
+
+    private final RestClient restClient;
+
+    public TeamMembershipVerificationClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${identity.team-service.internal-base-url:${TEAM_SERVICE_INTERNAL_URL:http://team-service:8093}}")
+            String teamServiceBaseUrl
+    ) {
+        this.restClient = restClientBuilder
+                .baseUrl(teamServiceBaseUrl)
+                .build();
+    }
+
+    public boolean isActiveTeamMember(Long teamId, Long userId) {
+        try {
+            ApiResponse<InternalTeamMembershipVerifyResponse> response = restClient.get()
+                    .uri("/internal/v1/teams/{teamId}/members/{userId}/verify", teamId, String.valueOf(userId))
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<>() {
+                    });
+            return response != null
+                    && response.success()
+                    && response.data() != null
+                    && response.data().isValid();
+        } catch (HttpClientErrorException.NotFound ex) {
+            return false;
+        }
+    }
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/UserService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/UserService.java
@@ -3,17 +3,24 @@ package com.zerobugfreinds.identity_service.service;
 import com.zerobugfreinds.identity_service.dto.SignupRequest;
 import com.zerobugfreinds.identity_service.dto.SignupResponse;
 import com.zerobugfreinds.identity_service.dto.LoginRequest;
-import com.zerobugfreinds.identity_service.dto.LoginResponse;
+import com.zerobugfreinds.identity_service.dto.TokenResponse;
 import com.zerobugfreinds.identity_service.entity.User;
+import com.zerobugfreinds.identity_service.entity.RefreshTokenEntity;
 import com.zerobugfreinds.identity_service.exception.DuplicateEmailException;
 import com.zerobugfreinds.identity_service.exception.InvalidCredentialsException;
 import com.zerobugfreinds.identity_service.exception.InvalidSignupRequestException;
+import com.zerobugfreinds.identity_service.repository.RefreshTokenRepository;
 import com.zerobugfreinds.identity_service.repository.UserRepository;
 import com.zerobugfreinds.identity_service.security.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,17 +32,23 @@ import java.util.Set;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final RefreshTokenRepository refreshTokenRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final TeamMembershipVerificationClient teamMembershipVerificationClient;
 
 	public UserService(
 			UserRepository userRepository,
+			RefreshTokenRepository refreshTokenRepository,
 			PasswordEncoder passwordEncoder,
-			JwtTokenProvider jwtTokenProvider
+			JwtTokenProvider jwtTokenProvider,
+			TeamMembershipVerificationClient teamMembershipVerificationClient
 	) {
 		this.userRepository = userRepository;
+		this.refreshTokenRepository = refreshTokenRepository;
 		this.passwordEncoder = passwordEncoder;
 		this.jwtTokenProvider = jwtTokenProvider;
+		this.teamMembershipVerificationClient = teamMembershipVerificationClient;
 	}
 
 	/**
@@ -68,8 +81,8 @@ public class UserService {
 	/**
 	 * 로그인: 이메일/비밀번호를 검증하고 JWT 액세스 토큰을 발행한다.
 	 */
-	@Transactional(readOnly = true)
-	public LoginResponse login(LoginRequest request) {
+	@Transactional
+	public TokenResponse login(LoginRequest request) {
 		User user = userRepository.findByEmail(request.email())
 				.orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다"));
 
@@ -77,8 +90,28 @@ public class UserService {
 			throw new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다");
 		}
 
-		String accessToken = jwtTokenProvider.generateAccessToken(user);
-		return new LoginResponse(accessToken, "Bearer", jwtTokenProvider.getAccessTokenTtlSeconds());
+		return issueTokenPair(user, null);
+	}
+
+	@Transactional
+	public TokenResponse switchTeam(Long authenticatedUserId, Long targetTeamId, String bearerToken) {
+		if (authenticatedUserId == null) {
+			throw new IllegalArgumentException("인증 사용자 정보가 없습니다");
+		}
+		if (targetTeamId == null) {
+			throw new IllegalArgumentException("targetTeamId는 필수입니다");
+		}
+		Long userIdFromToken = extractUserIdFromBearerToken(bearerToken);
+		if (!authenticatedUserId.equals(userIdFromToken)) {
+			throw new IllegalArgumentException("토큰 사용자와 요청 사용자가 일치하지 않습니다");
+		}
+		boolean isValidMember = teamMembershipVerificationClient.isActiveTeamMember(targetTeamId, authenticatedUserId);
+		if (!isValidMember) {
+			throw new IllegalArgumentException("요청한 팀의 활성 멤버가 아닙니다");
+		}
+		User user = userRepository.findById(authenticatedUserId)
+				.orElseThrow(() -> new InvalidCredentialsException("사용자 정보를 찾을 수 없습니다"));
+		return issueTokenPair(user, targetTeamId);
 	}
 
 	@Transactional(readOnly = true)
@@ -111,5 +144,59 @@ public class UserService {
 		return userRepository.findAllById(numericUserIds).stream()
 				.map(user -> String.valueOf(user.getId()))
 				.collect(LinkedHashSet::new, Set::add, Set::addAll);
+	}
+
+	private TokenResponse issueTokenPair(User user, Long activeTeamId) {
+		String accessToken = jwtTokenProvider.createAccessToken(user, activeTeamId);
+		String refreshToken = jwtTokenProvider.createRefreshToken(user, activeTeamId);
+		replaceRefreshToken(user.getId(), refreshToken, activeTeamId);
+		return new TokenResponse(
+				accessToken,
+				refreshToken,
+				"Bearer",
+				jwtTokenProvider.getAccessTokenTtlSeconds(),
+				jwtTokenProvider.getRefreshTokenTtlSeconds()
+		);
+	}
+
+	private void replaceRefreshToken(Long userId, String refreshToken, Long activeTeamId) {
+		refreshTokenRepository.deleteAllByUserId(userId);
+		RefreshTokenEntity tokenEntity = RefreshTokenEntity.issue(
+				userId,
+				sha256Hex(refreshToken),
+				activeTeamId,
+				Instant.now().plusSeconds(jwtTokenProvider.getRefreshTokenTtlSeconds())
+		);
+		refreshTokenRepository.save(tokenEntity);
+	}
+
+	private Long extractUserIdFromBearerToken(String bearerToken) {
+		if (bearerToken == null || bearerToken.isBlank() || !bearerToken.startsWith("Bearer ")) {
+			throw new IllegalArgumentException("Authorization Bearer 토큰이 필요합니다");
+		}
+		String token = bearerToken.substring("Bearer ".length()).trim();
+		Claims claims = jwtTokenProvider.validateAndGetClaims(token);
+		Object userIdClaim = claims.get("userId");
+		if (userIdClaim == null) {
+			throw new IllegalArgumentException("토큰에 userId 클레임이 없습니다");
+		}
+		if (userIdClaim instanceof Number number) {
+			return number.longValue();
+		}
+		return Long.parseLong(userIdClaim.toString());
+	}
+
+	private static String sha256Hex(String value) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] bytes = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+			StringBuilder sb = new StringBuilder(bytes.length * 2);
+			for (byte b : bytes) {
+				sb.append(String.format("%02x", b));
+			}
+			return sb.toString();
+		} catch (NoSuchAlgorithmException ex) {
+			throw new IllegalStateException("SHA-256 algorithm is unavailable", ex);
+		}
 	}
 }

--- a/services/identity-service/src/main/resources/application.properties
+++ b/services/identity-service/src/main/resources/application.properties
@@ -46,3 +46,11 @@ identity.external-api-key-event.routing-key=${IDENTITY_EXTERNAL_API_KEY_EVENT_RO
 # 다른 서비스가 삭제 완료 시 identity 로 보내는 ACK (이 큐를 리스닝)
 identity.account-deletion-ack.queue=${IDENTITY_ACCOUNT_DELETION_ACK_QUEUE:identity.account-deletion.ack.queue}
 identity.account-deletion-ack.routing-key=${IDENTITY_ACCOUNT_DELETION_ACK_ROUTING_KEY:identity.user.account-deletion-ack}
+
+# team-service 내부 멤버십 검증 API 호출 베이스 URL
+identity.team-service.internal-base-url=${IDENTITY_TEAM_SERVICE_INTERNAL_BASE_URL:${TEAM_SERVICE_INTERNAL_URL:http://team-service:8093}}
+
+# team-service TEAM_MEMBER_REMOVED 이벤트 구독(수신 후 refresh token 무효화)
+identity.team-event.exchange=${IDENTITY_TEAM_EVENT_EXCHANGE:team.events}
+identity.team-member-removed.routing-key=${IDENTITY_TEAM_MEMBER_REMOVED_ROUTING_KEY:team-member-added}
+identity.team-member-removed.queue=${IDENTITY_TEAM_MEMBER_REMOVED_QUEUE:identity.team.member-removed.queue}

--- a/services/identity-service/src/test/java/com/zerobugfreinds/identity_service/controller/AuthSwitchTeamE2ETest.java
+++ b/services/identity-service/src/test/java/com/zerobugfreinds/identity_service/controller/AuthSwitchTeamE2ETest.java
@@ -1,0 +1,162 @@
+package com.zerobugfreinds.identity_service.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobugfreinds.identity_service.security.JwtTokenProvider;
+import com.zerobugfreinds.identity_service.service.TeamMembershipVerificationClient;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+@ActiveProfiles("test")
+class AuthSwitchTeamE2ETest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private TeamMembershipVerificationClient teamMembershipVerificationClient;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    void loginThenSwitchTeam_issuesTokenWithActiveTeamIdClaim() throws Exception {
+        signup("switch-user@local.test", "switched-user");
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "switch-user@local.test",
+                                  "password": "test1234!"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String firstAccessToken = accessTokenFrom(loginResult);
+        Claims firstClaims = jwtTokenProvider.validateAndGetClaims(firstAccessToken);
+        assertThat(firstClaims.get("active_team_id")).isNull();
+
+        Long targetTeamId = 701L;
+        Long userId = claimAsLong(firstClaims.get("userId"));
+        when(teamMembershipVerificationClient.isActiveTeamMember(eq(targetTeamId), eq(userId))).thenReturn(true);
+
+        MvcResult switchResult = mockMvc.perform(post("/api/auth/token/switch-team")
+                        .header("Authorization", "Bearer " + firstAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "targetTeamId": 701
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String switchedAccessToken = accessTokenFrom(switchResult);
+        Claims switchedClaims = jwtTokenProvider.validateAndGetClaims(switchedAccessToken);
+        assertThat(claimAsLong(switchedClaims.get("active_team_id"))).isEqualTo(targetTeamId);
+    }
+
+    @Test
+    void personalExternalApiKeyFlow_stillWorksWithUpdatedJwtStructure() throws Exception {
+        signup("apikey-user@local.test", "apikey-user");
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "apikey-user@local.test",
+                                  "password": "test1234!"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String accessToken = accessTokenFrom(loginResult);
+
+        mockMvc.perform(post("/api/auth/external-keys")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "provider": "OPENAI",
+                                  "externalKey": "sk-test-regression-key",
+                                  "alias": "personal-main",
+                                  "monthlyBudgetUsd": 10.50
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/auth/external-keys")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+    }
+
+    private void signup(String email, String name) throws Exception {
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "%s",
+                                  "password": "test1234!",
+                                  "passwordConfirm": "test1234!",
+                                  "name": "%s",
+                                  "role": "USER"
+                                }
+                                """.formatted(email, name)))
+                .andExpect(status().isCreated());
+    }
+
+    private String accessTokenFrom(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        return root.path("data").path("accessToken").asText();
+    }
+
+    private static Long claimAsLong(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        return Long.parseLong(String.valueOf(value));
+    }
+
+    @TestConfiguration
+    static class TestBeans {
+        @Bean
+        TeamMembershipVerificationClient teamMembershipVerificationClient() {
+            return mock(TeamMembershipVerificationClient.class);
+        }
+    }
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/entity/TeamEventOutbox.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/entity/TeamEventOutbox.java
@@ -1,0 +1,98 @@
+package com.zerobugfreinds.team_service.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.Instant;
+
+/**
+ * 팀 이벤트 발행 이력(outbox) 저장 엔티티.
+ */
+@Entity
+@Table(
+        name = "team_event_outbox",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_team_event_outbox_event_id", columnNames = "event_id")
+        }
+)
+public class TeamEventOutbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "event_id", nullable = false, length = 64)
+    private String eventId;
+
+    @Column(name = "aggregate_id", nullable = false)
+    private Long aggregateId;
+
+    @Column(name = "event_type", nullable = false, length = 50)
+    private String eventType;
+
+    @Column(name = "payload", nullable = false, columnDefinition = "text")
+    private String payload;
+
+    @Column(name = "published", nullable = false, columnDefinition = "boolean default false")
+    private boolean published = false;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    protected TeamEventOutbox() {
+    }
+
+    public static TeamEventOutbox create(
+            String eventId,
+            Long aggregateId,
+            String eventType,
+            String payload
+    ) {
+        TeamEventOutbox entity = new TeamEventOutbox();
+        entity.eventId = eventId;
+        entity.aggregateId = aggregateId;
+        entity.eventType = eventType;
+        entity.payload = payload;
+        entity.published = false;
+        entity.createdAt = Instant.now();
+        return entity;
+    }
+
+    public void markPublished() {
+        this.published = true;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public Long getAggregateId() {
+        return aggregateId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public boolean isPublished() {
+        return published;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/mq/TeamApiKeyStatusChangedEventRelay.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/mq/TeamApiKeyStatusChangedEventRelay.java
@@ -1,0 +1,83 @@
+package com.zerobugfreinds.team_service.mq;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobugfreinds.team_service.config.TeamApiKeyStatusEventRabbitConstants;
+import com.zerobugfreinds.team_service.entity.TeamEventOutbox;
+import com.zerobugfreinds.team_service.event.TeamDomainOutboundEvent.TeamApiKeyStatusChangedEvent;
+import com.zerobugfreinds.team_service.repository.TeamEventOutboxRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 트랜잭션 커밋 후 TeamApiKeyStatusChangedEvent를 Outbox에 저장하고 RabbitMQ로 릴레이한다.
+ */
+@Component
+public class TeamApiKeyStatusChangedEventRelay {
+
+    private static final Logger log = LoggerFactory.getLogger(TeamApiKeyStatusChangedEventRelay.class);
+
+    private final TeamEventOutboxRepository teamEventOutboxRepository;
+    private final RabbitTemplate rabbitTemplate;
+    private final ObjectMapper objectMapper;
+    private final String exchange;
+    private final String routingKey;
+
+    public TeamApiKeyStatusChangedEventRelay(
+            TeamEventOutboxRepository teamEventOutboxRepository,
+            RabbitTemplate rabbitTemplate,
+            ObjectMapper objectMapper,
+            @Value("${" + TeamApiKeyStatusEventRabbitConstants.EXCHANGE_PROPERTY + ":"
+                    + TeamApiKeyStatusEventRabbitConstants.DEFAULT_EXCHANGE + "}") String exchange,
+            @Value("${" + TeamApiKeyStatusEventRabbitConstants.ROUTING_KEY_PROPERTY + ":"
+                    + TeamApiKeyStatusEventRabbitConstants.DEFAULT_ROUTING_KEY + "}") String routingKey
+    ) {
+        this.teamEventOutboxRepository = teamEventOutboxRepository;
+        this.rabbitTemplate = rabbitTemplate;
+        this.objectMapper = objectMapper;
+        this.exchange = exchange;
+        this.routingKey = routingKey;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onTeamApiKeyStatusChanged(TeamApiKeyStatusChangedEvent event) {
+        if (teamEventOutboxRepository.existsByEventId(event.eventId())) {
+            return;
+        }
+
+        final String payload;
+        try {
+            payload = objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException ex) {
+            log.error("Failed to serialize TeamApiKeyStatusChangedEvent eventId={}", event.eventId(), ex);
+            return;
+        }
+
+        TeamEventOutbox outbox = TeamEventOutbox.create(
+                event.eventId(),
+                event.teamApiKeyId(),
+                event.eventType(),
+                payload
+        );
+        outbox = teamEventOutboxRepository.save(outbox);
+
+        try {
+            rabbitTemplate.convertAndSend(exchange, routingKey, payload);
+            outbox.markPublished();
+            teamEventOutboxRepository.save(outbox);
+        } catch (Exception ex) {
+            log.error(
+                    "Failed to publish TeamApiKeyStatusChangedEvent eventId={} exchange={} routingKey={}",
+                    event.eventId(),
+                    exchange,
+                    routingKey,
+                    ex
+            );
+        }
+    }
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamEventOutboxRepository.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamEventOutboxRepository.java
@@ -1,0 +1,12 @@
+package com.zerobugfreinds.team_service.repository;
+
+import com.zerobugfreinds.team_service.entity.TeamEventOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamEventOutboxRepository extends JpaRepository<TeamEventOutbox, Long> {
+    boolean existsByEventId(String eventId);
+
+    Optional<TeamEventOutbox> findByEventId(String eventId);
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java
@@ -13,13 +13,16 @@ import com.zerobugfreinds.team_service.event.TeamDomainOutboundEvent.TeamApiKeyD
 import com.zerobugfreinds.team_service.event.TeamDomainOutboundEvent.TeamApiKeyDeletionCancelledEvent;
 import com.zerobugfreinds.team_service.event.TeamDomainOutboundEvent.TeamApiKeyDeletionScheduledEvent;
 import com.zerobugfreinds.team_service.event.TeamDomainOutboundEvent.TeamApiKeyRegisteredEvent;
+import com.zerobugfreinds.team_service.event.TeamDomainOutboundEvent.TeamApiKeyStatusChangedEvent;
 import com.zerobugfreinds.team_service.event.TeamDomainOutboundEvent.TeamApiKeyUpdatedEvent;
 import com.zerobugfreinds.team_service.event.TeamEventRecipients;
+import com.zerobugfreinds.team_service.event.TeamApiKeyStatus;
 import com.zerobugfreinds.team_service.exception.TeamNotFoundException;
 import com.zerobugfreinds.team_service.repository.TeamApiKeyRepository;
 import com.zerobugfreinds.team_service.repository.TeamMemberRepository;
 import com.zerobugfreinds.team_service.repository.TeamRepository;
 import com.zerobugfreinds.team_service.util.EncryptionUtil;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -41,19 +44,22 @@ public class TeamApiKeyService {
     private final TeamApiKeyRepository teamApiKeyRepository;
     private final EncryptionUtil encryptionUtil;
     private final TeamDomainEventPublisher teamDomainEventPublisher;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public TeamApiKeyService(
             TeamRepository teamRepository,
             TeamMemberRepository teamMemberRepository,
             TeamApiKeyRepository teamApiKeyRepository,
             EncryptionUtil encryptionUtil,
-            TeamDomainEventPublisher teamDomainEventPublisher
+            TeamDomainEventPublisher teamDomainEventPublisher,
+            ApplicationEventPublisher applicationEventPublisher
     ) {
         this.teamRepository = teamRepository;
         this.teamMemberRepository = teamMemberRepository;
         this.teamApiKeyRepository = teamApiKeyRepository;
         this.encryptionUtil = encryptionUtil;
         this.teamDomainEventPublisher = teamDomainEventPublisher;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     @Transactional
@@ -105,6 +111,14 @@ public class TeamApiKeyService {
                 saved.getKeyAlias(),
                 occurredAt
         ));
+        publishTeamApiKeyStatusChanged(
+                teamId,
+                saved.getId(),
+                saved.getKeyAlias(),
+                saved.getProvider().name(),
+                TeamApiKeyStatus.ACTIVE,
+                null
+        );
         return toSummary(saved);
     }
 
@@ -172,6 +186,14 @@ public class TeamApiKeyService {
                 entity.getKeyAlias(),
                 Instant.now()
         ));
+        publishTeamApiKeyStatusChanged(
+                teamId,
+                entity.getId(),
+                entity.getKeyAlias(),
+                entity.getProvider().name(),
+                TeamApiKeyStatus.ACTIVE,
+                null
+        );
         return toSummary(entity);
     }
 
@@ -208,6 +230,14 @@ public class TeamApiKeyService {
                     occurredAt
             ));
             teamApiKeyRepository.delete(entity);
+            publishTeamApiKeyStatusChanged(
+                    teamId,
+                    entity.getId(),
+                    entity.getKeyAlias(),
+                    entity.getProvider().name(),
+                    TeamApiKeyStatus.DELETED,
+                    retainLogs
+            );
             return toSummary(entity);
         }
         entity.markDeletionRequested(Instant.now(), days, retainLogs);
@@ -224,6 +254,14 @@ public class TeamApiKeyService {
                 entity.getPermanentDeletionAt(),
                 occurredAt
         ));
+        publishTeamApiKeyStatusChanged(
+                teamId,
+                entity.getId(),
+                entity.getKeyAlias(),
+                entity.getProvider().name(),
+                TeamApiKeyStatus.DELETION_REQUESTED,
+                retainLogs
+        );
         return toSummary(entity);
     }
 
@@ -365,5 +403,25 @@ public class TeamApiKeyService {
 
     private void publish(TeamDomainOutboundEvent event) {
         teamDomainEventPublisher.publish(event);
+    }
+
+    private void publishTeamApiKeyStatusChanged(
+            Long teamId,
+            Long teamApiKeyId,
+            String alias,
+            String provider,
+            TeamApiKeyStatus status,
+            Boolean retainLogs
+    ) {
+        applicationEventPublisher.publishEvent(
+                TeamApiKeyStatusChangedEvent.of(
+                        teamId,
+                        teamApiKeyId,
+                        alias,
+                        provider,
+                        status,
+                        retainLogs
+                )
+        );
     }
 }

--- a/services/team-service/web/src/app/api/auth/token/switch-team/route.ts
+++ b/services/team-service/web/src/app/api/auth/token/switch-team/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from "next/server"
+
+const ACCESS_TOKEN_COOKIE = "access_token"
+
+type ApiResponse<T> = {
+  success: boolean
+  message: string
+  data: T | null
+}
+
+type TokenResponse = {
+  accessToken: string
+  tokenType: string
+  expiresInSeconds: number
+}
+
+function noStoreHeaders() {
+  return { "Cache-Control": "no-store" }
+}
+
+function envIdentityBaseUrl() {
+  const url = process.env.IDENTITY_SERVICE_URL
+  if (!url) return null
+  return url.replace(/\/+$/, "")
+}
+
+function getCookieValue(cookieHeader: string | null, name: string): string | null {
+  if (!cookieHeader) return null
+  const prefix = `${name}=`
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim()
+    if (trimmed.startsWith(prefix)) {
+      const value = trimmed.slice(prefix.length)
+      return value.length > 0 ? value : null
+    }
+  }
+  return null
+}
+
+function isSecureCookie(request: Request): boolean {
+  const configured = process.env.TEAM_WEB_SECURE_COOKIE?.trim().toLowerCase()
+  if (configured === "true") return true
+  if (configured === "false") return false
+  const forwardedProto = request.headers.get("x-forwarded-proto")
+  if (forwardedProto) {
+    return forwardedProto.split(",")[0]?.trim().toLowerCase() === "https"
+  }
+  try {
+    return new URL(request.url).protocol === "https:"
+  } catch {
+    return process.env.NODE_ENV === "production"
+  }
+}
+
+function isTokenData(data: unknown): data is TokenResponse {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    typeof (data as { accessToken?: unknown }).accessToken === "string" &&
+    typeof (data as { tokenType?: unknown }).tokenType === "string" &&
+    typeof (data as { expiresInSeconds?: unknown }).expiresInSeconds === "number"
+  )
+}
+
+function toMessage(upstreamJson: unknown, fallback: string): string {
+  if (
+    typeof upstreamJson === "object" &&
+    upstreamJson !== null &&
+    "message" in upstreamJson &&
+    typeof (upstreamJson as { message?: unknown }).message === "string"
+  ) {
+    return (upstreamJson as { message: string }).message
+  }
+  return fallback
+}
+
+export async function POST(request: Request) {
+  const token = getCookieValue(request.headers.get("cookie"), ACCESS_TOKEN_COOKIE)
+  if (!token) {
+    return NextResponse.json({ success: false, message: "로그인이 필요합니다", data: null }, { status: 401, headers: noStoreHeaders() })
+  }
+
+  const identityBaseUrl = envIdentityBaseUrl()
+  if (!identityBaseUrl) {
+    return NextResponse.json(
+      { success: false, message: "서버 설정이 필요합니다 (IDENTITY_SERVICE_URL)", data: null },
+      { status: 500, headers: noStoreHeaders() },
+    )
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, message: "JSON 형식이 올바르지 않습니다", data: null }, { status: 400, headers: noStoreHeaders() })
+  }
+
+  let upstream: Response
+  try {
+    upstream = await fetch(`${identityBaseUrl}/api/auth/token/switch-team`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    })
+  } catch {
+    return NextResponse.json(
+      { success: false, message: "인증 서비스에 연결할 수 없습니다", data: null },
+      { status: 502, headers: noStoreHeaders() },
+    )
+  }
+
+  let upstreamJson: unknown = null
+  try {
+    upstreamJson = await upstream.json()
+  } catch {
+    upstreamJson = null
+  }
+
+  if (!upstream.ok) {
+    return NextResponse.json(
+      { success: false, message: toMessage(upstreamJson, "요청 처리에 실패했습니다"), data: null },
+      { status: upstream.status, headers: noStoreHeaders() },
+    )
+  }
+
+  const body = upstreamJson as ApiResponse<TokenResponse>
+  if (!body?.success || !isTokenData(body.data)) {
+    return NextResponse.json(
+      { success: false, message: "팀 전환 응답 형식이 올바르지 않습니다", data: null },
+      { status: 502, headers: noStoreHeaders() },
+    )
+  }
+
+  const response = NextResponse.json(
+    { success: true, message: body.message || "팀 전환이 완료되었습니다", data: null },
+    { status: 200, headers: noStoreHeaders() },
+  )
+  response.cookies.set({
+    name: ACCESS_TOKEN_COOKIE,
+    value: body.data.accessToken,
+    httpOnly: true,
+    secure: isSecureCookie(request),
+    sameSite: "lax",
+    path: "/",
+    maxAge: body.data.expiresInSeconds,
+  })
+  return response
+}

--- a/services/team-service/web/src/components/team/team-management-view.tsx
+++ b/services/team-service/web/src/components/team/team-management-view.tsx
@@ -164,6 +164,34 @@ async function requestApi(path: string, init?: RequestInit) {
   return { res, body: asApiResponse(json) }
 }
 
+/**
+ * Debug helper for browser Network tab inspection.
+ * - switch-team succeeds, then this request should carry the refreshed auth cookie.
+ * - Gateway should decode JWT(active_team_id) and append X-Team-Id to upstream calls.
+ */
+async function debugGatewayTeamHeaderReadiness() {
+  await fetch(teamApiPath("/api/team/v1/me/teams"), {
+    method: "GET",
+    credentials: "include",
+    cache: "no-store",
+    headers: { Accept: "application/json", "X-Debug-Team-Switch": "network-check" },
+  })
+}
+
+async function switchActiveTeam(teamId: string) {
+  const res = await fetch("/api/auth/token/switch-team", {
+    method: "POST",
+    credentials: "include",
+    cache: "no-store",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({ targetTeamId: Number(teamId) }),
+  })
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as ApiResponse<unknown> | null
+    throw new Error(body?.message ?? "팀 전환 토큰 갱신에 실패했습니다")
+  }
+}
+
 export function TeamManagementView() {
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
@@ -946,6 +974,14 @@ export function TeamManagementView() {
                           setInviteInputsByTeamId((prev) =>
                             prev[team.id] !== undefined ? prev : { ...prev, [team.id]: [newInviteeRow()] },
                           )
+                          void switchActiveTeam(team.id)
+                            .then(() => debugGatewayTeamHeaderReadiness())
+                            .catch((e) => {
+                              setMessage({
+                                kind: "error",
+                                text: e instanceof Error ? e.message : "팀 전환 토큰 갱신에 실패했습니다",
+                              })
+                            })
                         }}
                       >
                         <div className="flex items-center gap-2">


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #N/A (필요 시 이슈 번호 연결)

## 작업 내용
- **해당 서비스**: Identity / Team / Team-Web (BFF)
- 로그인 후 팀 전환 시 JWT에 `active_team_id`를 반영하고, 팀 전환 토큰 재발급 흐름을 구현했습니다.
- Team API Key 상태 동기화 이벤트 계약/발행 경로를 추가하고, Outbox 기반 릴레이(`AFTER_COMMIT`)로 발행 신뢰성을 보강했습니다.
- 팀 멤버 강퇴/탈퇴(`TEAM_MEMBER_REMOVED`) 이벤트 수신 시 해당 사용자 refresh 토큰을 무효화하도록 구현했습니다.
- Team-Web에서 팀 전환 성공 직후 새 access token 쿠키를 즉시 갱신하도록 BFF 라우트를 추가했습니다.
- 관련 통합 테스트(E2E) 및 구현 문서를 추가했습니다.

## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- Identity
  - `JwtTokenProvider`에 `active_team_id` claim 지원 및 access/refresh token pair 발급 구조 반영
  - `AuthController`에 `/api/auth/switch-team`, `/api/auth/token/switch-team` 지원
  - `UserService`에 switch-team 검증/재발급/refresh 토큰 회전(기존 무효화 + 신규 저장) 로직 구현
  - `TeamMembershipVerificationClient` + `RestClientConfig` 추가
  - `TEAM_MEMBER_REMOVED` 소비 리스너/설정 추가 및 refresh token 무효화 서비스 구현
  - 로그인→팀전환→JWT claim 검증 + 개인 API Key 회귀 E2E 테스트 추가
- Team
  - 내부 멤버십 검증 API `GET /internal/v1/teams/{teamId}/members/{userId}/verify` 추가
  - `TeamApiKeyStatusChangedEvent` 계약 DTO/상태 enum/타입 상수 추가
  - `TeamApiKeyService` 등록/수정/삭제 성공 시 내부 도메인 이벤트 발행 추가
  - `TeamEventOutbox` 엔티티/레포지토리 추가
  - `TeamApiKeyStatusChangedEventRelay`(`@TransactionalEventListener(AFTER_COMMIT)`) 구현  
    - Outbox 저장(멱등 `eventId`) → Rabbit 발송 → 성공 시 `published=true` 업데이트
- Team-Web
  - `/api/auth/token/switch-team` BFF 라우트 추가 (Identity 호출 후 `access_token` 쿠키 즉시 갱신)
  - 팀 선택 UI에서 팀 전환 API 호출 및 네트워크 점검용 디버그 유틸 추가
- Docs
  - `docs/contracts/team-api-key-event-contract.md` 추가
  - `docs/identity-team-token-event-implementation-20260426.md` 추가

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [x] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [x] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
- `identity-service`: `./gradlew compileJava` 성공
- `team-service`: `./gradlew compileJava` 성공
- `identity-service`: `./gradlew test --tests "com.zerobugfreinds.identity_service.controller.AuthSwitchTeamE2ETest"` 성공
- `team-service/web`: lint는 로컬 의존성(`semver` 모듈 누락) 환경 이슈로 실행 불가 확인

## 리뷰 요구사항
- `switch-team` 토큰 회전 정책(기존 refresh 전량 폐기)이 의도한 보안 정책과 일치하는지 확인 부탁드립니다.
- Team API Key Outbox 릴레이에서 실패 건(`published=false`) 재시도 스케줄러 추가 범위를 다음 PR로 분리할지 확인 부탁드립니다.
- Gateway의 `active_team_id -> X-Team-Id` 주입은 이번 범위(수정 제한)에서 코드 변경하지 않았으므로, 배포 브랜치 반영 계획 확인 부탁드립니다.