### PR TITLE
Feature/api gateway integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ GATEWAY_SHARED_SECRET=local-dev-gateway-shared-secret-do-not-use-in-prod
 # JWT 검증용 (GATEWAY_DEV_MODE=false 일 때 gateway.jwt.secret 과 동일한 HMAC 키)
 GATEWAY_DEV_MODE=false
 GATEWAY_JWT_SECRET=change-this-secret-key-to-at-least-32-bytes
+# Gateway CORS 허용 Origin 목록(쉼표 구분). 기본 단일 진입점(web-edge): 8888
+# 예) GATEWAY_CORS_ALLOWED_ORIGINS=http://localhost:8888,http://127.0.0.1:8888
+GATEWAY_CORS_ALLOWED_ORIGINS=http://localhost:8888
 
 POSTGRES_USER=app
 POSTGRES_PASSWORD=app

--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,9 @@ NOTIFICATION_WEB_PORT=3004
 # WEB_IDENTITY_SERVICE_URL=http://host.docker.internal:8090
 # 컨테이너 team-web → team-service BFF. profile web 에서 Compose 가 team-service 를 띄우면 이 줄을 비우면 docker-compose 기본 http://team-service:8093. 호스트에서만 team 을 bootRun(8094) 할 때만 설정한다.
 # WEB_TEAM_SERVICE_URL=http://host.docker.internal:8094
+# 컨테이너 team-web → API Gateway(base URL). 기본값은 Compose 네트워크의 http://api-gateway-service:8080.
+# 호스트에서 게이트웨이를 따로 띄우는 경우에만 아래 값을 설정한다.
+# WEB_GATEWAY_URL=http://host.docker.internal:8080
 # 컨테이너 notification-web → notification-service. 기본값은 Compose 네트워크의 http://notification-service:8096.
 # 호스트에서 notification-service 를 따로 띄우는 경우에만 아래 값을 설정한다.
 # WEB_NOTIFICATION_SERVICE_URL=http://host.docker.internal:8096

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -330,6 +330,7 @@ services:
     depends_on:
       - team-service
     environment:
+      GATEWAY_URL: ${WEB_GATEWAY_URL:-http://api-gateway-service:8080}
       TEAM_SERVICE_URL: ${WEB_TEAM_SERVICE_URL:-http://team-service:8093}
       IDENTITY_SERVICE_URL: ${WEB_IDENTITY_SERVICE_URL:-http://host.docker.internal:8090}
     extra_hosts:

--- a/docs/notification-service-gateway-integration-guide.md
+++ b/docs/notification-service-gateway-integration-guide.md
@@ -1,0 +1,142 @@
+# Notification Service Gateway Integration Guide (Task 38-2)
+
+## 1) 목적과 범위
+
+- 본 문서는 `notification-service`를 API Gateway 단일 진입점 구조에 정식 편입하기 위한 분석/전환 가이드다.
+- 이번 태스크 범위는 **분석 및 제안**이며, 서비스/게이트웨이 로직 변경은 포함하지 않는다.
+- 기준 코드:
+  - `services/api-gateway-service`
+  - `services/notification-service`
+
+## 2) 현재 Gateway 인증/헤더 전파 구조
+
+### 2.1 라우팅
+
+- `api-gateway-service`는 `/api/notification/**`를 `notification-service`로 라우팅한다.
+- 현재 route filter는 `Authorization` 헤더를 제거하고 경로를 `/api/${segment}`로 rewrite한다.
+  - 예: `/api/notification/in-app-notifications` -> `/api/in-app-notifications`
+
+### 2.2 Security 설정
+
+- `SecurityConfiguration` 기준:
+  - `gateway.dev-mode=true`: `/api/notification/**`는 `permitAll`
+  - `gateway.dev-mode=false`: `/api/notification/**`도 현재 `permitAll` (인증 유예 상태)
+
+### 2.3 글로벌 필터(ProxyTrustHeadersWebFilter)
+
+- 게이트웨이 표준 전파 헤더:
+  - `X-User-Id` (`sub`)
+  - `X-Platform-User-Id` (`userId`)
+  - `X-Org-Id` (`org_id`)
+  - `X-Team-Id` (`team_id`)
+  - `X-Scope-Type` (`scope_type`, 없으면 `team_id` 기반 추론)
+  - `X-Correlation-Id` (존재 시 전달)
+  - `X-Gateway-Auth` (공유 시크릿)
+- 단, 현재는 `isNotificationPath("/api/notification/**")`에서 필터가 즉시 bypass되어 notification 경로에는 위 헤더 주입이 적용되지 않는다.
+
+## 3) notification-service 현재 상태 진단
+
+## 3.1 백엔드(Nest) 인증 방식
+
+- `notification-service`는 JWT를 직접 검증하지 않는다.
+- `InAppAuthGuard`는 아래 방식으로 요청을 허용한다.
+  1. `X-User-Id`가 있으면 인증 성공
+  2. 없더라도 `X-Notification-Internal-Secret`이 유효하면 내부 호출로 허용
+  3. 둘 다 없으면 `401 Missing X-User-Id`
+- 즉, 이미 "헤더 기반 신뢰 모델"을 부분적으로 사용 중이다.
+
+## 3.2 사용자 식별 사용 지점
+
+- `InAppNotificationsController`:
+  - `req.userId`를 list/read/read-all의 기준 사용자로 사용
+  - `test-send`는 `req.auth.isInternal` 여부로 타 사용자 발송 허용 여부를 결정
+- `InAppNotificationsService`:
+  - DB 쿼리는 `userId` 기준으로 수행
+- 요약: 핵심 비즈니스는 `userId` 문자열만 있으면 동작 가능하며, JWT 파싱 의존은 없다.
+
+## 3.3 프런트 BFF 연계 상태
+
+- `services/notification-service/web/src/app/api/notification/[[...path]]/route.ts`는 아직 Gateway 경유가 아닌 **notification-service 직접 호출** 구조다.
+- 이 BFF는 Identity `/api/auth/session`으로 이메일을 조회해 `X-User-Id`를 생성/전달한다.
+- 따라서 notification 백엔드는 현재 "Gateway 헤더"와 "BFF 생성 헤더"를 모두 받을 수 있는 상태다.
+
+## 4) 전환 전략 (제안만, 미적용)
+
+### 4.1 인증 방식 전환
+
+목표: notification-service는 Gateway가 검증/주입한 공통 헤더를 표준 입력으로 사용.
+
+제안:
+- 1단계(호환 단계)
+  - `InAppAuthGuard`를 "Gateway 헤더 우선 + 기존 내부 시크릿 fallback" 구조로 명시화
+  - 우선 신뢰 헤더: `X-User-Id`, 보조 컨텍스트: `X-Team-Id`, `X-Scope-Type`, `X-Platform-User-Id`
+- 2단계(정식 단계)
+  - 외부 클라이언트가 직접 `X-User-Id`를 넣어 접근하지 못하도록 네트워크/게이트웨이 경계에서만 허용
+  - 필요 시 `X-Gateway-Auth` 검증을 도입해 게이트웨이 경유 요청만 수락
+
+### 4.2 사용자/팀 식별 로직 일원화
+
+목표: 컨트롤러마다 헤더 파싱하지 않고 공통 컨텍스트 객체로 주입.
+
+제안:
+- `AuthContext` 형태로 정규화:
+  - `userId` (`X-User-Id`)
+  - `platformUserId` (`X-Platform-User-Id`, optional)
+  - `teamId` (`X-Team-Id`, optional)
+  - `scopeType` (`X-Scope-Type`, USER|TEAM)
+  - `isInternal` (internal secret 검증 결과)
+- 적용 방식(택1):
+  - Nest `Guard + Request 확장` 유지 (현재 구조 최소 변경)
+  - 또는 `Custom Decorator`/`Param decorator`로 `@AuthContext()` 주입
+- 권장: 현재 코드 일관성을 위해 Guard 기반을 유지하고, 타입(`in-app-notifications.types.ts`)만 확장
+
+### 4.3 Gateway 설정 동기화(Whitelist 해제 시점)
+
+#### 해제 전 선행 조건
+
+1. notification-service가 `X-User-Id` 누락/오염 케이스를 명확히 401 처리
+2. notification-web BFF 또는 클라이언트가 Gateway 경유 호출로 전환 완료
+3. 통합 테스트에서 `/api/notification/**` 경로의 인증 성공/실패 시나리오 확보
+
+#### 해제 절차
+
+1. `SecurityConfiguration`에서 `/api/notification/**`를 `authenticated()`로 변경(`dev-mode=false`)
+2. `ProxyTrustHeadersWebFilter`에서 notification bypass 제거:
+   - `isNotificationPath` 우회 삭제
+   - notification 경로에도 표준 헤더 주입 활성화
+3. 관측:
+   - 게이트웨이 로그에서 notification 요청도 `[Gateway] Forwarding ...` 패턴 확인
+   - 401/403 비율 및 알림 API 성공률 모니터링
+
+## 5) notification-service 수정 필요 지점 목록(후속 승인 시 대상)
+
+- `src/in-app-notifications/auth/in-app-auth.guard.ts`
+  - Gateway 헤더 우선 신뢰 정책, 컨텍스트 확장, (선택) `X-Gateway-Auth` 검증
+- `src/in-app-notifications/in-app-notifications.types.ts`
+  - `teamId`, `scopeType`, `platformUserId` 필드 확장
+- `src/in-app-notifications/in-app-notifications.controller.ts`
+  - 공통 인증 컨텍스트 사용으로 반복 체크 정리
+- (선택) `src/common/auth/*` 신규 모듈
+  - 서비스 전역에서 재사용 가능한 인증 컨텍스트 추출 유틸/데코레이터
+- 테스트 코드(신규/기존)
+  - 헤더 조합별 인증/인가 케이스 검증
+
+참고(백엔드 외 연계):
+- `services/notification-service/web/src/app/api/notification/[[...path]]/route.ts`
+  - Gateway 완전 전환 시 업스트림을 Gateway 기준으로 재정렬할지 검토 필요
+
+## 6) identity/team 서비스와 충돌 가능성 점검 결과
+
+- 현재 분석 기준으로 `identity-service`, `team-service` 내부 로직과 직접 충돌하는 지점은 확인되지 않았다.
+- 이유:
+  - 이번 전환 대상은 notification 경로의 게이트웨이 인증 정책 및 notification 내부 헤더 수용 방식
+  - identity/team의 기존 엔드포인트/필터 계약을 변경할 필요가 없음
+- 단, 플랫폼 JWT 클레임 스키마(`sub`, `userId`, `team_id`, `scope_type`) 변경이 발생하면 세 서비스 공통 영향이 있으므로 별도 공지/버전 관리가 필요하다.
+
+## 7) 권장 적용 순서(승인 후)
+
+1. notification-service: 헤더 컨텍스트 확장 + 테스트
+2. notification-web BFF/호출 경로 점검(게이트웨이 경유 일관화)
+3. api-gateway: notification whitelist 해제 + filter bypass 제거
+4. 스테이징 검증 후 운영 반영
+

--- a/services/api-gateway-service/bin/main/application.yml
+++ b/services/api-gateway-service/bin/main/application.yml
@@ -72,3 +72,5 @@ gateway:
   shared-secret: ${GATEWAY_SHARED_SECRET:local-dev-gateway-shared-secret-do-not-use-in-prod}
   jwt:
     secret: ${GATEWAY_JWT_SECRET:change-this-secret-key-to-at-least-32-bytes}
+  cors:
+    allowed-origins: ${GATEWAY_CORS_ALLOWED_ORIGINS:http://localhost:8888}

--- a/services/api-gateway-service/bin/main/application.yml
+++ b/services/api-gateway-service/bin/main/application.yml
@@ -44,12 +44,12 @@ spring:
                 - RewritePath=/api/identity/(?<segment>.*), /api/${segment}
 
             - id: team-http
-              uri: ${GATEWAY_TEAM_URI:http://localhost:8093}
+              uri: ${GATEWAY_TEAM_URI:http://team-service:8093}
               predicates:
                 - Path=/api/team/**
               filters:
                 - RemoveRequestHeader=Authorization
-                - RewritePath=/api/team/(?<segment>.*), /api/v1/${segment}
+                - RewritePath=/api/team/(?<segment>.*), /api/${segment}
 
             - id: notification-http
               uri: ${GATEWAY_NOTIFICATION_URI:http://localhost:8096}

--- a/services/api-gateway-service/bin/main/application.yml
+++ b/services/api-gateway-service/bin/main/application.yml
@@ -35,6 +35,30 @@ spring:
               filters:
                 - RemoveRequestHeader=Authorization
 
+            - id: identity-http
+              uri: ${GATEWAY_IDENTITY_URI:http://localhost:8090}
+              predicates:
+                - Path=/api/identity/**
+              filters:
+                - RemoveRequestHeader=Authorization
+                - RewritePath=/api/identity/(?<segment>.*), /api/${segment}
+
+            - id: team-http
+              uri: ${GATEWAY_TEAM_URI:http://localhost:8093}
+              predicates:
+                - Path=/api/team/**
+              filters:
+                - RemoveRequestHeader=Authorization
+                - RewritePath=/api/team/(?<segment>.*), /api/v1/${segment}
+
+            - id: notification-http
+              uri: ${GATEWAY_NOTIFICATION_URI:http://localhost:8096}
+              predicates:
+                - Path=/api/notification/**
+              filters:
+                - RemoveRequestHeader=Authorization
+                - RewritePath=/api/notification/(?<segment>.*), /api/${segment}
+
 management:
   endpoints:
     web:

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/config/GatewayProperties.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/config/GatewayProperties.java
@@ -2,6 +2,8 @@ package com.eevee.apigateway.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+
 /**
  * See {@code docs/contracts/gateway-proxy.md}.
  */
@@ -19,6 +21,7 @@ public class GatewayProperties {
     private String sharedSecret = "";
 
     private final Jwt jwt = new Jwt();
+    private final Cors cors = new Cors();
 
     public boolean isDevMode() {
         return devMode;
@@ -40,6 +43,10 @@ public class GatewayProperties {
         return jwt;
     }
 
+    public Cors getCors() {
+        return cors;
+    }
+
     public static class Jwt {
         /**
          * HMAC256 secret for validating platform JWTs (same convention as legacy combined gateway module).
@@ -52,6 +59,18 @@ public class GatewayProperties {
 
         public void setSecret(String secret) {
             this.secret = secret;
+        }
+    }
+
+    public static class Cors {
+        private List<String> allowedOrigins = List.of("http://localhost:8888");
+
+        public List<String> getAllowedOrigins() {
+            return allowedOrigins;
+        }
+
+        public void setAllowedOrigins(List<String> allowedOrigins) {
+            this.allowedOrigins = allowedOrigins;
         }
     }
 }

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/config/SecurityConfiguration.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/config/SecurityConfiguration.java
@@ -4,11 +4,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import com.eevee.apigateway.filter.ProxyTrustHeadersWebFilter;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsConfigurationSource;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -23,6 +29,7 @@ public class SecurityConfiguration {
         http.csrf(ServerHttpSecurity.CsrfSpec::disable);
         http.httpBasic(ServerHttpSecurity.HttpBasicSpec::disable);
         http.formLogin(ServerHttpSecurity.FormLoginSpec::disable);
+        http.cors(cors -> {});
 
         if (gatewayProperties.isDevMode()) {
             http.authorizeExchange(ex -> ex
@@ -30,6 +37,11 @@ public class SecurityConfiguration {
                     .pathMatchers("/api/v1/ai/**").permitAll()
                     .pathMatchers("/api/v1/usage/**").permitAll()
                     .pathMatchers("/api/v1/expenditure/**").permitAll()
+                    .pathMatchers(HttpMethod.POST, "/api/identity/auth/signup", "/api/identity/auth/login",
+                            "/api/identity/auth/forgot-password", "/api/identity/auth/reset-password").permitAll()
+                    .pathMatchers("/api/identity/**").permitAll()
+                    .pathMatchers("/api/team/**").permitAll()
+                    .pathMatchers("/api/notification/**").permitAll()
                     .anyExchange().denyAll()
             );
         } else {
@@ -43,11 +55,38 @@ public class SecurityConfiguration {
                     .pathMatchers("/api/v1/ai/**").authenticated()
                     .pathMatchers("/api/v1/usage/**").authenticated()
                     .pathMatchers("/api/v1/expenditure/**").authenticated()
+                    .pathMatchers(HttpMethod.POST, "/api/identity/auth/signup", "/api/identity/auth/login",
+                            "/api/identity/auth/forgot-password", "/api/identity/auth/reset-password").permitAll()
+                    .pathMatchers("/api/identity/**").authenticated()
+                    .pathMatchers("/api/team/**").authenticated()
+                    .pathMatchers("/api/notification/**").authenticated()
                     .anyExchange().denyAll()
             );
         }
 
         http.addFilterAfter(new ProxyTrustHeadersWebFilter(gatewayProperties), SecurityWebFiltersOrder.AUTHORIZATION);
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:8888"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of(
+                "Authorization",
+                "Content-Type",
+                "X-Correlation-Id",
+                "X-User-Id",
+                "X-Platform-User-Id",
+                "X-Team-Id",
+                "X-Scope-Type"
+        ));
+        config.setExposedHeaders(List.of("X-Correlation-Id"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/config/SecurityConfiguration.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/config/SecurityConfiguration.java
@@ -59,7 +59,7 @@ public class SecurityConfiguration {
                             "/api/identity/auth/forgot-password", "/api/identity/auth/reset-password").permitAll()
                     .pathMatchers("/api/identity/**").authenticated()
                     .pathMatchers("/api/team/**").authenticated()
-                    .pathMatchers("/api/notification/**").authenticated()
+                    .pathMatchers("/api/notification/**").permitAll()
                     .anyExchange().denyAll()
             );
         }
@@ -69,9 +69,9 @@ public class SecurityConfiguration {
     }
 
     @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
+    public CorsConfigurationSource corsConfigurationSource(GatewayProperties gatewayProperties) {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:8888"));
+        config.setAllowedOrigins(gatewayProperties.getCors().getAllowedOrigins());
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of(
                 "Authorization",

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
@@ -52,6 +52,9 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         String path = exchange.getRequest().getPath().value();
+        if (isNotificationPath(path)) {
+            return chain.filter(exchange);
+        }
         if (!requiresGatewayTrustHeaders(path)) {
             return chain.filter(exchange);
         }
@@ -161,6 +164,7 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
         String scopeType = resolveScopeType(jwt, team);
         req.header(HDR_SCOPE_TYPE, scopeType);
         attachGatewayAuth(req);
+        logForwarding(jwt.getSubject(), pathToService(exchange.getRequest().getPath().value()), scopeType, team);
         return chain.filter(exchange.mutate().request(req.build()).build());
     }
 
@@ -186,6 +190,9 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
             req.header(HDR_SCOPE_TYPE, (teamId != null && !teamId.isBlank()) ? "TEAM" : "USER");
         }
         attachGatewayAuth(req);
+        logForwarding(userId, pathToService(exchange.getRequest().getPath().value()),
+                (scopeType != null && !scopeType.isBlank()) ? scopeType : ((teamId != null && !teamId.isBlank()) ? "TEAM" : "USER"),
+                teamId);
         return chain.filter(exchange.mutate().request(req.build()).build());
     }
 
@@ -195,6 +202,35 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
             return claim.toUpperCase();
         }
         return (teamIdClaim != null && !teamIdClaim.isBlank()) ? "TEAM" : "USER";
+    }
+
+    private static boolean isNotificationPath(String path) {
+        return path.startsWith("/api/notification/");
+    }
+
+    private static String pathToService(String path) {
+        if (path.startsWith("/api/team/")) return "team-service";
+        if (path.startsWith("/api/identity/")) return "identity-service";
+        if (path.startsWith("/api/notification/")) return "notification-service";
+        if (path.startsWith("/api/v1/usage/")) return "usage-service";
+        if (path.startsWith("/api/v1/expenditure/")) return "billing-service";
+        if (path.startsWith("/api/v1/ai/")) return "proxy-service";
+        return "unknown";
+    }
+
+    private void logForwarding(String userId, String service, String scopeType, String teamId) {
+        String maskedUser = maskUserId(userId);
+        String maskedTeam = (teamId == null || teamId.isBlank()) ? "-" : maskUserId(teamId);
+        log.info("[Gateway] Forwarding request for User: {} to Service: {} scope={} team={}",
+                maskedUser, service, scopeType, maskedTeam);
+    }
+
+    private static String maskUserId(String value) {
+        if (value == null || value.isBlank()) {
+            return "-";
+        }
+        int keep = Math.min(4, value.length());
+        return value.substring(0, keep) + "***";
     }
 
     private void copyCorrelation(ServerWebExchange exchange, ServerHttpRequest.Builder req) {

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
@@ -38,6 +38,7 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
     private static final String HDR_PLATFORM_USER = "X-Platform-User-Id";
     private static final String HDR_ORG = "X-Org-Id";
     private static final String HDR_TEAM = "X-Team-Id";
+    private static final String HDR_SCOPE_TYPE = "X-Scope-Type";
     private static final String HDR_GATEWAY_AUTH = "X-Gateway-Auth";
     private static final String HDR_CORRELATION = "X-Correlation-Id";
     private static final Logger log = LoggerFactory.getLogger(ProxyTrustHeadersWebFilter.class);
@@ -157,6 +158,8 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
         if (team != null && !team.isBlank()) {
             req.header(HDR_TEAM, team);
         }
+        String scopeType = resolveScopeType(jwt, team);
+        req.header(HDR_SCOPE_TYPE, scopeType);
         attachGatewayAuth(req);
         return chain.filter(exchange.mutate().request(req.build()).build());
     }
@@ -172,8 +175,26 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
         if (platformUserId != null && !platformUserId.isBlank()) {
             req.header(HDR_PLATFORM_USER, platformUserId);
         }
+        String teamId = exchange.getRequest().getHeaders().getFirst(HDR_TEAM);
+        if (teamId != null && !teamId.isBlank()) {
+            req.header(HDR_TEAM, teamId);
+        }
+        String scopeType = exchange.getRequest().getHeaders().getFirst(HDR_SCOPE_TYPE);
+        if (scopeType != null && !scopeType.isBlank()) {
+            req.header(HDR_SCOPE_TYPE, scopeType);
+        } else {
+            req.header(HDR_SCOPE_TYPE, (teamId != null && !teamId.isBlank()) ? "TEAM" : "USER");
+        }
         attachGatewayAuth(req);
         return chain.filter(exchange.mutate().request(req.build()).build());
+    }
+
+    private static String resolveScopeType(Jwt jwt, String teamIdClaim) {
+        String claim = jwt.getClaimAsString("scope_type");
+        if ("TEAM".equalsIgnoreCase(claim) || "USER".equalsIgnoreCase(claim)) {
+            return claim.toUpperCase();
+        }
+        return (teamIdClaim != null && !teamIdClaim.isBlank()) ? "TEAM" : "USER";
     }
 
     private void copyCorrelation(ServerWebExchange exchange, ServerHttpRequest.Builder req) {
@@ -193,6 +214,9 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
     static boolean requiresGatewayTrustHeaders(String path) {
         return path.startsWith("/api/v1/ai/")
                 || path.startsWith("/api/v1/usage/")
-                || path.startsWith("/api/v1/expenditure/");
+                || path.startsWith("/api/v1/expenditure/")
+                || path.startsWith("/api/identity/")
+                || path.startsWith("/api/team/")
+                || path.startsWith("/api/notification/");
     }
 }

--- a/services/api-gateway-service/src/main/resources/application.yml
+++ b/services/api-gateway-service/src/main/resources/application.yml
@@ -72,3 +72,5 @@ gateway:
   shared-secret: ${GATEWAY_SHARED_SECRET:local-dev-gateway-shared-secret-do-not-use-in-prod}
   jwt:
     secret: ${GATEWAY_JWT_SECRET:change-this-secret-key-to-at-least-32-bytes}
+  cors:
+    allowed-origins: ${GATEWAY_CORS_ALLOWED_ORIGINS:http://localhost:8888}

--- a/services/api-gateway-service/src/main/resources/application.yml
+++ b/services/api-gateway-service/src/main/resources/application.yml
@@ -44,12 +44,12 @@ spring:
                 - RewritePath=/api/identity/(?<segment>.*), /api/${segment}
 
             - id: team-http
-              uri: ${GATEWAY_TEAM_URI:http://localhost:8093}
+              uri: ${GATEWAY_TEAM_URI:http://team-service:8093}
               predicates:
                 - Path=/api/team/**
               filters:
                 - RemoveRequestHeader=Authorization
-                - RewritePath=/api/team/(?<segment>.*), /api/v1/${segment}
+                - RewritePath=/api/team/(?<segment>.*), /api/${segment}
 
             - id: notification-http
               uri: ${GATEWAY_NOTIFICATION_URI:http://localhost:8096}

--- a/services/api-gateway-service/src/main/resources/application.yml
+++ b/services/api-gateway-service/src/main/resources/application.yml
@@ -35,6 +35,30 @@ spring:
               filters:
                 - RemoveRequestHeader=Authorization
 
+            - id: identity-http
+              uri: ${GATEWAY_IDENTITY_URI:http://localhost:8090}
+              predicates:
+                - Path=/api/identity/**
+              filters:
+                - RemoveRequestHeader=Authorization
+                - RewritePath=/api/identity/(?<segment>.*), /api/${segment}
+
+            - id: team-http
+              uri: ${GATEWAY_TEAM_URI:http://localhost:8093}
+              predicates:
+                - Path=/api/team/**
+              filters:
+                - RemoveRequestHeader=Authorization
+                - RewritePath=/api/team/(?<segment>.*), /api/v1/${segment}
+
+            - id: notification-http
+              uri: ${GATEWAY_NOTIFICATION_URI:http://localhost:8096}
+              predicates:
+                - Path=/api/notification/**
+              filters:
+                - RemoveRequestHeader=Authorization
+                - RewritePath=/api/notification/(?<segment>.*), /api/${segment}
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> N/A

## 작업 내용
- **해당 서비스**: API Gateway
> 단일 진입점(Port 8888)을 통한 서비스 통합을 위해 identity, team, notification 서비스를 게이트웨이 라우팅에 추가하고, 각 서비스 간 사용자 컨텍스트 전파 및 보안 정책을 일괄 정비했습니다. 또한, 로컬 및 도커 환경에서의 연결 이슈를 해결하기 위한 인프라 설정을 보강했습니다.

  
## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [x] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
1. 신규 서비스 라우팅 및 경로 리라이트 통합
- 라우팅 추가: identity, team, notification 서비스를 게이트웨이 엔드포인트로 통합했습니다.
- 경로 리라이트 정규화: 하위 서비스의 API 규격에 맞춰 게이트웨이 진입 경로를 변환하도록 설정했습니다.

/api/identity/** → /api/

/api/team/** → /api/ (중복 v1 경로 생성 방지를 위한 규칙 수정)

/api/notification/** → /api/

- 컨테이너 통신 최적화: 도커 환경 내 원활한 통신을 위해 localhost 참조를 서비스 명(team-service 등)으로 전환했습니다.

2. 글로벌 컨텍스트 헤더 전파 및 로깅 보강
- JWT 기반 헤더 주입: JWT 클레임을 분석하여 X-User-Id, X-Team-Id, X-Scope-Type 헤더를 하위 서비스로 전파하는 로직을 확장했습니다.
- 보안 로깅 도입: 하위 서비스로 전달되는 헤더 정보를 추적하는 로그를 추가했으며, 민감 정보(ID 등)는 마스킹 처리(앞 4글자 + ***)하여 가시성과 보안성을 동시에 확보했습니다.
- 알림 서비스 인증 유예: notification 서비스의 특성을 고려하여 특정 경로에 대해 인증 필터 우회 및 permitAll 정책을 적용했습니다.

3. 보안 및 CORS 정책 환경변수화
- CORS 설정 유연화: 허용 오리진(allowed-origins)을 환경변수(GATEWAY_CORS_ALLOWED_ORIGINS)로 관리하도록 개선하여 환경별 대응력을 높였습니다.
- 환경 변수 문서화: .env.example 파일에 신규 환경 변수 사용법(쉼표 구분 다중 오리진 등)을 상세히 추가했습니다.

4. 인프라 설정 오류 수정 (BFF & Docker)
- BFF 환경 변수 보완: team-web 서비스에서 게이트웨이 호출 시 필요한 GATEWAY_URL 누락으로 인한 500 에러를 해결했습니다.
- 도커 컴포즈 동기화: docker-compose.yml 내 서비스 간 의존성 및 환경 변수 설정을 최신화했습니다.

5. notification-service의 api-gateway전환을 위한 가이드 문서 작성
- docs/notification-service-gateway-integration-guide.md 문서를 참조하세요.


## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
## 리뷰 요구사항 
> 무수정 원칙 확인: identity, team, notification 등 하위 서비스 내부 코드 변경 없이 게이트웨이와 설정 파일만 수정되었는지 확인 부탁드립니다.
> 라우팅 규칙: team-service로 전달되는 리라이트 경로(v1 중복 여부)가 의도한 대로 동작하는지 검토가 필요합니다.
> 환경 변수: .env.example에 추가된 CORS 설정 예시가 명확하게 전달되는지 확인 부탁드립니다.
