### PR TITLE
Fix/api gateway 403

### DIFF
--- a/docs/notification-service-gateway-integration-guide.md
+++ b/docs/notification-service-gateway-integration-guide.md
@@ -1,4 +1,4 @@
-# Notification Service Gateway Integration Guide (Task 38-2)
+ # Notification Service Gateway Integration Guide (Task 38-2)
 
 ## 1) 목적과 범위
 
@@ -24,9 +24,10 @@
 
 ### 2.3 글로벌 필터(ProxyTrustHeadersWebFilter)
 
-- 게이트웨이 표준 전파 헤더:
-  - `X-User-Id` (`sub`)
-  - `X-Platform-User-Id` (`userId`)
+- 게이트웨이 표준 전파 헤더(JWT 검증 후 `forwardWithJwt` 적용 경로 기준):
+  - `X-User-Id` ← JWT 클레임 **`userId`** (플랫폼 사용자 ID 문자열). **`sub`(이메일 등)은 `X-User-Id`로 전달하지 않음.**
+  - `X-Platform-User-Id` ← 동일하게 JWT 클레임 **`userId`** 값을 사용한다.
+  - JWT에 **`userId` 클레임이 없거나 빈 문자열이면** 요청은 조용히 통과하지 않고 **401**(Missing userId claim)으로 처리한다.
   - `X-Org-Id` (`org_id`)
   - `X-Team-Id` (`team_id`)
   - `X-Scope-Type` (`scope_type`, 없으면 `team_id` 기반 추론)
@@ -58,6 +59,7 @@
 
 - `services/notification-service/web/src/app/api/notification/[[...path]]/route.ts`는 아직 Gateway 경유가 아닌 **notification-service 직접 호출** 구조다.
 - 이 BFF는 Identity `/api/auth/session`으로 이메일을 조회해 `X-User-Id`를 생성/전달한다.
+- Gateway 경로에서 내려오는 `X-User-Id`는 **플랫폼 숫자 `userId`** 이고, 위 BFF 경로에서 보내는 값은 **이메일 문자열**일 수 있다. 인앱 알림 도메인에서 기준 식별자를 하나로 정할지(또는 양쪽을 구분할지)는 통합 완료 시점에 정합성 검토가 필요하다.
 - 따라서 notification 백엔드는 현재 "Gateway 헤더"와 "BFF 생성 헤더"를 모두 받을 수 있는 상태다.
 
 ## 4) 전환 전략 (제안만, 미적용)
@@ -81,7 +83,7 @@
 제안:
 - `AuthContext` 형태로 정규화:
   - `userId` (`X-User-Id`)
-  - `platformUserId` (`X-Platform-User-Id`, optional)
+  - `platformUserId` (`X-Platform-User-Id`, optional — Gateway JWT 경로에서는 현재 구현상 **`userId`와 동일 값**이 내려온다)
   - `teamId` (`X-Team-Id`, optional)
   - `scopeType` (`X-Scope-Type`, USER|TEAM)
   - `isInternal` (internal secret 검증 결과)
@@ -131,7 +133,7 @@
 - 이유:
   - 이번 전환 대상은 notification 경로의 게이트웨이 인증 정책 및 notification 내부 헤더 수용 방식
   - identity/team의 기존 엔드포인트/필터 계약을 변경할 필요가 없음
-- 단, 플랫폼 JWT 클레임 스키마(`sub`, `userId`, `team_id`, `scope_type`) 변경이 발생하면 세 서비스 공통 영향이 있으므로 별도 공지/버전 관리가 필요하다.
+- 단, 플랫폼 JWT 클레임 스키마(`sub`, `userId`, `team_id`, `scope_type`) 변경이 발생하면 세 서비스 공통 영향이 있으므로 별도 공지/버전 관리가 필요하다. 특히 **`sub`는 이메일 등 로그인 식별자로 남을 수 있으나, 다운스트림 신뢰 헤더 `X-User-Id`는 `userId` 클레임 기준**으로 맞추는 것이 identity/team과의 계약과 일치한다.
 
 ## 7) 권장 적용 순서(승인 후)
 

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
@@ -146,12 +146,15 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
 
     private Mono<Void> forwardWithJwt(ServerWebExchange exchange, WebFilterChain chain, JwtAuthenticationToken jwtAuth) {
         Jwt jwt = jwtAuth.getToken();
-        ServerHttpRequest.Builder req = exchange.getRequest().mutate();
-        req.header(HDR_USER, jwt.getSubject());
         String platformUserId = jwt.getClaimAsString("userId");
-        if (platformUserId != null && !platformUserId.isBlank()) {
-            req.header(HDR_PLATFORM_USER, platformUserId);
+        if (platformUserId == null || platformUserId.isBlank()) {
+            log.warn("Reject JWT without userId claim path={} subject={}",
+                    exchange.getRequest().getPath().value(), jwt.getSubject());
+            return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing userId claim"));
         }
+        ServerHttpRequest.Builder req = exchange.getRequest().mutate();
+        req.header(HDR_USER, platformUserId);
+        req.header(HDR_PLATFORM_USER, platformUserId);
         copyCorrelation(exchange, req);
         String org = jwt.getClaimAsString("org_id");
         if (org != null && !org.isBlank()) {
@@ -164,7 +167,7 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
         String scopeType = resolveScopeType(jwt, team);
         req.header(HDR_SCOPE_TYPE, scopeType);
         attachGatewayAuth(req);
-        logForwarding(jwt.getSubject(), pathToService(exchange.getRequest().getPath().value()), scopeType, team);
+        logForwarding(platformUserId, pathToService(exchange.getRequest().getPath().value()), scopeType, team);
         return chain.filter(exchange.mutate().request(req.build()).build());
     }
 

--- a/services/api-gateway-service/src/test/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilterTest.java
+++ b/services/api-gateway-service/src/test/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilterTest.java
@@ -27,7 +27,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * E2E 대체: 운영 JWT 모드에서 {@code sub} → {@code X-User-Id} 정합, 개발 모드에서 클라이언트 {@code X-User-Id} 전달.
+ * E2E 대체: 운영 JWT 모드에서 {@code userId} claim → {@code X-User-Id}/{@code X-Platform-User-Id} 정합,
+ * 개발 모드에서 클라이언트 {@code X-User-Id} 전달.
  * 문서: {@code docs/contracts/gateway-proxy.md} §4.2.
  */
 class ProxyTrustHeadersWebFilterTest {
@@ -150,11 +151,12 @@ class ProxyTrustHeadersWebFilterTest {
     }
 
     @Test
-    void jwtSubjectIsForwardedAsXUserId_forUsagePath() {
+    void jwtUserIdClaimIsForwardedAsXUserId_forUsagePath() {
         gatewayProperties.setDevMode(false);
         Jwt jwt = Jwt.withTokenValue("dummy")
                 .header("alg", "HS256")
                 .subject("user@example.com")
+                .claim("userId", "42")
                 .build();
         JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
 
@@ -171,7 +173,7 @@ class ProxyTrustHeadersWebFilterTest {
         StepVerifier.create(filter.applyTrustHeaders(exchange, chain, auth))
                 .verifyComplete();
 
-        assertThat(userIdSeen.get()).isEqualTo("user@example.com");
+        assertThat(userIdSeen.get()).isEqualTo("42");
     }
 
     @Test
@@ -198,6 +200,27 @@ class ProxyTrustHeadersWebFilterTest {
                 .verifyComplete();
 
         assertThat(platformUserIdSeen.get()).isEqualTo("42");
+    }
+
+    @Test
+    void jwtWithoutUserIdClaim_isRejectedInNonDevMode() {
+        gatewayProperties.setDevMode(false);
+        Jwt jwt = Jwt.withTokenValue("dummy")
+                .header("alg", "HS256")
+                .subject("user@example.com")
+                .build();
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/identity/auth/session").build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        WebFilterChain chain = ex -> Mono.empty();
+
+        ProxyTrustHeadersWebFilter filter = new ProxyTrustHeadersWebFilter(gatewayProperties);
+
+        StepVerifier.create(filter.applyTrustHeaders(exchange, chain, auth))
+                .expectErrorMatches(t -> t instanceof org.springframework.web.server.ResponseStatusException
+                        && ((org.springframework.web.server.ResponseStatusException) t).getStatusCode().value() == 401)
+                .verify();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> N/A

## 작업 내용
- **해당 서비스**: api-gateway, documentation
> 하위 서비스로 전파되는 사용자 식별값의 일관성을 위해 X-User-Id 추출 소스를 변경하고, 이에 따른 인증 보안 강화 및 가이드 문서 최신화를 진행했습니다. 이제 게이트웨이는 이메일(Subject)이 아닌 고유 ID(userId Claim)를 기준으로 통신합니다.

  
## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
1. 사용자 식별 헤더 추출 기준 변경 (Subject → userId)
- 추출 소스 변경: ProxyTrustHeadersWebFilter에서 X-User-Id 및 X-Platform-User-Id 주입 시 사용하던 jwt.getSubject()(이메일 형식)를 삭제하고, JWT 내부의 userId 클레임(숫자/고유 ID 형식)을 사용하도록 수정했습니다.
- 로깅 식별자 통일: 게이트웨이 적재 로그의 사용자 식별값 또한 Platform User ID 기준으로 변경하여 모니터링 가시성을 통일했습니다.

2. 보안 예외 처리 강화 (Strict User Validation)
- 필수 클레임 검증: JWT 내에 userId 클레임이 누락되었거나 공백인 경우를 엄격히 제한합니다.
- 즉시 차단: 검증 실패 시 경고(warn) 로그를 남기고, 하위 서비스로 요청을 넘기지 않은 채 즉시 401 Unauthorized (Missing userId claim) 응답을 반환합니다.

3. 알림 서비스 통합 가이드 및 인터페이스 계약 수정
- 매핑 정보 정정: 이전 문서에서 sub와 X-User-Id를 연동하여 설명하던 부분을 userId 클레임 기준으로 전면 수정했습니다.
- 역할 분리 명시: sub(이메일)와 X-User-Id(고유 식별자)의 역할 분리 계약을 요약하여 추가했습니다.
- 정합성 주의 문구: BFF에서 사용하는 식별자 형식(이메일)과 게이트웨이가 전달하는 형식(숫자 ID)의 차이에 따른 정합성 검토 주의사항을 보강했습니다.
- 헤더 동일성 설명: 게이트웨이 JWT 경로에서 X-User-Id와 X-Platform-User-Id가 동일한 값을 가짐을 명시했습니다.

4. 테스트 코드 보강 및 회귀 방지
- 기존 테스트 갱신: ProxyTrustHeadersWebFilterTest에서 헤더 주입 기준이 변경된 로직을 검증하도록 업데이트했습니다.
- 회귀 테스트 추가: 운영(non-dev) 모드에서 userId 클레임이 없는 토큰 요청이 정상적으로 401 거부되는지 시나리오를 추가했습니다.

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
## 리뷰 요구사항 
> 식별자 형식: 하위 서비스(identity, team, notification 등)에서 이제 이메일이 아닌 고유 ID를 X-User-Id로 받게 됩니다. 각 서비스의 수용 로직에 문제가 없는지 다시 한번 체크 부탁드립니다.
> 보안 로직: userId 클레임 누락 시 401로 차단하는 로직이 운영 환경에서 의도치 않은 거부를 발생시키지 않는지 검토 부탁드립니다.
> 문서 정합성: 수정된 가이드 문서의 내용이 실제 게이트웨이의 헤더 전파 로직과 일치하는지 확인 부탁드립니다.

