### PR TITLE
Feature/notification gateway unification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,10 @@ TEAM_SERVICE_HOST_PORT=8093
 BILLING_SERVICE_PORT=8095
 # Gateway → billing-service HTTP (Compose api-gateway 가 호스트 billing 을 부를 때; BILLING_SERVICE_PORT 와 동일 포트)
 GATEWAY_BILLING_URI=http://host.docker.internal:8095
+# Gateway → notification-service HTTP
+# - Docker Compose(권장): http://notification-service:8096
+# - 호스트에서 notification-service 단독 실행 시: http://host.docker.internal:8096
+GATEWAY_NOTIFICATION_URI=http://notification-service:8096
 
 # notification-service (Nest) — HTTP는 서비스 로컬 `.env` 의 `PORT`(기본 8096, billing 8095와 구분). DB 는 NOTIFICATION_POSTGRES_* / `services/notification-service/.env.example` 의 DATABASE_URL 과 맞출 것.
 # Docker Compose: notification-service 호스트 포트(좌측). 컨테이너 내부 포트는 8096 고정.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,7 @@ services:
       GATEWAY_PROXY_URI: http://proxy-service:8081
       GATEWAY_IDENTITY_URI: ${GATEWAY_IDENTITY_URI:-http://host.docker.internal:8090}
       GATEWAY_USAGE_URI: ${GATEWAY_USAGE_URI:-http://host.docker.internal:8092}
+      GATEWAY_NOTIFICATION_URI: ${GATEWAY_NOTIFICATION_URI:-http://notification-service:8096}
       # Host-run billing (bootRun default 8095). Override if billing runs elsewhere.
       GATEWAY_BILLING_URI: ${GATEWAY_BILLING_URI:-http://host.docker.internal:8095}
       GATEWAY_SHARED_SECRET: ${GATEWAY_SHARED_SECRET:-}

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/config/SecurityConfiguration.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/config/SecurityConfiguration.java
@@ -59,7 +59,7 @@ public class SecurityConfiguration {
                             "/api/identity/auth/forgot-password", "/api/identity/auth/reset-password").permitAll()
                     .pathMatchers("/api/identity/**").authenticated()
                     .pathMatchers("/api/team/**").authenticated()
-                    .pathMatchers("/api/notification/**").permitAll()
+                    .pathMatchers("/api/notification/**").authenticated()
                     .anyExchange().denyAll()
             );
         }

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
@@ -149,8 +149,10 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
                     exchange.getRequest().getPath().value(), jwt.getSubject());
             return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing userId claim"));
         }
+        String service = pathToService(exchange.getRequest().getPath().value());
+        String effectiveUserId = resolveUserIdForService(service, jwt.getSubject(), platformUserId);
         ServerHttpRequest.Builder req = exchange.getRequest().mutate();
-        req.header(HDR_USER, platformUserId);
+        req.header(HDR_USER, effectiveUserId);
         req.header(HDR_PLATFORM_USER, platformUserId);
         copyCorrelation(exchange, req);
         String org = jwt.getClaimAsString("org_id");
@@ -164,8 +166,19 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
         String scopeType = resolveScopeType(jwt, team);
         req.header(HDR_SCOPE_TYPE, scopeType);
         attachGatewayAuth(req);
-        logForwarding(platformUserId, pathToService(exchange.getRequest().getPath().value()), scopeType, team);
+        logForwarding(effectiveUserId, service, scopeType, team);
         return chain.filter(exchange.mutate().request(req.build()).build());
+    }
+
+    private static String resolveUserIdForService(String service, String subject, String platformUserId) {
+        if (("usage-service".equals(service)
+                || "team-service".equals(service)
+                || "billing-service".equals(service)
+                || "notification-service".equals(service))
+                && subject != null && !subject.isBlank()) {
+            return subject;
+        }
+        return platformUserId;
     }
 
     private Mono<Void> forwardDevHeaders(ServerWebExchange exchange, WebFilterChain chain) {

--- a/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
+++ b/services/api-gateway-service/src/main/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilter.java
@@ -52,9 +52,6 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         String path = exchange.getRequest().getPath().value();
-        if (isNotificationPath(path)) {
-            return chain.filter(exchange);
-        }
         if (!requiresGatewayTrustHeaders(path)) {
             return chain.filter(exchange);
         }
@@ -205,10 +202,6 @@ public class ProxyTrustHeadersWebFilter implements WebFilter {
             return claim.toUpperCase();
         }
         return (teamIdClaim != null && !teamIdClaim.isBlank()) ? "TEAM" : "USER";
-    }
-
-    private static boolean isNotificationPath(String path) {
-        return path.startsWith("/api/notification/");
     }
 
     private static String pathToService(String path) {

--- a/services/api-gateway-service/src/test/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilterTest.java
+++ b/services/api-gateway-service/src/test/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilterTest.java
@@ -151,7 +151,7 @@ class ProxyTrustHeadersWebFilterTest {
     }
 
     @Test
-    void jwtUserIdClaimIsForwardedAsXUserId_forUsagePath() {
+    void jwtSubjectIsForwardedAsXUserId_forUsagePath() {
         gatewayProperties.setDevMode(false);
         Jwt jwt = Jwt.withTokenValue("dummy")
                 .header("alg", "HS256")
@@ -173,7 +173,7 @@ class ProxyTrustHeadersWebFilterTest {
         StepVerifier.create(filter.applyTrustHeaders(exchange, chain, auth))
                 .verifyComplete();
 
-        assertThat(userIdSeen.get()).isEqualTo("42");
+        assertThat(userIdSeen.get()).isEqualTo("user@example.com");
     }
 
     @Test
@@ -200,6 +200,58 @@ class ProxyTrustHeadersWebFilterTest {
                 .verifyComplete();
 
         assertThat(platformUserIdSeen.get()).isEqualTo("42");
+    }
+
+    @Test
+    void jwtUserIdClaimIsForwardedAsXUserId_forIdentityPath() {
+        gatewayProperties.setDevMode(false);
+        Jwt jwt = Jwt.withTokenValue("dummy")
+                .header("alg", "HS256")
+                .subject("user@example.com")
+                .claim("userId", "42")
+                .build();
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/identity/auth/session").build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        AtomicReference<String> userIdSeen = new AtomicReference<>();
+        WebFilterChain chain = ex -> {
+            userIdSeen.set(ex.getRequest().getHeaders().getFirst("X-User-Id"));
+            return Mono.empty();
+        };
+
+        ProxyTrustHeadersWebFilter filter = new ProxyTrustHeadersWebFilter(gatewayProperties);
+
+        StepVerifier.create(filter.applyTrustHeaders(exchange, chain, auth))
+                .verifyComplete();
+
+        assertThat(userIdSeen.get()).isEqualTo("42");
+    }
+
+    @Test
+    void jwtSubjectIsForwardedAsXUserId_forNotificationPath() {
+        gatewayProperties.setDevMode(false);
+        Jwt jwt = Jwt.withTokenValue("dummy")
+                .header("alg", "HS256")
+                .subject("user@example.com")
+                .claim("userId", "42")
+                .build();
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/notification/in-app-notifications").build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        AtomicReference<String> userIdSeen = new AtomicReference<>();
+        WebFilterChain chain = ex -> {
+            userIdSeen.set(ex.getRequest().getHeaders().getFirst("X-User-Id"));
+            return Mono.empty();
+        };
+
+        ProxyTrustHeadersWebFilter filter = new ProxyTrustHeadersWebFilter(gatewayProperties);
+
+        StepVerifier.create(filter.applyTrustHeaders(exchange, chain, auth))
+                .verifyComplete();
+
+        assertThat(userIdSeen.get()).isEqualTo("user@example.com");
     }
 
     @Test

--- a/services/api-gateway-service/src/test/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilterTest.java
+++ b/services/api-gateway-service/src/test/java/com/eevee/apigateway/filter/ProxyTrustHeadersWebFilterTest.java
@@ -294,4 +294,39 @@ class ProxyTrustHeadersWebFilterTest {
         assertThat(chainRan.get()).isTrue();
         assertThat(exchange.getRequest().getHeaders().getFirst("X-User-Id")).isNull();
     }
+
+    @Test
+    void notificationPath_noLongerBypassesFilter_andForwardsDevHeaders() {
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/notification/in-app-notifications")
+                .header("X-User-Id", "42")
+                .header("X-Team-Id", "team-1")
+                .build();
+        ServerWebExchange exchange = MockServerWebExchange.from(request);
+        AtomicReference<String> userIdSeen = new AtomicReference<>();
+        WebFilterChain chain = ex -> {
+            userIdSeen.set(ex.getRequest().getHeaders().getFirst("X-User-Id"));
+            return Mono.empty();
+        };
+
+        ProxyTrustHeadersWebFilter filter = new ProxyTrustHeadersWebFilter(gatewayProperties);
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        assertThat(userIdSeen.get()).isEqualTo("42");
+    }
+
+    @Test
+    void notificationPath_missingUserHeader_returns401InDevMode() {
+        MockServerHttpRequest request = MockServerHttpRequest.get("/api/notification/in-app-notifications").build();
+        ServerWebExchange exchange = MockServerWebExchange.from(request);
+        WebFilterChain chain = ex -> Mono.empty();
+
+        ProxyTrustHeadersWebFilter filter = new ProxyTrustHeadersWebFilter(gatewayProperties);
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .expectErrorMatches(t -> t instanceof org.springframework.web.server.ResponseStatusException
+                        && ((org.springframework.web.server.ResponseStatusException) t).getStatusCode().value() == 401)
+                .verify();
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> N/A

## 작업 내용
- **해당 서비스**: api-gateway-service, docker compose
> 유예되었던 알림 서비스(notification-service)의 인증 통합을 완료하고, 도커 환경에서의 연결 이슈를 해결했습니다. 특히, 식별자 기준 변경(userId 클레임 도입) 과정에서 발생한 기존 서비스들과의 데이터 정합성 문제를 서비스별 맞춤형 헤더 매핑 로직을 통해 최종 복구했습니다.

  
## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
1. 알림 서비스 인증 통합 및 필터 우회 제거
- 보안 정책 강화: /api/notification/** 경로를 permitAll()에서 authenticated()로 전환하여 전역 보안 표준에 통합했습니다.
- 필터 로직 단일화: ProxyTrustHeadersWebFilter 내 알림 서비스 전용 Bypass 분기문을 제거하고, 타 서비스와 동일한 JWT 검증 및 헤더 주입 프로세스를 적용했습니다.

2. 인프라 환경 변수 주입 및 정합성 점검
- 네트워크 참조 오류 수정: 도커 컨테이너 환경에서 게이트웨이가 알림 서비스를 올바르게 참조할 수 있도록 GATEWAY_NOTIFICATION_URI 환경 변수를 docker-compose.yml 및 .env에 보강했습니다.
- 경로 정합성 검증: 게이트웨이의 Rewrite 규칙(/api/notification/ → /api/)과 알림 서비스 컨트롤러 간의 매핑이 정상임을 확인했습니다.

3. 서비스별 X-User-Id 식별자 정합성 복구
- 원인 분석: X-User-Id를 숫자 ID(userId 클레임)로 일괄 변경 시, 기존 데이터가 이메일 형식으로 저장된 서비스(usage, team, billing, notification)에서 조회 누락이 발생하는 것을 확인했습니다.
- 맞춤형 매핑 로직 도입 (resolveUserIdForService):
- 이메일(Subject) 기반: usage, team, billing, notification 서비스 (기존 데이터 정합성 유지)
- 숫자 ID(userId Claim) 기반: identity 서비스
- 플랫폼 공통 ID: X-Platform-User-Id 헤더는 모든 경로에서 고유 숫자 ID를 유지하여 식별성을 보존했습니다.
- 데이터 조회 정상화: 복구 조치를 통해 각 서비스 엔드포인트 호출 시 500 에러 및 빈 데이터 응답 이슈를 해결했습니다.

4. 테스트 코드 보강 및 회귀 방지
- 경로별 검증 시나리오: usage 등 데이터 조회 서비스는 subject가, identity 서비스는 userId 클레임이 X-User-Id로 전달되는지 각각 검증하는 테스트를 추가했습니다.
- 알림 서비스 회귀 테스트: 알림 서비스 경로에 대한 인증 차단 및 식별자 매핑 로직을 단위 테스트(ProxyTrustHeadersWebFilterTest)에 반영하여 BUILD SUCCESSFUL을 확인했습니다.

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [x] **DB**: 서비스별(Notification/Usage/Team/Billing) DB 내 식별자 형식(이메일) 재확인 및 정합 완료

## 📸 스크린샷 / 테스트 결과 (선택)
## 리뷰 요구사항 
> 매핑 로직 적절성: 서비스별로 X-User-Id의 소스를 다르게 가져가는 resolveUserIdForService 분기 처리가 시스템 구조상 합당한지 검토 부탁드립니다.
> 알림 서비스 연동: 이제 알림 서비스도 게이트웨이 인증을 필수로 거치게 됩니다. 프론트엔드(notification-web)에서의 호출 규격 변경이 필요한지 확인이 필요합니다.
> 인프라 설정: .env.example에 추가된 알림 서비스 관련 환경 변수명이 컨벤션에 맞는지 확인 부탁드립니다.
