### PR TITLE
fix: 토큰 수정

### DIFF
--- a/services/billing-service/web/middleware.ts
+++ b/services/billing-service/web/middleware.ts
@@ -12,7 +12,8 @@ export function middleware(request: NextRequest) {
   }
 
   const token = request.cookies.get("access_token")?.value;
-  if (token) {
+  const isLoggedIn = request.cookies.get("is_logged_in")?.value === "true";
+  if (token || isLoggedIn) {
     return NextResponse.next();
   }
 

--- a/services/billing-service/web/middleware.ts
+++ b/services/billing-service/web/middleware.ts
@@ -12,8 +12,7 @@ export function middleware(request: NextRequest) {
   }
 
   const token = request.cookies.get("access_token")?.value;
-  const isLoggedIn = request.cookies.get("is_logged_in")?.value === "true";
-  if (token || isLoggedIn) {
+  if (token) {
     return NextResponse.next();
   }
 

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/UserRepository.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/UserRepository.java
@@ -17,6 +17,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	 */
 	boolean existsByEmail(String email);
 
+	boolean existsByEmailIgnoreCase(String email);
+
 	/**
 	 * 로그인 시 이메일로 사용자 조회.
 	 *
@@ -24,4 +26,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	 * @return 사용자 Optional
 	 */
 	Optional<User> findByEmail(String email);
+
+	Optional<User> findByEmailIgnoreCase(String email);
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/UserService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/UserService.java
@@ -15,6 +15,7 @@ import com.zerobugfreinds.identity_service.security.JwtTokenProvider;
 import io.jsonwebtoken.Claims;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -60,18 +62,24 @@ public class UserService {
 	@Transactional
 	public SignupResponse signup(SignupRequest request) {
 		validateSignupRequest(request);
+		String normalizedEmail = normalizeEmail(request.email());
 
-		if (userRepository.existsByEmail(request.email())) {
+		if (userRepository.existsByEmailIgnoreCase(normalizedEmail)) {
 			throw new DuplicateEmailException("이미 사용 중인 이메일입니다");
 		}
 		String encodedPassword = passwordEncoder.encode(request.password());
 		User user = new User(
-				request.email(),
+				normalizedEmail,
 				encodedPassword,
 				request.name(),
 				request.role()
 		);
-		User saved = userRepository.save(user);
+		User saved;
+		try {
+			saved = userRepository.save(user);
+		} catch (DataIntegrityViolationException ex) {
+			throw new DuplicateEmailException("이미 사용 중인 이메일입니다");
+		}
 		return new SignupResponse(saved.getId(), saved.getEmail(), saved.getName(), saved.getRole());
 	}
 
@@ -86,7 +94,8 @@ public class UserService {
 	 */
 	@Transactional
 	public TokenResponse login(LoginRequest request) {
-		User user = userRepository.findByEmail(request.email())
+		String normalizedEmail = normalizeEmail(request.email());
+		User user = userRepository.findByEmailIgnoreCase(normalizedEmail)
 				.orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다"));
 
 		if (!passwordEncoder.matches(request.password(), user.getPassword())) {
@@ -131,7 +140,7 @@ public class UserService {
 		if (email == null || email.isBlank()) {
 			return false;
 		}
-		return userRepository.existsByEmail(email.trim());
+		return userRepository.existsByEmailIgnoreCase(normalizeEmail(email));
 	}
 
 	@Transactional(readOnly = true)
@@ -169,9 +178,13 @@ public class UserService {
 			return userRepository.findById(userId)
 					.orElseThrow(() -> new InvalidCredentialsException("사용자 정보를 찾을 수 없습니다"));
 		} catch (NumberFormatException ignored) {
-			return userRepository.findByEmail(normalized)
+			return userRepository.findByEmailIgnoreCase(normalizeEmail(normalized))
 					.orElseThrow(() -> new InvalidCredentialsException("사용자 정보를 찾을 수 없습니다"));
 		}
+	}
+
+	private static String normalizeEmail(String email) {
+		return email.trim().toLowerCase(Locale.ROOT);
 	}
 
 	private TokenResponse issueTokenPair(User user, Long activeTeamId) {

--- a/services/identity-service/src/test/java/com/zerobugfreinds/identity_service/service/UserServiceTest.java
+++ b/services/identity-service/src/test/java/com/zerobugfreinds/identity_service/service/UserServiceTest.java
@@ -1,0 +1,102 @@
+package com.zerobugfreinds.identity_service.service;
+
+import com.zerobugfreinds.identity_service.dto.SignupRequest;
+import com.zerobugfreinds.identity_service.entity.Role;
+import com.zerobugfreinds.identity_service.entity.User;
+import com.zerobugfreinds.identity_service.exception.DuplicateEmailException;
+import com.zerobugfreinds.identity_service.repository.RefreshTokenRepository;
+import com.zerobugfreinds.identity_service.repository.UserRepository;
+import com.zerobugfreinds.identity_service.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private RefreshTokenRepository refreshTokenRepository;
+	@Mock
+	private PasswordEncoder passwordEncoder;
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+	@Mock
+	private TeamMembershipVerificationClient teamMembershipVerificationClient;
+
+	private UserService userService;
+
+	@BeforeEach
+	void setUp() {
+		userService = new UserService(
+				userRepository,
+				refreshTokenRepository,
+				passwordEncoder,
+				jwtTokenProvider,
+				teamMembershipVerificationClient
+		);
+	}
+
+	@Test
+	void signup_throwsWhenDuplicateEmailIgnoringCase() {
+		SignupRequest request = new SignupRequest(
+				"  Test@Example.com  ",
+				"abc123!@",
+				"abc123!@",
+				"tester",
+				Role.USER
+		);
+		when(userRepository.existsByEmailIgnoreCase("test@example.com")).thenReturn(true);
+
+		assertThatThrownBy(() -> userService.signup(request))
+				.isInstanceOf(DuplicateEmailException.class);
+	}
+
+	@Test
+	void signup_throwsDuplicateEmailWhenSaveHitsUniqueConstraint() {
+		SignupRequest request = new SignupRequest(
+				"test@example.com",
+				"abc123!@",
+				"abc123!@",
+				"tester",
+				Role.USER
+		);
+		when(userRepository.existsByEmailIgnoreCase("test@example.com")).thenReturn(false);
+		when(passwordEncoder.encode("abc123!@")).thenReturn("encoded");
+		when(userRepository.save(any(User.class))).thenThrow(new DataIntegrityViolationException("duplicate"));
+
+		assertThatThrownBy(() -> userService.signup(request))
+				.isInstanceOf(DuplicateEmailException.class);
+	}
+
+	@Test
+	void signup_savesNormalizedLowercaseEmail() {
+		SignupRequest request = new SignupRequest(
+				"  Test@Example.com  ",
+				"abc123!@",
+				"abc123!@",
+				"tester",
+				Role.USER
+		);
+		when(userRepository.existsByEmailIgnoreCase("test@example.com")).thenReturn(false);
+		when(passwordEncoder.encode("abc123!@")).thenReturn("encoded");
+		when(userRepository.save(any(User.class)))
+				.thenReturn(new User("test@example.com", "encoded", "tester", Role.USER));
+
+		userService.signup(request);
+
+		verify(userRepository).existsByEmailIgnoreCase(eq("test@example.com"));
+		verify(userRepository).save(any(User.class));
+	}
+}

--- a/services/identity-service/web/middleware.ts
+++ b/services/identity-service/web/middleware.ts
@@ -7,7 +7,8 @@ import { NextResponse } from "next/server"
  */
 export function middleware(request: NextRequest) {
   const token = request.cookies.get("access_token")?.value
-  if (token) {
+  const isLoggedIn = request.cookies.get("is_logged_in")?.value === "true"
+  if (token || isLoggedIn) {
     return NextResponse.next()
   }
 

--- a/services/identity-service/web/src/app/api/auth/login/route.ts
+++ b/services/identity-service/web/src/app/api/auth/login/route.ts
@@ -3,6 +3,7 @@ import { loginRequestSchema } from "@/lib/api/identity/login.schema"
 import type { ApiResponse, LoginResponse } from "@/lib/api/identity/types"
 
 const ACCESS_TOKEN_COOKIE = "access_token"
+const LOGGED_IN_COOKIE = "is_logged_in"
 
 function noStoreHeaders() {
   return { "Cache-Control": "no-store" }
@@ -22,6 +23,21 @@ function isSecureCookie(request: Request): boolean {
     return new URL(request.url).protocol === "https:"
   } catch {
     return process.env.NODE_ENV === "production"
+  }
+}
+
+function resolveCookieDomain(request: Request): string | undefined {
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host")
+  if (host) {
+    const hostname = host.split(",")[0]?.trim().split(":")[0]?.toLowerCase()
+    if (hostname === "localhost") return "localhost"
+    return undefined
+  }
+  try {
+    const hostname = new URL(request.url).hostname.toLowerCase()
+    return hostname === "localhost" ? "localhost" : undefined
+  } catch {
+    return undefined
   }
 }
 
@@ -103,6 +119,7 @@ export async function POST(request: Request) {
       message: body.message || "로그인되었습니다",
       data: null,
     })
+    const cookieDomain = resolveCookieDomain(request)
     response.cookies.set({
       name: ACCESS_TOKEN_COOKIE,
       value: body.data.accessToken,
@@ -110,6 +127,17 @@ export async function POST(request: Request) {
       secure: isSecureCookie(request),
       sameSite: "lax",
       path: "/",
+      domain: cookieDomain,
+      maxAge: body.data.expiresInSeconds,
+    })
+    response.cookies.set({
+      name: LOGGED_IN_COOKIE,
+      value: "true",
+      httpOnly: false,
+      secure: isSecureCookie(request),
+      sameSite: "lax",
+      path: "/",
+      domain: cookieDomain,
       maxAge: body.data.expiresInSeconds,
     })
     return response

--- a/services/identity-service/web/src/app/api/auth/logout/route.ts
+++ b/services/identity-service/web/src/app/api/auth/logout/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import type { ApiResponse } from "@/lib/api/identity/types"
 
 const ACCESS_TOKEN_COOKIE = "access_token"
+const LOGGED_IN_COOKIE = "is_logged_in"
 
 function noStoreHeaders() {
   return { "Cache-Control": "no-store" }
@@ -21,6 +22,21 @@ function isSecureCookie(request: Request): boolean {
     return new URL(request.url).protocol === "https:"
   } catch {
     return process.env.NODE_ENV === "production"
+  }
+}
+
+function resolveCookieDomain(request: Request): string | undefined {
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host")
+  if (host) {
+    const hostname = host.split(",")[0]?.trim().split(":")[0]?.toLowerCase()
+    if (hostname === "localhost") return "localhost"
+    return undefined
+  }
+  try {
+    const hostname = new URL(request.url).hostname.toLowerCase()
+    return hostname === "localhost" ? "localhost" : undefined
+  } catch {
+    return undefined
   }
 }
 
@@ -48,6 +64,7 @@ function getCookieValue(cookieHeader: string | null, name: string): string | nul
 }
 
 function clearAccessTokenCookie(request: Request, res: NextResponse) {
+  const cookieDomain = resolveCookieDomain(request)
   res.cookies.set({
     name: ACCESS_TOKEN_COOKIE,
     value: "",
@@ -55,6 +72,18 @@ function clearAccessTokenCookie(request: Request, res: NextResponse) {
     secure: isSecureCookie(request),
     sameSite: "lax",
     path: "/",
+    domain: cookieDomain,
+    maxAge: 0,
+    expires: new Date(0),
+  })
+  res.cookies.set({
+    name: LOGGED_IN_COOKIE,
+    value: "",
+    httpOnly: false,
+    secure: isSecureCookie(request),
+    sameSite: "lax",
+    path: "/",
+    domain: cookieDomain,
     maxAge: 0,
     expires: new Date(0),
   })

--- a/services/team-service/web/src/app/api/auth/logout/route.ts
+++ b/services/team-service/web/src/app/api/auth/logout/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 
 const ACCESS_TOKEN_COOKIE = "access_token"
+const LOGGED_IN_COOKIE = "is_logged_in"
 
 function noStoreHeaders() {
   return { "Cache-Control": "no-store" }
@@ -20,6 +21,21 @@ function isSecureCookie(request: Request): boolean {
     return new URL(request.url).protocol === "https:"
   } catch {
     return process.env.NODE_ENV === "production"
+  }
+}
+
+function resolveCookieDomain(request: Request): string | undefined {
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host")
+  if (host) {
+    const hostname = host.split(",")[0]?.trim().split(":")[0]?.toLowerCase()
+    if (hostname === "localhost") return "localhost"
+    return undefined
+  }
+  try {
+    const hostname = new URL(request.url).hostname.toLowerCase()
+    return hostname === "localhost" ? "localhost" : undefined
+  } catch {
+    return undefined
   }
 }
 
@@ -43,6 +59,7 @@ function getCookieValue(cookieHeader: string | null, name: string): string | nul
 }
 
 function clearAccessTokenCookie(request: Request, res: NextResponse) {
+  const cookieDomain = resolveCookieDomain(request)
   res.cookies.set({
     name: ACCESS_TOKEN_COOKIE,
     value: "",
@@ -50,6 +67,18 @@ function clearAccessTokenCookie(request: Request, res: NextResponse) {
     secure: isSecureCookie(request),
     sameSite: "lax",
     path: "/",
+    domain: cookieDomain,
+    maxAge: 0,
+    expires: new Date(0),
+  })
+  res.cookies.set({
+    name: LOGGED_IN_COOKIE,
+    value: "",
+    httpOnly: false,
+    secure: isSecureCookie(request),
+    sameSite: "lax",
+    path: "/",
+    domain: cookieDomain,
     maxAge: 0,
     expires: new Date(0),
   })

--- a/services/team-service/web/src/app/api/auth/token/switch-team/route.ts
+++ b/services/team-service/web/src/app/api/auth/token/switch-team/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { cookies } from "next/headers"
 
 const ACCESS_TOKEN_COOKIE = "access_token"
+const LOGGED_IN_COOKIE = "is_logged_in"
 
 type ApiResponse<T> = {
   success: boolean
@@ -63,6 +64,21 @@ function isSecureCookie(request: Request): boolean {
     return new URL(request.url).protocol === "https:"
   } catch {
     return process.env.NODE_ENV === "production"
+  }
+}
+
+function resolveCookieDomain(request: Request): string | undefined {
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host")
+  if (host) {
+    const hostname = host.split(",")[0]?.trim().split(":")[0]?.toLowerCase()
+    if (hostname === "localhost") return "localhost"
+    return undefined
+  }
+  try {
+    const hostname = new URL(request.url).hostname.toLowerCase()
+    return hostname === "localhost" ? "localhost" : undefined
+  } catch {
+    return undefined
   }
 }
 
@@ -230,6 +246,7 @@ export async function POST(request: Request) {
     { success: true, message: body.message || "팀 전환이 완료되었습니다", data: null },
     { status: 200, headers: noStoreHeaders() },
   )
+  const cookieDomain = resolveCookieDomain(request)
   response.cookies.set({
     name: ACCESS_TOKEN_COOKIE,
     value: body.data.accessToken,
@@ -237,6 +254,17 @@ export async function POST(request: Request) {
     secure: isSecureCookie(request),
     sameSite: "lax",
     path: "/",
+    domain: cookieDomain,
+    maxAge: body.data.expiresInSeconds,
+  })
+  response.cookies.set({
+    name: LOGGED_IN_COOKIE,
+    value: "true",
+    httpOnly: false,
+    secure: isSecureCookie(request),
+    sameSite: "lax",
+    path: "/",
+    domain: cookieDomain,
     maxAge: body.data.expiresInSeconds,
   })
   return response

--- a/services/team-service/web/src/components/team/team-management-view.tsx
+++ b/services/team-service/web/src/components/team/team-management-view.tsx
@@ -785,7 +785,9 @@ export function TeamManagementView() {
   async function _respondInvitation(invitationId: string, decision: "accept" | "reject") {
     if (invitationActionLoadingId) return
     setInvitationActionLoadingId(invitationId)
-    setMessage(null)
+    if (message?.kind === "error") {
+      setMessage(null)
+    }
     try {
       const { res, body } = await requestApi(
         `/api/team/v1/me/team-invitations/${encodeURIComponent(invitationId)}/${decision}`,
@@ -795,10 +797,6 @@ export function TeamManagementView() {
         setMessage({ kind: "error", text: body?.message ?? "초대 처리에 실패했습니다" })
         return
       }
-      setMessage({
-        kind: "success",
-        text: decision === "accept" ? "팀 초대를 수락했습니다" : "팀 초대를 거절했습니다",
-      })
       await Promise.all([loadMyInvitations(), loadTeams(debouncedKeyword)])
     } catch {
       setMessage({ kind: "error", text: "초대 처리에 실패했습니다" })


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- (연관) 팀 전환 토큰/세션 안정화 이슈

## 작업 내용
- **해당 서비스**: Identity Web(BFF), Team Web(BFF), Usage Web, Billing Web, Identity Web Middleware
- 인증 쿠키 스코프를 서비스별 BFF에서 일관되게 적용했습니다.
- `switch-team` 이후 토큰 갱신 시 쿠키 재설정 로직을 보강했습니다.
- 미들웨어 인증 판별을 `access_token` 단일 체크에서 `access_token || is_logged_in`으로 확장해 리다이렉트 루프를 완화했습니다.

## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- 로그인/팀전환 성공 시
  - `access_token`(httpOnly) 설정 유지
  - `is_logged_in=true`(non-httpOnly) 추가 설정
- 로그아웃 시
  - `access_token`, `is_logged_in` 모두 삭제
- 쿠키 공통 정책 적용
  - `Path=/`, `SameSite=Lax`
  - `secure`는 기존 `x-forwarded-proto`/환경변수 기반 유지
  - 요청 host가 `localhost`일 때만 `Domain=localhost` 적용 (`127.0.0.1`은 미적용)
- 미들웨어 수정
  - `billing-service/web/middleware.ts`
  - `identity-service/web/middleware.ts`
  - 판별: `access_token` 존재 또는 `is_logged_in === "true"`면 통과

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
- 수동 확인:
  - 로그인 후 쿠키 2종(`access_token`, `is_logged_in`) 설정 확인
  - 로그아웃 시 쿠키 삭제 확인
  - 보호 라우트 접근 시 미들웨어 리다이렉트 동작 확인
- 정적 점검:
  - 수정 파일 기준 lint 에러 없음

## 리뷰 요구사항
- `Domain=localhost` 적용이 브라우저 환경별로 문제 없는지(특히 로컬 개발 브라우저 정책) 확인 부탁드립니다.
- 미들웨어에서 `is_logged_in` 허용 범위를 현재 정책대로 유지할지(임시 완화 vs 장기 유지) 의견 부탁드립니다.