### PR TITLE
Fix/provider

### DIFF
--- a/docs/contracts/web-team-bff.md
+++ b/docs/contracts/web-team-bff.md
@@ -137,7 +137,7 @@
 | 필드 | 설명 |
 |---|---|
 | `id` | 키 행 ID |
-| `provider` | `OPENAI` / `GEMINI` / `CLAUDE` |
+| `provider` | `OPENAI` / `GOOGLE` / `CLAUDE` |
 | `alias` | 별칭 |
 | `monthlyBudgetUsd` | 월 예산(USD), 숫자 |
 | `createdAt` | 생성 시각(ISO-8601) |
@@ -146,7 +146,7 @@
 | `deletionGraceDays` | 삭제 요청 시 선택한 유예 기간(일). 생략 시 서버 기본은 7일. 삭제 예정이 아니면 생략. |
 
 - `POST /api/team/v1/teams/{id}/api-keys`
-  - 요청 본문: `provider` (`OPENAI`/`GEMINI`/`CLAUDE`), `alias`, `externalKey`, `monthlyBudgetUsd` (0 이상, USD 월 예산 한도 — identity-service 외부 키와 동일 개념)
+  - 요청 본문: `provider` (`OPENAI`/`GOOGLE`/`CLAUDE`), `alias`, `externalKey`, `monthlyBudgetUsd` (0 이상, USD 월 예산 한도 — identity-service 외부 키와 동일 개념)
   - 성공: `201`, `data`에 등록된 키 요약(위 표의 활성 키에 해당하는 필드)
   - 실패:
     - `400` (`success=false`): 필수값 누락, alias 중복, 동일 provider+키 값(해시)이 **이미 활성**인 경우 `이미 등록된 API Key입니다`, 동일 해시가 **삭제 예정** 행에 있으면 `삭제 예정키와 중복입니다`

--- a/packages/shell/src/console-nav.ts
+++ b/packages/shell/src/console-nav.ts
@@ -125,7 +125,7 @@ export function ownsNavItemForSpaLink(profile: ConsoleProfile, id: ConsoleNavId)
     case "notification":
       return id === "notifications"
     case "team":
-      return false
+      return id === "teams"
     case "agent":
       return id === "assistant"
     default: {
@@ -151,7 +151,8 @@ function spaInternalHref(profile: ConsoleProfile, id: ConsoleNavId): string {
     case "agent":
       return "/"
     case "team":
-      throw new Error("resolveConsoleNavLink: team profile has no SPA main-nav targets")
+      if (id === "teams") return "/"
+      throw new Error(`resolveConsoleNavLink: unexpected team SPA id ${id}`)
     default: {
       const _exhaustive: never = profile
       throw new Error(`Unexpected profile: ${_exhaustive}`)
@@ -174,6 +175,9 @@ export function resolveConsoleNavLink(profile: ConsoleProfile, id: ConsoleNavId)
    * identity 등 타 오리진에서 상대 `/teams`로 잘못 이탈하는 것을 막는다(Task37-13).
    */
   if (id === "teams") {
+    if (ownsNavItemForSpaLink(profile, id)) {
+      return { kind: "next", href: spaInternalHref(profile, id) }
+    }
     return { kind: "anchor", href: resolveTeamShellEntryHref() }
   }
 
@@ -287,7 +291,7 @@ export function isConsoleNavActive(profile: ConsoleProfile, pathname: string, id
   }
 
   if (profile === "team") {
-    if (id === "teams") return p === "/teams" || p.startsWith("/teams?") || p.startsWith("/teams/")
+    if (id === "teams") return p === "/" || p === "/teams" || p.startsWith("/teams?") || p.startsWith("/teams/")
     if (id === "assistant") return p === "/agent" || p.startsWith("/agent/")
     return false
   }

--- a/packages/shell/src/console-sidebar.tsx
+++ b/packages/shell/src/console-sidebar.tsx
@@ -241,7 +241,7 @@ export function ConsoleSidebarInner({
   }
 
   return (
-    <aside className="flex h-full min-h-0 w-64 min-w-[240px] max-w-[280px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
+    <aside className="sticky top-0 flex h-screen min-h-0 w-64 min-w-[240px] max-w-[280px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
       <div className="border-b border-sidebar-border px-4 py-4">
         <p className="text-xs font-medium uppercase tracking-wide text-sidebar-foreground/60">콘솔</p>
         <p className="mt-1 text-sm font-semibold leading-tight tracking-tight text-sidebar-foreground">

--- a/services/agent-service/web/src/app/(shell)/page.tsx
+++ b/services/agent-service/web/src/app/(shell)/page.tsx
@@ -459,48 +459,8 @@ export default function AgentPage() {
               setLoadingMessage,
             })
 
-      setResults((prev: AnalysisResult[]) => {
-        const byKeyId = new Map<number, AnalysisResult>()
-        for (const item of prev) {
-          byKeyId.set(item.keyId, item)
-        }
-        for (const item of nextResults) {
-          const current = byKeyId.get(item.keyId)
-          if (!current) {
-            byKeyId.set(item.keyId, item)
-            continue
-          }
-          const mergedData = item.data ?? current.data
-          const mergedRecommendation =
-            action === "ANALYSIS"
-              ? undefined
-              : item.recommendation !== undefined
-                ? item.recommendation
-                : current.recommendation
-          const mergedRecommendationError =
-            action === "ANALYSIS"
-              ? undefined
-              : item.recommendationError !== undefined
-                ? item.recommendationError
-                : current.recommendationError
-          const mergedAnalysisError =
-            action === "ANALYSIS"
-              ? item.error !== undefined
-                ? item.error
-                : undefined
-              : current.error
-          byKeyId.set(item.keyId, {
-            ...current,
-            ...item,
-            data: mergedData,
-            recommendation: mergedRecommendation,
-            forecastGaps: item.forecastGaps ?? current.forecastGaps,
-            error: mergedAnalysisError,
-            recommendationError: mergedRecommendationError,
-          })
-        }
-        return Array.from(byKeyId.values())
-      })
+      // 버튼을 누를 때마다 해당 요청 결과만 화면에 표시한다 (이전 결과는 보관하지 않음).
+      setResults(nextResults)
     } finally {
       setLoadingAction(null)
       setLoadingMessage("")

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/bootstrap/ExternalApiKeyProviderMigrationInitializer.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/bootstrap/ExternalApiKeyProviderMigrationInitializer.java
@@ -39,7 +39,7 @@ public class ExternalApiKeyProviderMigrationInitializer {
 				"""
 				update external_api_keys
 				set provider = 'GOOGLE'
-				where provider = 'GEMINI'
+				where cast(provider as varchar) = 'GEMINI'
 				"""
 		);
 		log.info("external_api_keys provider migration completed updatedRows={}", updated);

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/bootstrap/ExternalApiKeyProviderMigrationInitializer.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/bootstrap/ExternalApiKeyProviderMigrationInitializer.java
@@ -1,0 +1,47 @@
+package com.zerobugfreinds.identity_service.bootstrap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 외부 API 키 provider 레거시 값(GEMINI)을 GOOGLE로 통일한다.
+ */
+@Component
+public class ExternalApiKeyProviderMigrationInitializer {
+	private static final Logger log = LoggerFactory.getLogger(ExternalApiKeyProviderMigrationInitializer.class);
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public ExternalApiKeyProviderMigrationInitializer(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void migrateGeminiProviderToGoogle() {
+		Integer tableCount = jdbcTemplate.queryForObject(
+				"""
+				select count(*)
+				from information_schema.tables
+				where upper(table_name) = 'EXTERNAL_API_KEYS'
+				""",
+				Integer.class
+		);
+		if (tableCount == null || tableCount == 0) {
+			log.info("external_api_keys table not found; skip provider migration");
+			return;
+		}
+
+		int updated = jdbcTemplate.update(
+				"""
+				update external_api_keys
+				set provider = 'GOOGLE'
+				where provider = 'GEMINI'
+				"""
+		);
+		log.info("external_api_keys provider migration completed updatedRows={}", updated);
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/ExternalApiKeyController.java
@@ -1,6 +1,7 @@
 package com.zerobugfreinds.identity_service.controller;
 
 import com.zerobugfreinds.identity_service.common.ApiResponse;
+import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
 import com.zerobugfreinds.identity_service.dto.ExternalApiKeyRegisterRequest;
 import com.zerobugfreinds.identity_service.dto.ExternalApiKeyRegisterResponse;
 import com.zerobugfreinds.identity_service.dto.ExternalApiKeyUpdateRequest;
@@ -119,7 +120,7 @@ public class ExternalApiKeyController {
 	private static ExternalApiKeyRegisterResponse toResponse(ExternalApiKeyEntity key) {
 		return new ExternalApiKeyRegisterResponse(
 				key.getId(),
-				key.getProvider().name(),
+				normalizeProviderName(key.getProvider()),
 				key.getKeyAlias(),
 				key.getCreatedAt(),
 				key.getMonthlyBudgetUsd(),
@@ -127,5 +128,9 @@ public class ExternalApiKeyController {
 				key.getPermanentDeletionAt(),
 				key.getDeletionGraceDays()
 		);
+	}
+
+	private static String normalizeProviderName(ExternalApiKeyProvider provider) {
+		return provider.name();
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
@@ -130,7 +130,7 @@ public class GlobalExceptionHandler {
 	public ApiResponse<Void> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
 		String detail = ex.getMostSpecificCause().getMessage();
 		if (detail != null && detail.contains("ExternalApiKeyProvider")) {
-			return ApiResponse.fail("provider 값이 올바르지 않습니다. 허용: GEMINI, OPENAI, ANTHROPIC");
+			return ApiResponse.fail("provider 값이 올바르지 않습니다. 허용: GOOGLE, OPENAI, ANTHROPIC");
 		}
 		return ApiResponse.fail("요청 본문 형식이 올바르지 않습니다");
 	}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/domain/ExternalApiKeyProvider.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/domain/ExternalApiKeyProvider.java
@@ -20,7 +20,7 @@ public enum ExternalApiKeyProvider {
 		return switch (normalized) {
 			case "openai" -> OPENAI;
 			case "anthropic" -> ANTHROPIC;
-			case "google", "gemini" -> GOOGLE;
+			case "google" -> GOOGLE;
 			case "meta" -> META;
 			case "mistral" -> MISTRAL;
 			case "cohere" -> COHERE;

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/domain/ExternalApiKeyProvider.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/domain/ExternalApiKeyProvider.java
@@ -4,7 +4,6 @@ package com.zerobugfreinds.identity_service.domain;
  * 사용자가 등록하는 외부 AI API 제공자.
  */
 public enum ExternalApiKeyProvider {
-	GEMINI,
 	GOOGLE,
 	OPENAI,
 	ANTHROPIC,
@@ -21,8 +20,7 @@ public enum ExternalApiKeyProvider {
 		return switch (normalized) {
 			case "openai" -> OPENAI;
 			case "anthropic" -> ANTHROPIC;
-			case "google" -> GOOGLE;
-			case "gemini" -> GEMINI;
+			case "google", "gemini" -> GOOGLE;
 			case "meta" -> META;
 			case "mistral" -> MISTRAL;
 			case "cohere" -> COHERE;

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
@@ -72,6 +72,7 @@ public class ExternalApiKeyService {
 		if (provider == null) {
 			throw new IllegalArgumentException("provider는 필수입니다");
 		}
+		ExternalApiKeyProvider normalizedProvider = normalizeProvider(provider);
 		String trimmedAlias = StringUtils.hasText(alias) ? alias.trim() : "";
 		if (!StringUtils.hasText(trimmedAlias)) {
 			throw new IllegalArgumentException("alias는 필수입니다");
@@ -88,9 +89,9 @@ public class ExternalApiKeyService {
 			throw new DuplicateExternalApiKeyAliasException("이미 사용 중인 별칭입니다");
 		}
 
-		String keyHash = encryptionUtil.sha256HexForUniqueness(provider.name(), normalizedKey);
+		String keyHash = encryptionUtil.sha256HexForUniqueness(normalizedProvider.name(), normalizedKey);
 		Optional<ExternalApiKeyEntity> existingSameHash =
-				externalApiKeyRepository.findByUserIdAndProviderAndKeyHash(userId, provider, keyHash);
+				externalApiKeyRepository.findByUserIdAndProviderAndKeyHash(userId, normalizedProvider, keyHash);
 		if (existingSameHash.isPresent()) {
 			if (existingSameHash.get().isPendingDeletion()) {
 				throw new DuplicateExternalApiKeyException("삭제예정키와 중복된 키");
@@ -98,7 +99,7 @@ public class ExternalApiKeyService {
 			log.warn(
 					"[AUDIT] external_api_key_duplicate_detected userId={} provider={} alias={} hashPrefix={}",
 					userId,
-					provider.name(),
+					normalizedProvider.name(),
 					trimmedAlias,
 					keyHash.substring(0, 8)
 			);
@@ -108,7 +109,7 @@ public class ExternalApiKeyService {
 		String encrypted = encryptionUtil.encryptAes256Gcm(normalizedKey);
 		ExternalApiKeyEntity entity = ExternalApiKeyEntity.register(
 				userId,
-				provider,
+				normalizedProvider,
 				trimmedAlias,
 				keyHash,
 				encrypted,
@@ -119,7 +120,7 @@ public class ExternalApiKeyService {
 		log.info(
 				"[AUDIT] external_api_key_registered userId={} provider={} alias={} keyId={}",
 				userId,
-				provider.name(),
+				normalizedProvider.name(),
 				trimmedAlias,
 				saved.getId()
 		);
@@ -184,9 +185,10 @@ public class ExternalApiKeyService {
 			if (provider == null) {
 				throw new IllegalArgumentException("externalKey를 수정할 때 provider는 필수입니다");
 			}
-			String keyHash = encryptionUtil.sha256HexForUniqueness(provider.name(), normalizedKey);
+			ExternalApiKeyProvider normalizedProvider = normalizeProvider(provider);
+			String keyHash = encryptionUtil.sha256HexForUniqueness(normalizedProvider.name(), normalizedKey);
 			Optional<ExternalApiKeyEntity> otherSameHash =
-					externalApiKeyRepository.findByUserIdAndProviderAndKeyHash(userId, provider, keyHash);
+					externalApiKeyRepository.findByUserIdAndProviderAndKeyHash(userId, normalizedProvider, keyHash);
 			if (otherSameHash.isPresent() && !otherSameHash.get().getId().equals(externalKeyId)) {
 				if (otherSameHash.get().isPendingDeletion()) {
 					throw new DuplicateExternalApiKeyException("삭제예정키와 중복된 키");
@@ -195,7 +197,7 @@ public class ExternalApiKeyService {
 			}
 
 			String encrypted = encryptionUtil.encryptAes256Gcm(normalizedKey);
-			entity.updateCredential(provider, trimmedAlias, keyHash, encrypted, monthlyBudgetUsd);
+			entity.updateCredential(normalizedProvider, trimmedAlias, keyHash, encrypted, monthlyBudgetUsd);
 		} else {
 			entity.updateAliasAndBudget(trimmedAlias, monthlyBudgetUsd);
 		}
@@ -203,7 +205,7 @@ public class ExternalApiKeyService {
 		log.info(
 				"[AUDIT] external_api_key_updated userId={} provider={} alias={} keyId={}",
 				userId,
-				entity.getProvider().name(),
+				providerName(entity.getProvider()),
 				trimmedAlias,
 				entity.getId()
 		);
@@ -221,8 +223,9 @@ public class ExternalApiKeyService {
 		if (provider == null) {
 			throw new IllegalArgumentException("provider는 필수입니다");
 		}
+		ExternalApiKeyProvider normalizedProvider = normalizeProvider(provider);
 		ExternalApiKeyEntity entity = externalApiKeyRepository
-				.findTopByUserIdAndProviderAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(userId, provider)
+				.findTopByUserIdAndProviderAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(userId, normalizedProvider)
 				.orElseThrow(() -> new ExternalApiKeyNotFoundException("등록된 API 키를 찾을 수 없습니다"));
 		String plainKey = encryptionUtil.decryptAes256Gcm(entity.getEncryptedKey());
 		return new InternalApiKeyResponse(plainKey, String.valueOf(entity.getId()));
@@ -276,7 +279,7 @@ public class ExternalApiKeyService {
 			monthlyBudgetsByKey.add(
 					new UserMonthlyBudgetByKey(
 							key.getId(),
-							key.getProvider().name(),
+							providerName(key.getProvider()),
 							key.getKeyAlias(),
 							budget
 					)
@@ -363,7 +366,7 @@ public class ExternalApiKeyService {
 					"[AUDIT] external_api_key_purged userId={} keyId={} provider={}",
 					e.getUserId(),
 					e.getId(),
-					e.getProvider().name()
+					providerName(e.getProvider())
 			);
 			publishExternalApiKeyDeleted(e, e.isRetainUsageLogs());
 		}
@@ -376,7 +379,7 @@ public class ExternalApiKeyService {
 				entity.getId(),
 				entity.getKeyAlias(),
 				entity.getUserId(),
-				entity.getProvider().name(),
+				providerName(entity.getProvider()),
 				status
 		);
 		applicationEventPublisher.publishEvent(event);
@@ -388,7 +391,7 @@ public class ExternalApiKeyService {
 				entity.getId(),
 				Instant.now(),
 				retainLogs,
-				entity.getProvider().name(),
+				providerName(entity.getProvider()),
 				entity.getKeyAlias()
 		);
 		applicationEventPublisher.publishEvent(event);
@@ -399,11 +402,19 @@ public class ExternalApiKeyService {
 				entity.getId(),
 				entity.getKeyAlias(),
 				entity.getUserId(),
-				entity.getProvider().name(),
+				providerName(entity.getProvider()),
 				status,
 				entity.getMonthlyBudgetUsd()
 		);
 		applicationEventPublisher.publishEvent(event);
+	}
+
+	private static ExternalApiKeyProvider normalizeProvider(ExternalApiKeyProvider provider) {
+		return provider;
+	}
+
+	private static String providerName(ExternalApiKeyProvider provider) {
+		return normalizeProvider(provider).name();
 	}
 
 	private static int resolveGracePeriodDays(Integer requested) {

--- a/services/identity-service/web/src/app/api/auth/external-keys/route.ts
+++ b/services/identity-service/web/src/app/api/auth/external-keys/route.ts
@@ -52,8 +52,8 @@ async function resolveAccessToken(request: Request): Promise<string | null> {
 }
 
 const createExternalKeyRequestSchema = z.object({
-  provider: z.enum(["GEMINI", "OPENAI", "ANTHROPIC"], {
-    message: "provider는 GEMINI/OPENAI/ANTHROPIC 중 하나여야 합니다",
+  provider: z.enum(["GOOGLE", "OPENAI", "ANTHROPIC"], {
+    message: "provider는 GOOGLE/OPENAI/ANTHROPIC 중 하나여야 합니다",
   }),
   externalKey: z
     .string({ message: "externalKey는 문자열이어야 합니다" })
@@ -86,7 +86,7 @@ function isExternalKeySummary(data: unknown): boolean {
   return (
     typeof o.id === "number" &&
     typeof o.provider === "string" &&
-    (o.provider === "GEMINI" || o.provider === "OPENAI" || o.provider === "ANTHROPIC") &&
+    (o.provider === "GOOGLE" || o.provider === "OPENAI" || o.provider === "ANTHROPIC") &&
     typeof o.alias === "string" &&
     typeof o.createdAt === "string" &&
     optionalBudget(o.monthlyBudgetUsd) &&

--- a/services/identity-service/web/src/components/account/account-settings-view.tsx
+++ b/services/identity-service/web/src/components/account/account-settings-view.tsx
@@ -24,7 +24,7 @@ function asApiResponse(json: unknown): ApiResponse<unknown> | null {
 
 function providerLabel(provider: ExternalKeyProvider) {
   if (provider === "OPENAI") return "OpenAI"
-  if (provider === "GEMINI") return "Gemini"
+  if (provider === "GOOGLE") return "Google"
   return "Anthropic"
 }
 
@@ -735,7 +735,7 @@ export function AccountSettingsView({ pathSegments }: { pathSegments?: string[] 
               onChange={(e) => setProvider(e.target.value as ExternalKeyProvider)}
               disabled={submitLoading}
             >
-              <option value="GEMINI">GEMINI</option>
+              <option value="GOOGLE">GOOGLE</option>
               <option value="OPENAI">OPENAI</option>
               <option value="ANTHROPIC">ANTHROPIC</option>
             </select>

--- a/services/identity-service/web/src/lib/api/identity/external-keys.schema.test.ts
+++ b/services/identity-service/web/src/lib/api/identity/external-keys.schema.test.ts
@@ -16,9 +16,9 @@ describe("createExternalKeyRequestSchema", () => {
 
   it("rejects empty externalKey", () => {
     const parsed = createExternalKeyRequestSchema.safeParse({
-      provider: "GEMINI",
+      provider: "GOOGLE",
       externalKey: "   ",
-      alias: "Gemini 키 1",
+      alias: "Google 키 1",
       monthlyBudgetUsd: 10,
     })
 

--- a/services/identity-service/web/src/lib/api/identity/external-keys.schema.ts
+++ b/services/identity-service/web/src/lib/api/identity/external-keys.schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 
-export const externalKeyProviderSchema = z.enum(["GEMINI", "OPENAI", "ANTHROPIC"], {
-  message: "provider는 GEMINI/OPENAI/ANTHROPIC 중 하나여야 합니다",
+export const externalKeyProviderSchema = z.enum(["GOOGLE", "OPENAI", "ANTHROPIC"], {
+  message: "provider는 GOOGLE/OPENAI/ANTHROPIC 중 하나여야 합니다",
 })
 
 export const createExternalKeyRequestSchema = z.object({

--- a/services/identity-service/web/src/lib/api/identity/types.ts
+++ b/services/identity-service/web/src/lib/api/identity/types.ts
@@ -32,7 +32,7 @@ export type LoginResponse = {
   expiresInSeconds: number
 }
 
-export type ExternalKeyProvider = "GEMINI" | "OPENAI" | "ANTHROPIC"
+export type ExternalKeyProvider = "GOOGLE" | "OPENAI" | "ANTHROPIC"
 
 export type CreateExternalKeyRequest = {
   provider: ExternalKeyProvider

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/bootstrap/TeamApiKeyProviderMigrationInitializer.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/bootstrap/TeamApiKeyProviderMigrationInitializer.java
@@ -1,0 +1,47 @@
+package com.zerobugfreinds.team_service.bootstrap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 팀 API 키 provider 레거시 값(GEMINI)을 GOOGLE로 통일한다.
+ */
+@Component
+public class TeamApiKeyProviderMigrationInitializer {
+    private static final Logger log = LoggerFactory.getLogger(TeamApiKeyProviderMigrationInitializer.class);
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public TeamApiKeyProviderMigrationInitializer(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void migrateGeminiProviderToGoogle() {
+        Integer tableCount = jdbcTemplate.queryForObject(
+                """
+                select count(*)
+                from information_schema.tables
+                where upper(table_name) = 'TEAM_API_KEYS'
+                """,
+                Integer.class
+        );
+        if (tableCount == null || tableCount == 0) {
+            log.info("team_api_keys table not found; skip provider migration");
+            return;
+        }
+
+        int updated = jdbcTemplate.update(
+                """
+                update team_api_keys
+                set provider = 'GOOGLE'
+                where provider = 'GEMINI'
+                """
+        );
+        log.info("team_api_keys provider migration completed updatedRows={}", updated);
+    }
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/config/SecurityConfig.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
 						.requestMatchers("/internal/api-keys/**").permitAll()
 						.requestMatchers("/internal/teams/**").permitAll()
 						.requestMatchers("/internal/v1/teams/**").permitAll()
+						.requestMatchers("/internal/v1/users/**").permitAll()
 						.requestMatchers("/internal/v1/team-invitations/**").permitAll()
 						.requestMatchers("/internal/admin/**").permitAll()
 						.requestMatchers("/error").permitAll()

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/InternalTeamController.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/InternalTeamController.java
@@ -6,6 +6,7 @@ import com.zerobugfreinds.team_service.dto.InternalTeamInvitationDecisionRequest
 import com.zerobugfreinds.team_service.dto.InternalTeamMembershipVerifyResponse;
 import com.zerobugfreinds.team_service.dto.InternalTeamDetailResponse;
 import com.zerobugfreinds.team_service.dto.TeamInvitationActionResponse;
+import com.zerobugfreinds.team_service.dto.TeamSummaryResponse;
 import com.zerobugfreinds.team_service.service.TeamService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -55,6 +56,14 @@ public class InternalTeamController {
 	) {
 		InternalTeamMembershipVerifyResponse response = teamService.verifyTeamMembershipInternal(teamId, userId);
 		return ResponseEntity.ok(ApiResponse.ok("팀 멤버십 검증에 성공했습니다", response));
+	}
+
+	@GetMapping("/v1/users/{userId}/teams")
+	public ResponseEntity<ApiResponse<List<TeamSummaryResponse>>> getUserTeams(
+			@PathVariable("userId") String userId
+	) {
+		List<TeamSummaryResponse> teams = teamService.getUserTeamsInternal(userId);
+		return ResponseEntity.ok(ApiResponse.ok("사용자 팀 목록 조회에 성공했습니다", teams));
 	}
 
 	@PostMapping("/v1/team-invitations/{invitationId}/decision")

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/domain/TeamApiKeyProvider.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/domain/TeamApiKeyProvider.java
@@ -7,7 +7,6 @@ public enum TeamApiKeyProvider {
     META,
     MISTRAL,
     COHERE,
-    GEMINI,
     CLAUDE,
     GROK
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamService.java
@@ -199,6 +199,11 @@ public class TeamService {
 	}
 
 	@Transactional(readOnly = true)
+	public List<TeamSummaryResponse> getUserTeamsInternal(String userId) {
+		return getMyTeams(userId);
+	}
+
+	@Transactional(readOnly = true)
 	public List<InternalBillingTeamSummaryResponse> getBillingTeamSummariesInternal(String userId) {
 		if (!StringUtils.hasText(userId)) {
 			throw new IllegalArgumentException("userId는 필수입니다");

--- a/services/team-service/web/src/components/team/team-management-view.tsx
+++ b/services/team-service/web/src/components/team/team-management-view.tsx
@@ -1,4 +1,4 @@
-﻿"use client"
+"use client"
 
 import * as React from "react"
 import { ChevronRight, Minus, Plus, Search } from "lucide-react"
@@ -1049,7 +1049,7 @@ export function TeamManagementView() {
             ) : null}
           </div>
 
-          <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden p-3">
+          <div className="min-h-0 min-w-0 flex-1 p-3">
             {message ? (
               <div
                 className={`mb-3 rounded-md border px-3 py-2 text-xs ${

--- a/services/team-service/web/src/components/team/team-management-view.tsx
+++ b/services/team-service/web/src/components/team/team-management-view.tsx
@@ -31,7 +31,7 @@ type TeamSummaryLike = {
   createdAt?: string
 }
 
-type ExternalKeyProvider = "GEMINI" | "OPENAI" | "ANTHROPIC"
+type ExternalKeyProvider = "GOOGLE" | "OPENAI" | "ANTHROPIC"
 
 type TeamApiKeySummary = {
   id: number
@@ -126,7 +126,7 @@ function parseTeamApiKeyDeletionGraceInput(raw: string):
 }
 
 const TEAM_WEB_BASE_PATH = "/teams"
-const EXTERNAL_KEY_PROVIDER_OPTIONS: ExternalKeyProvider[] = ["GEMINI", "OPENAI", "ANTHROPIC"]
+const EXTERNAL_KEY_PROVIDER_OPTIONS: ExternalKeyProvider[] = ["GOOGLE", "OPENAI", "ANTHROPIC"]
 const DISMISSED_EXPIRED_INVITATION_STORAGE_KEY = "team.dismissedExpiredInvitationNoticeIds"
 
 type InviteeFieldRow = { id: string; value: string }
@@ -944,8 +944,8 @@ export function TeamManagementView() {
           </div>
         </div>
       ) : null}
-      <aside className="h-full w-full min-w-0 max-w-full shrink-0 border-r border-border bg-muted/20">
-        <div className="flex h-full min-h-0 min-w-0 flex-col">
+      <aside className="w-full min-w-0 max-w-full shrink-0 border-r border-border bg-muted/20">
+        <div className="flex min-w-0 flex-col">
           <div className="sticky top-0 z-10 border-b border-border bg-muted/20 px-4 py-4 backdrop-blur-sm">
             <div className="flex items-center justify-between gap-2">
               <h2 className="text-base font-semibold text-foreground">팀 목록</h2>
@@ -1049,7 +1049,7 @@ export function TeamManagementView() {
             ) : null}
           </div>
 
-          <div className="min-h-0 min-w-0 flex-1 p-3">
+          <div className="min-w-0 p-3">
             {message ? (
               <div
                 className={`mb-3 rounded-md border px-3 py-2 text-xs ${


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #없음 (또는 연결할 이슈 번호로 교체)

## 작업 내용
- **해당 서비스**: Identity / Team / Agent Web / Shell
- External API Key provider 기본값을 `google`로 정리하고, 기존 데이터에 대한 provider 마이그레이션 초기화 로직을 추가했습니다.
- Team/Agent 웹 화면에서 팀/개인 분리, 네비게이션/사이드바 동작, 스크롤 UX를 수정했습니다.
- 내부 API 및 예외 처리/스키마 테스트를 함께 보완해 CI 이슈를 해결했습니다.

## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- Identity
  - `ExternalApiKeyProviderMigrationInitializer` 추가로 기존 키 provider 데이터 보정.
  - `ExternalApiKeyService`, `ExternalApiKeyController`, `GlobalExceptionHandler` 수정.
  - 웹 API 라우트/타입/스키마 테스트(`external-keys.schema.test.ts`) 동기화.
- Team
  - `TeamApiKeyProviderMigrationInitializer` 추가.
  - `InternalTeamController` 내부 조회 API 보강 및 `SecurityConfig` 허용 경로 업데이트.
  - `TeamService` 이벤트 발행 흐름 보완.
- Frontend (Shell/Agent/Team Web)
  - `console-nav.ts`, `console-sidebar.tsx` 네비/레이아웃 개선.
  - Agent shell 페이지 팀/개인 화면 분리 및 팀 화면 UX 수정.
  - Team 관리 화면 일부 UI/동작 정리.
- 문서
  - `docs/contracts/web-team-bff.md` 계약 문서 동기화.

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [x] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부  
  (스키마 변경은 없고, 기존 데이터 보정용 마이그레이션 초기화 로직 추가)

## 📸 스크린샷 / 테스트 결과 (선택)
- CI 통과 (identity 관련 테스트/스키마 검증 포함)
- 필요 시 팀/개인 화면 분리 전후 캡처 첨부 예정

## 리뷰 요구사항
- provider 마이그레이션 초기화 로직이 운영 데이터에서도 안전하게 동작하는지 확인 부탁드립니다.
- Team 이벤트 발행 시점(`TeamService`)이 기존 소비자와 계약상 문제 없는지 중점 리뷰 부탁드립니다.
- Shell/Agent 웹 네비 변경이 기존 라우팅 및 접근 권한 흐름에 영향 없는지 확인 부탁드립니다.