### PR TITLE
Feature/provider proxy service

### DIFF
--- a/docs/billing-identity-budget.md
+++ b/docs/billing-identity-budget.md
@@ -35,7 +35,7 @@ Identity 예산 API 응답은 아래 필드를 포함한다.
     },
     {
       "externalApiKeyId": 102,
-      "provider": "GEMINI",
+      "provider": "GOOGLE",
       "alias": "개인키-2",
       "monthlyBudgetUsd": 25.0
     }
@@ -51,7 +51,7 @@ Identity 예산 API 응답은 아래 필드를 포함한다.
 - **예산 임계 AMQP** (`billing.budget.threshold.reached`): 이벤트 한 건마다 `IdentityBudgetClient.fetchMonthlyBudgetKeyRow(userId, provider, apiKeyId)`로 **해당 키 한 줄**만 고르고,
   - 월 예산(`monthlyBudgetUsd`) 뿐 아니라 표시용 별칭(`alias`)도 함께 활용해 이벤트 페이로드의 `apiKeyAlias`로 전달할 수 있다.
   - `UsageRecordedEvent.apiKeyId`는 Identity의 **`externalApiKeyId`와 동일한 숫자**로 파싱 가능해야 한다(문자열이어도 내용이 long이어야 매칭).
-  - **프로바이더 이름**: billing `AiProvider`는 `OPENAI` / `ANTHROPIC` / `GOOGLE` 이고, Identity JSON의 `provider`는 **`GEMINI`**(Google) / `OPENAI` / `ANTHROPIC` 형태이므로, 클라이언트는 **`GOOGLE` 사용 이벤트 ↔ Identity 행 `GEMINI`** 로 맞춘다.
+  - **프로바이더 이름**: billing `AiProvider`와 Identity JSON의 `provider`는 `OPENAI` / `ANTHROPIC` / `GOOGLE`를 사용한다. 레거시 `GEMINI` 데이터가 남아 있으면 내부에서 `GOOGLE`로 호환 매핑한다.
   - 위 매칭 행이 없거나 예산이 0 이하면 해당 사용 이벤트에 대해 **임계 이벤트를 발행하지 않는다**.
 
 ## MSA 원칙

--- a/docs/contracts/gateway-proxy.md
+++ b/docs/contracts/gateway-proxy.md
@@ -37,6 +37,7 @@
 - **Base path:** `/api/v1/ai`
 - **패턴:** `/api/v1/ai/{provider}/**`
 - `{provider}`: `openai` | `anthropic` | `google` ([AiProvider](../../libs/usage-events/src/main/java/com/eevee/usage/events/AiProvider.java)와 동일)
+- 공개 계약의 canonical provider 표기는 `google`만 사용한다. 레거시 `gemini` 저장/조회 호환은 내부 구현에서만 처리하며 외부 경로/응답에는 노출하지 않는다.
 
 **예:** `POST /api/v1/ai/openai/v1/chat/completions`
 
@@ -219,12 +220,7 @@ Usage는 MQ로 적재 후 HTTP 조회를 제공한다(컨트롤러: `UsageAnalyt
 | Proxy | 8081 |
 | Identity `web`(호스트 매핑, Compose) | 3000 (`IDENTITY_WEB_PORT`) |
 | Usage `web`(호스트 매핑, Compose) | 3001 (`USAGE_WEB_PORT`) |
-<<<<<<< HEAD
 | Team `web` (호스트 매핑, Compose) | 3002 (`TEAM_WEB_PORT`) |
-=======
-| Team BFF `team-web`(호스트 매핑, Compose) | 3012 (`TEAM_WEB_PORT`) |
-| Main Shell `web-host`(호스트 매핑, Compose) | 3002 (`WEB_HOST_PORT`) |
->>>>>>> origin/develop
 | Billing `web`(호스트 매핑, Compose) | 3003 (`BILLING_WEB_PORT`) |
 | **team-service**(Spring, 호스트 `bootRun` 예시) | `TEAM_SERVICE_PORT` 기본 8093; `scripts/bootrun.ps1`은 **8094** 권장(Compose 호스트 매핑과 충돌 방지 — [`architecture.md`](../architecture.md) §3.3) |
 | **billing-service**(Spring) | `BILLING_SERVICE_PORT` 기본 **8095**; API Gateway **`GATEWAY_BILLING_URI`** 와 맞출 것 |

--- a/docs/contracts/proxy-team-key-internal-api.md
+++ b/docs/contracts/proxy-team-key-internal-api.md
@@ -25,11 +25,14 @@ resolving **team-scoped** provider keys.
 - `openai`
 - `anthropic`
 - `google`
-- `gemini` (alias for Google-compatible key registrations)
+
+Legacy compatibility alias (internal-only):
+
+- `gemini` -> `google`
 
 ### Provider normalization
 
-- `gemini` is normalized to `google` in `team-service`.
+- `gemini` is normalized to `google` in `team-service` for backward compatibility.
 - Unknown provider values must return `400`.
 
 ## Response (200)

--- a/docs/contracts/web-team-bff.md
+++ b/docs/contracts/web-team-bff.md
@@ -137,7 +137,7 @@
 | 필드 | 설명 |
 |---|---|
 | `id` | 키 행 ID |
-| `provider` | `OPENAI` / `GEMINI` / `CLAUDE` |
+| `provider` | `OPENAI` / `GOOGLE` / `ANTHROPIC` |
 | `alias` | 별칭 |
 | `monthlyBudgetUsd` | 월 예산(USD), 숫자 |
 | `createdAt` | 생성 시각(ISO-8601) |
@@ -146,7 +146,7 @@
 | `deletionGraceDays` | 삭제 요청 시 선택한 유예 기간(일). 생략 시 서버 기본은 7일. 삭제 예정이 아니면 생략. |
 
 - `POST /api/team/v1/teams/{id}/api-keys`
-  - 요청 본문: `provider` (`OPENAI`/`GEMINI`/`CLAUDE`), `alias`, `externalKey`, `monthlyBudgetUsd` (0 이상, USD 월 예산 한도 — identity-service 외부 키와 동일 개념)
+  - 요청 본문: `provider` (`OPENAI`/`GOOGLE`/`ANTHROPIC`), `alias`, `externalKey`, `monthlyBudgetUsd` (0 이상, USD 월 예산 한도 — identity-service 외부 키와 동일 개념)
   - 성공: `201`, `data`에 등록된 키 요약(위 표의 활성 키에 해당하는 필드)
   - 실패:
     - `400` (`success=false`): 필수값 누락, alias 중복, 동일 provider+키 값(해시)이 **이미 활성**인 경우 `이미 등록된 API Key입니다`, 동일 해시가 **삭제 예정** 행에 있으면 `삭제 예정키와 중복입니다`
@@ -179,6 +179,7 @@
   - 실패:
     - `403` (`success=false`): 팀 멤버가 아닌 사용자의 조회 시도
     - `404` (`success=false`): 대상 팀이 존재하지 않는 경우
+- 레거시 호환: 내부 저장값/경로에 `GEMINI`가 남아 있어도 외부 BFF 계약의 provider 표기는 `GOOGLE`로 통일한다.
 
 ---
 

--- a/docs/identity-auth-api-contract.md
+++ b/docs/identity-auth-api-contract.md
@@ -46,6 +46,8 @@
 | `POST` | `/api/auth/external-keys/{id}/deletion-cancel` | 필요  | 외부 AI API 키 삭제 예약 취소 |
 | `POST` | `/api/auth/logout`  | 불필요 | 로그아웃 신호 응답(BFF 쿠키 삭제 유도) |
 
+레거시 호환: 과거 `GEMINI` 값으로 저장된 항목이 있더라도 외부 API 응답의 canonical provider 표기는 `GOOGLE`로 유지한다.
+
 
 ---
 
@@ -145,7 +147,7 @@
   "data": [
     {
       "id": 1,
-      "provider": "GEMINI",
+      "provider": "GOOGLE",
       "alias": "데모용 제미나이 키",
       "monthlyBudgetUsd": 20.5,
       "createdAt": "2026-03-29T08:05:19.296098200Z"
@@ -195,16 +197,16 @@
 
 | 필드 | 타입 | 필수 | 제약 | 예시 값 |
 | --- | --- | --- | --- | --- |
-| `provider` | string (enum) | 예 | `GEMINI`, `OPENAI`, `ANTHROPIC` 중 하나 | `"GEMINI"` |
+| `provider` | string (enum) | 예 | `GOOGLE`, `OPENAI`, `ANTHROPIC` 중 하나 | `"GOOGLE"` |
 | `externalKey` | string | 예 | 공백만 불가, 최대 4096자 | 제3자가 발급한 비밀 키 |
-| `alias` | string | 예 | 공백만 불가, 최대 100자 | `"데모용 Gemini"` |
+| `alias` | string | 예 | 공백만 불가, 최대 100자 | `"데모용 Google"` |
 | `monthlyBudgetUsd` | number | 예 | 0 이상, 소수점 둘째 자리까지 | `20.5` |
 
 요청 본문 예시:
 
 | 항목 | 예시 JSON |
 | --- | --- |
-| Body | `{"provider":"GEMINI","externalKey":"<비밀키>","alias":"데모용 Gemini","monthlyBudgetUsd":20.5}` |
+| Body | `{"provider":"GOOGLE","externalKey":"<비밀키>","alias":"데모용 Google","monthlyBudgetUsd":20.5}` |
 
 ### 7.2 성공 응답 (`201 Created`)
 
@@ -222,7 +224,7 @@
 | `success` | boolean | `true` | 처리 성공 여부 |
 | `message` | string | `"외부 API 키가 등록되었습니다"` | 사용자에게 보일 메시지 |
 | `data.id` | number | `1` | 등록 레코드 ID |
-| `data.provider` | string | `"GEMINI"` | 제공자 |
+| `data.provider` | string | `"GOOGLE"` | 제공자 |
 | `data.alias` | string | `"데모용 제미나이 키"` | 별칭 |
 | `data.monthlyBudgetUsd` | number | `20.5` | 월 예산(USD) |
 | `data.createdAt` | string | `"2026-03-29T08:05:19.296098200Z"` | 등록 시각(ISO-8601 UTC, 나노초 포함 가능) |
@@ -235,7 +237,7 @@
   "message": "외부 API 키가 등록되었습니다",
   "data": {
     "id": 1,
-    "provider": "GEMINI",
+    "provider": "GOOGLE",
     "alias": "데모용 제미나이 키",
     "monthlyBudgetUsd": 20.5,
     "createdAt": "2026-03-29T08:05:19.296098200Z"
@@ -251,7 +253,7 @@
 | `externalKey` 누락 | `400` | `{"success":false,"message":"externalKey는 필수입니다","data":null}` |
 | `alias` 누락 | `400` | `{"success":false,"message":"alias는 필수입니다","data":null}` |
 | `monthlyBudgetUsd` 누락 | `400` | `{"success":false,"message":"monthlyBudgetUsd는 필수입니다","data":null}` |
-| `provider` 값 불가 | `400` | `{"success":false,"message":"provider 값이 올바르지 않습니다. 허용: GEMINI, OPENAI, ANTHROPIC","data":null}` (또는 본문 형식 오류 메시지) |
+| `provider` 값 불가 | `400` | `{"success":false,"message":"provider 값이 올바르지 않습니다. 허용: GOOGLE, OPENAI, ANTHROPIC","data":null}` (또는 본문 형식 오류 메시지) |
 | 동일 provider·동일 키 재등록(활성 행 존재) | `409` | `{"success":false,"message":"이미 등록된 API 키입니다","data":null}` |
 | 동일 provider·동일 키, 삭제 예정 행과만 충돌 | `409` | `{"success":false,"message":"삭제예정키와 중복된 키","data":null}` |
 
@@ -292,7 +294,7 @@
 
 | 필드 | 타입 | 필수 | 제약 | 예시 값 |
 | --- | --- | --- | --- | --- |
-| `provider` | string (enum) | 조건부 | `GEMINI`, `OPENAI`, `ANTHROPIC` 중 하나 (`externalKey`를 함께 보낼 때 필수) | `"GEMINI"` |
+| `provider` | string (enum) | 조건부 | `GOOGLE`, `OPENAI`, `ANTHROPIC` 중 하나 (`externalKey`를 함께 보낼 때 필수) | `"GOOGLE"` |
 | `externalKey` | string | 아니오 | 공백만 불가, 최대 4096자 (`provider`와 함께 보낼 때 키 교체) | 제3자가 발급한 비밀 키 |
 | `alias` | string | 예 | 공백만 불가, 최대 100자 | `"데모용 Gemini (수정)"` |
 | `monthlyBudgetUsd` | number | 예 | 0 이상, 소수점 둘째 자리까지 | `35.0` |
@@ -312,7 +314,7 @@
   "message": "외부 API 키가 수정되었습니다",
   "data": {
     "id": 1,
-    "provider": "GEMINI",
+    "provider": "GOOGLE",
     "alias": "데모용 Gemini (수정)",
     "monthlyBudgetUsd": 35.0,
     "createdAt": "2026-03-29T08:05:19.296098200Z"
@@ -362,7 +364,7 @@
 
 | 상황 | 상태 코드 | 예시 JSON |
 | --- | --- | --- |
-| 삭제 예약 성공 | `200` | `{"success":true,"message":"삭제가 예약되었습니다. 일주일 이내에 취소할 수 있으며, 이후에는 키가 영구 삭제됩니다.","data":{"id":1,"provider":"GEMINI","alias":"데모 키","createdAt":"...","monthlyBudgetUsd":10,"deletionRequestedAt":"...","permanentDeletionAt":"...","deletionGraceDays":7}}` |
+| 삭제 예약 성공 | `200` | `{"success":true,"message":"삭제가 예약되었습니다. 일주일 이내에 취소할 수 있으며, 이후에는 키가 영구 삭제됩니다.","data":{"id":1,"provider":"GOOGLE","alias":"데모 키","createdAt":"...","monthlyBudgetUsd":10,"deletionRequestedAt":"...","permanentDeletionAt":"...","deletionGraceDays":7}}` |
 | `gracePeriodDays` 범위 밖 | `400` | `{"success":false,"message":"유예 기간은 1일 이상 365일 이하로 설정할 수 있습니다","data":null}` |
 | 대상 키 없음 | `404` | `{"success":false,"message":"등록된 API 키를 찾을 수 없습니다","data":null}` |
 | 이미 삭제 예정 | `409` | `{"success":false,"message":"이미 삭제 예정인 키입니다","data":null}` |
@@ -371,7 +373,7 @@
 
 | 상황 | 상태 코드 | 예시 JSON |
 | --- | --- | --- |
-| 삭제 취소 성공 | `200` | `{"success":true,"message":"삭제 예약이 취소되었습니다","data":{"id":1,"provider":"GEMINI","alias":"데모 키","createdAt":"...","monthlyBudgetUsd":10,"deletionRequestedAt":null,"permanentDeletionAt":null,"deletionGraceDays":null}}` |
+| 삭제 취소 성공 | `200` | `{"success":true,"message":"삭제 예약이 취소되었습니다","data":{"id":1,"provider":"GOOGLE","alias":"데모 키","createdAt":"...","monthlyBudgetUsd":10,"deletionRequestedAt":null,"permanentDeletionAt":null,"deletionGraceDays":null}}` |
 | 대상 키 없음 | `404` | `{"success":false,"message":"등록된 API 키를 찾을 수 없습니다","data":null}` |
 | 삭제 예정 상태 아님 | `409` | `{"success":false,"message":"삭제 예정 상태가 아닙니다","data":null}` |
 
@@ -422,6 +424,6 @@
   "keyId": 123,
   "alias": "플랫폼팀 제미나이",
   "userId": 456,
-  "provider": "GEMINI",
+  "provider": "GOOGLE",
   "status": "ACTIVE"
 }

--- a/services/proxy-service/src/main/java/com/eevee/proxyservice/key/ApiKeyClient.java
+++ b/services/proxy-service/src/main/java/com/eevee/proxyservice/key/ApiKeyClient.java
@@ -21,7 +21,7 @@ import java.util.HexFormat;
 import java.util.List;
 
 import static org.springframework.http.HttpStatus.BAD_GATEWAY;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 /**
  * Resolves provider API keys from API Key Service (or mock). Keys are never logged.
@@ -82,13 +82,12 @@ public class ApiKeyClient {
             return new ResolvedApiKey(mock, null, null, fingerprint(mock), "mock");
         }
 
-        List<String> providerSegments = providerSegmentsForLookup(provider);
         try {
             KeyResponse body;
             if (teamRequest) {
-                body = loadTeamKey(keyLookupUserId, teamId, providerSegments);
+                body = loadTeamKey(keyLookupUserId, teamId, provider);
             } else {
-                body = loadIdentityKey(keyLookupUserId, providerSegments);
+                body = loadIdentityKey(keyLookupUserId, provider);
             }
             if (body == null || body.plainKey() == null || body.plainKey().isBlank()) {
                 throw new ResponseStatusException(BAD_GATEWAY, "Key lookup returned empty key");
@@ -107,9 +106,9 @@ public class ApiKeyClient {
                 log.warn("API key lookup not found lookupTarget={} provider={} teamId={} user={} status={}",
                         lookupTarget, provider.pathSegment(), teamForLog, userForLog, e.getStatusCode().value());
                 String message = teamRequest
-                        ? "No registered TEAM provider API key"
-                        : "No registered provider API key";
-                throw new ResponseStatusException(BAD_REQUEST, message, e);
+                        ? "team API key not found for provider=" + provider.pathSegment() + " teamId=" + teamForLog
+                        : "API key not found for provider=" + provider.pathSegment() + " user=" + userForLog;
+                throw new ResponseStatusException(NOT_FOUND, message, e);
             }
             log.warn("API key lookup failed lookupTarget={} provider={} teamId={} user={} status={}",
                     lookupTarget, provider.pathSegment(), teamForLog, userForLog, e.getStatusCode().value());
@@ -123,71 +122,98 @@ public class ApiKeyClient {
         }
     }
 
-    private KeyResponse loadIdentityKey(String keyLookupUserId, List<String> providerSegments) {
+    private KeyResponse loadIdentityKey(String keyLookupUserId, AiProvider provider) {
         String token = proxyProperties.getKeyService().getInternalToken();
-        ResponseStatusException notFound = null;
-        for (String providerSegment : providerSegments) {
-            try {
-                return identityKeyServiceWebClient.get()
-                        .uri(uriBuilder -> uriBuilder
-                                .path("/internal/api-keys/{provider}")
-                                .queryParam("userId", keyLookupUserId)
-                                .build(providerSegment))
-                        .headers(h -> {
-                            if (token != null && !token.isBlank()) {
-                                h.setBearerAuth(token);
-                            }
-                        })
-                        .retrieve()
-                        .bodyToMono(KeyResponse.class)
-                        .block(Duration.ofSeconds(10));
-            } catch (WebClientResponseException e) {
-                if (e.getStatusCode().value() == 404) {
-                    notFound = new ResponseStatusException(BAD_REQUEST, "No registered provider API key", e);
-                    continue;
-                }
+        String primaryProvider = provider.pathSegment();
+        String userForLog = masked(keyLookupUserId);
+        try {
+            return loadIdentityKeyByProviderSegment(keyLookupUserId, primaryProvider, token);
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().value() != 404 || provider != AiProvider.GOOGLE) {
                 throw e;
             }
         }
-        if (notFound != null) {
-            throw notFound;
+
+        try {
+            return loadIdentityKeyByProviderSegment(keyLookupUserId, "gemini", token);
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().value() == 404) {
+                throw new ResponseStatusException(
+                        NOT_FOUND,
+                        "API key not found for provider=" + primaryProvider + " user=" + userForLog,
+                        e
+                );
+            }
+            throw e;
         }
-        throw new ResponseStatusException(BAD_REQUEST, "No registered provider API key");
+
     }
 
-    private KeyResponse loadTeamKey(String keyLookupUserId, String teamId, List<String> providerSegments) {
+    private KeyResponse loadIdentityKeyByProviderSegment(String keyLookupUserId, String providerSegment, String token) {
+        return identityKeyServiceWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/internal/api-keys/{provider}")
+                        .queryParam("userId", keyLookupUserId)
+                        .build(providerSegment))
+                .headers(h -> {
+                    if (token != null && !token.isBlank()) {
+                        h.setBearerAuth(token);
+                    }
+                })
+                .retrieve()
+                .bodyToMono(KeyResponse.class)
+                .block(Duration.ofSeconds(10));
+    }
+
+    private KeyResponse loadTeamKey(String keyLookupUserId, String teamId, AiProvider provider) {
         ProxyProperties.TeamKeyService teamKeyService = proxyProperties.getTeamKeyService();
         String token = teamKeyService.getInternalToken();
         String pathTemplate = teamKeyService.getPathTemplate();
-        ResponseStatusException notFound = null;
-        for (String providerSegment : providerSegments) {
-            try {
-                return teamKeyServiceWebClient.get()
-                        .uri(uriBuilder -> uriBuilder
-                                .path(pathTemplate)
-                                .queryParam("teamId", teamId)
-                                .queryParam("userId", keyLookupUserId)
-                                .build(providerSegment))
-                        .headers(h -> {
-                            if (token != null && !token.isBlank()) {
-                                h.setBearerAuth(token);
-                            }
-                        })
-                        .retrieve()
-                        .bodyToMono(KeyResponse.class)
-                        .block(Duration.ofSeconds(10));
-            } catch (WebClientResponseException e) {
-                if (e.getStatusCode().value() == 404) {
-                    notFound = new ResponseStatusException(BAD_REQUEST, "No registered TEAM provider API key", e);
-                    continue;
-                }
+        String primaryProvider = provider.pathSegment();
+        String teamForLog = masked(teamId);
+        try {
+            return loadTeamKeyByProviderSegment(keyLookupUserId, teamId, primaryProvider, token, pathTemplate);
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().value() != 404 || provider != AiProvider.GOOGLE) {
                 throw e;
             }
         }
-        if (notFound != null) {
-            throw notFound;
+
+        try {
+            return loadTeamKeyByProviderSegment(keyLookupUserId, teamId, "gemini", token, pathTemplate);
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().value() == 404) {
+                throw new ResponseStatusException(
+                        NOT_FOUND,
+                        "team API key not found for provider=" + primaryProvider + " teamId=" + teamForLog,
+                        e
+                );
+            }
+            throw e;
         }
-        throw new ResponseStatusException(BAD_REQUEST, "No registered TEAM provider API key");
+    }
+
+    private KeyResponse loadTeamKeyByProviderSegment(
+            String keyLookupUserId,
+            String teamId,
+            String providerSegment,
+            String token,
+            String pathTemplate
+    ) {
+        return teamKeyServiceWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(pathTemplate)
+                        .queryParam("teamId", teamId)
+                        .queryParam("userId", keyLookupUserId)
+                        .build(providerSegment))
+                .headers(h -> {
+                    if (token != null && !token.isBlank()) {
+                        h.setBearerAuth(token);
+                    }
+                })
+                .retrieve()
+                .bodyToMono(KeyResponse.class)
+                .block(Duration.ofSeconds(10));
     }
 
     /**
@@ -208,9 +234,6 @@ public class ApiKeyClient {
     }
 
     static List<String> providerSegmentsForLookup(AiProvider provider) {
-        if (provider == AiProvider.GOOGLE) {
-            return List.of("google", "gemini");
-        }
         return List.of(provider.pathSegment());
     }
 

--- a/services/proxy-service/src/test/java/com/eevee/proxyservice/key/ApiKeyClientProviderLookupTest.java
+++ b/services/proxy-service/src/test/java/com/eevee/proxyservice/key/ApiKeyClientProviderLookupTest.java
@@ -8,9 +8,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ApiKeyClientProviderLookupTest {
 
     @Test
-    void googleLookupAcceptsGoogleAndGeminiProviderSegments() {
+    void googleLookupUsesCanonicalGoogleSegmentOnly() {
         assertThat(ApiKeyClient.providerSegmentsForLookup(AiProvider.GOOGLE))
-                .containsExactly("google", "gemini");
+                .containsExactly("google");
     }
 
     @Test

--- a/services/proxy-service/src/test/java/com/eevee/proxyservice/key/ApiKeyClientTeamLookupFallbackTest.java
+++ b/services/proxy-service/src/test/java/com/eevee/proxyservice/key/ApiKeyClientTeamLookupFallbackTest.java
@@ -1,0 +1,142 @@
+package com.eevee.proxyservice.key;
+
+import com.eevee.proxyservice.config.ProxyProperties;
+import com.eevee.usage.events.AiProvider;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ApiKeyClientTeamLookupFallbackTest {
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void teamLookupFallsBackToGeminiWhenGoogleNotFound() throws Exception {
+        AtomicInteger googleCalls = new AtomicInteger();
+        AtomicInteger geminiCalls = new AtomicInteger();
+        startServer(exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            if (path.endsWith("/google")) {
+                googleCalls.incrementAndGet();
+                respond(exchange, 404, "{\"message\":\"not found\"}");
+                return;
+            }
+            if (path.endsWith("/gemini")) {
+                geminiCalls.incrementAndGet();
+                respond(exchange, 200, "{\"plainKey\":\"AIza-legacy\",\"keyId\":\"team-key-1\"}");
+                return;
+            }
+            respond(exchange, 404, "{\"message\":\"unknown\"}");
+        });
+
+        ApiKeyClient client = new ApiKeyClient(baseProps(server.getAddress().getPort()));
+        ApiKeyClient.ResolvedApiKey resolved = client.resolveApiKey("user-1", "123", AiProvider.GOOGLE).block();
+
+        assertThat(resolved).isNotNull();
+        assertThat(resolved.plainKey()).isEqualTo("AIza-legacy");
+        assertThat(resolved.keyId()).isEqualTo("team-key-1");
+        assertThat(googleCalls.get()).isEqualTo(1);
+        assertThat(geminiCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void teamLookupReturnsNotFoundWithProviderAndTeamContextWhenAllMissed() throws Exception {
+        startServer(exchange -> respond(exchange, 404, "{\"message\":\"not found\"}"));
+
+        ApiKeyClient client = new ApiKeyClient(baseProps(server.getAddress().getPort()));
+
+        assertThatThrownBy(() -> client.resolveApiKey("user-1", "999", AiProvider.GOOGLE).block())
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException statusException = (ResponseStatusException) ex;
+                    assertThat(statusException.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+                    assertThat(statusException.getReason()).contains("provider=google");
+                    assertThat(statusException.getReason()).contains("teamId=999***");
+                });
+    }
+
+    @Test
+    void teamLookupDoesNotFallbackOnNon404Error() throws Exception {
+        AtomicInteger googleCalls = new AtomicInteger();
+        AtomicInteger geminiCalls = new AtomicInteger();
+        startServer(exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            if (path.endsWith("/google")) {
+                googleCalls.incrementAndGet();
+                respond(exchange, 500, "{\"message\":\"upstream error\"}");
+                return;
+            }
+            if (path.endsWith("/gemini")) {
+                geminiCalls.incrementAndGet();
+                respond(exchange, 200, "{\"plainKey\":\"AIza-legacy\",\"keyId\":\"team-key-1\"}");
+                return;
+            }
+            respond(exchange, 404, "{\"message\":\"unknown\"}");
+        });
+
+        ApiKeyClient client = new ApiKeyClient(baseProps(server.getAddress().getPort()));
+
+        assertThatThrownBy(() -> client.resolveApiKey("user-1", "123", AiProvider.GOOGLE).block())
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException statusException = (ResponseStatusException) ex;
+                    assertThat(statusException.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+                });
+        assertThat(googleCalls.get()).isEqualTo(1);
+        assertThat(geminiCalls.get()).isEqualTo(0);
+    }
+
+    private void startServer(IoHandler handler) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/internal/api-keys", exchange -> {
+            try {
+                handler.handle(exchange);
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+    }
+
+    private static ProxyProperties baseProps(int port) {
+        ProxyProperties props = new ProxyProperties();
+        props.getKeyService().setBaseUrl("http://127.0.0.1:" + port);
+        props.getKeyService().setCacheTtl("PT1S");
+        props.getTeamKeyService().setBaseUrl("http://127.0.0.1:" + port);
+        props.getTeamKeyService().setPathTemplate("/internal/api-keys/{provider}");
+        return props;
+    }
+
+    private static void respond(HttpExchange exchange, int statusCode, String body) throws IOException {
+        byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, payload.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(payload);
+        }
+    }
+
+    @FunctionalInterface
+    private interface IoHandler {
+        void handle(HttpExchange exchange) throws IOException;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> N/A

## 작업 내용
- **해당 서비스**: Proxy service
> 외부 정책상 API Key 공급자(Provider)를 GOOGLE로 단일화하고, 내부적으로는 GEMINI 조회를 Fallback으로 유지하도록 조회 로직을 리팩터링했습니다. 또한 이에 따른 API 계약 문서를 전수 업데이트했습니다.

  
## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [x] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
1. ApiKeyClient 조회 정책 리팩터링:
- 외부 노출 Provider를 google로 고정하여 인터페이스 단순화.
- google 조회 결과가 404일 때만 내부적으로 레거시 gemini 공급자로 재시도하는 Fallback 로직 구현.
- 500 계열 오류 발생 시 Fallback 없이 즉시 502 Bad Gateway를 반환하도록 예외 전파 정책 정립.

2. 에러 컨텍스트 강화: 키 미존재 시 provider, teamId/userId 문맥을 포함하되, 보안을 위해 API Key 원문은 노출되지 않도록 처리.

3.  계약 문서(Docs) 최신화: gateway-proxy.md 포함 5종의 문서에서 외부 표기 관점의 GEMINI를 GOOGLE로 통일.

4. 테스트 코드 보강: google canonical only 검증 및 google(404) -> gemini(200) 성공 시나리오를 포함한 신규 테스트 케이스 추가.

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
-Fallback 로직: google 404 발생 시에만 gemini로 재시도하는 흐름이 의도한 정책(Legacy 호환성 유지)대로 작동하는지 검토 부탁드립니다.
- 보안 사항: 에러 메시지에 문맥 정보를 포함할 때 API Key 원문이 노출되지 않도록 처리한 부분이 적절한지 확인 바랍니다.
- 문서 정합성: gateway-proxy.md 내에 존재하는 기존 머지 충돌 마커(<<<<<<<)는 이번 작업 범위 밖의 레거시임을 참고 부탁드립니다.