### PR TITLE
fix: 팀 서비스 디비 provider 혼용 임시 조치

### DIFF
--- a/docs/contracts/web-team-bff.md
+++ b/docs/contracts/web-team-bff.md
@@ -1,6 +1,6 @@
 # Web(Next.js) ↔ Team Service BFF 계약
 
-버전: 0.11  
+버전: 0.12  
 관련: [web-split-boundary.md](./web-split-boundary.md), [web-identity-bff.md](./web-identity-bff.md) — `/teams` UI 소유·경로: §2.3
 
 ---
@@ -182,6 +182,7 @@
 - 레거시 호환: 내부 저장값/경로에 `GEMINI`가 남아 있어도 외부 BFF 계약의 provider 표기는 `GOOGLE`로 통일한다.
   - 내부 키 조회 API(`GET /internal/team-api-keys/{provider}`)는 `provider=gemini` 별칭을 입력받아 `GOOGLE`로 정규화한다(코드: `TeamInternalApiKeyResolveService`).
   - 부팅 시 `TeamApiKeyProviderMigrationInitializer`가 `team_api_keys`의 `GEMINI` 값을 `GOOGLE`로 정리한다.
+  - **임시 안정화 조치:** DB 혼재 상태로 인한 기동 실패를 막기 위해 부팅 시 `team_api_keys_provider_check`를 재생성하고, 제약조건 허용값에 `GEMINI`/`GOOGLE`를 함께 둔 뒤 데이터를 `GEMINI -> GOOGLE`로 수렴시킨다.
 
 ---
 

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/bootstrap/TeamApiKeyProviderMigrationInitializer.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/bootstrap/TeamApiKeyProviderMigrationInitializer.java
@@ -8,7 +8,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
- * 팀 API 키 provider 레거시 값(GEMINI)을 GOOGLE로 통일한다.
+ * 팀 API 키 provider 레거시 값을 현재 enum/계약과 호환되도록 보정한다.
  */
 @Component
 public class TeamApiKeyProviderMigrationInitializer {
@@ -21,7 +21,7 @@ public class TeamApiKeyProviderMigrationInitializer {
     }
 
     @EventListener(ApplicationReadyEvent.class)
-    public void migrateGeminiProviderToGoogle() {
+    public void migrateProviders() {
         Integer tableCount = jdbcTemplate.queryForObject(
                 """
                 select count(*)
@@ -35,13 +35,38 @@ public class TeamApiKeyProviderMigrationInitializer {
             return;
         }
 
-        int updated = jdbcTemplate.update(
+        jdbcTemplate.execute(
+                """
+                do $$
+                begin
+                  if exists (
+                    select 1
+                    from pg_constraint c
+                    join pg_class t on c.conrelid = t.oid
+                    where t.relname = 'team_api_keys'
+                      and c.conname = 'team_api_keys_provider_check'
+                  ) then
+                    alter table team_api_keys
+                      drop constraint team_api_keys_provider_check;
+                  end if;
+                end $$;
+                """
+        );
+        jdbcTemplate.execute(
+                """
+                alter table team_api_keys
+                add constraint team_api_keys_provider_check
+                check (provider in ('OPENAI', 'GEMINI', 'GOOGLE', 'ANTHROPIC', 'CLAUDE', 'META', 'MISTRAL', 'COHERE', 'GROK'))
+                """
+        );
+
+        int updatedGemini = jdbcTemplate.update(
                 """
                 update team_api_keys
                 set provider = 'GOOGLE'
                 where provider = 'GEMINI'
                 """
         );
-        log.info("team_api_keys provider migration completed updatedRows={}", updated);
+        log.info("team_api_keys provider migration completed updatedGeminiRows={}", updatedGemini);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> 없음 (필요 시 이슈 번호 추가)

## 작업 내용
- **해당 서비스**: Identity / Team (provider 마이그레이션), Team Web 문서
- `GEMINI -> GOOGLE` 전환 과정에서 DB 제약조건 불일치로 서비스가 재시작 실패할 수 있는 문제를 임시 안정화 방식으로 보완했습니다.
- Identity와 Team 모두 부팅 시 제약조건/데이터를 안전하게 처리하도록 마이그레이션 로직을 보강했고, Team BFF 문서에 해당 임시 조치를 반영했습니다.

## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- `services/identity-service/src/main/java/com/zerobugfreinds/identity_service/bootstrap/ExternalApiKeyProviderMigrationInitializer.java`
  - `external_api_keys_provider_check` 제약조건 재생성
  - 제약조건에 레거시/신규 값을 함께 허용한 뒤 `GEMINI -> GOOGLE` 업데이트 수행
- `services/team-service/src/main/java/com/zerobugfreinds/team_service/bootstrap/TeamApiKeyProviderMigrationInitializer.java`
  - `team_api_keys_provider_check` 제약조건 재생성
  - 제약조건 허용값에 `GEMINI`/`GOOGLE` 동시 포함
  - `GEMINI -> GOOGLE` 데이터 수렴 로직 적용
- `docs/contracts/web-team-bff.md`
  - 버전 `0.12`로 갱신
  - 위 임시 안정화 조치(제약조건 재생성 + 데이터 수렴) 문서화

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [x] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부  
  (DDL 제약조건 재생성 + 데이터 마이그레이션 SQL 실행)

## 📸 스크린샷 / 테스트 결과 (선택)
- `team-service` 재기동 후 정상 기동 확인 (`Up`)
- 로그 확인:
  - `team_api_keys provider migration completed updatedGeminiRows=0`
- DB 확인:
  - `team_api_keys_provider_check`가 임시 호환 제약조건으로 반영됨
- Identity도 동일 방식으로 기동/마이그레이션 동작 확인 완료

## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- 이번 변경은 **임시 안정화 목적**입니다. 운영 중 혼재 데이터로 인한 부팅 실패를 막기 위한 조치이며, 추후 canonical provider만 남기는 2차 정리(제약조건 축소)가 필요합니다.
- 제약조건 재생성 순서(드롭 -> 재생성 -> 데이터 업데이트)가 로컬/스테이징 DB 상태별로 안전한지 확인 부탁드립니다.