### PR TITLE
feat: proxy요구사항반영

### DIFF
--- a/docs/contracts/proxy-api-key-reverse-lookup-internal-api.md
+++ b/docs/contracts/proxy-api-key-reverse-lookup-internal-api.md
@@ -1,0 +1,213 @@
+# Proxy API Key 역조회 내부 API 가이드
+
+이 문서는 `proxy-service` 또는 다른 내부 호출자가 **외부 AI API Key의 해시값으로 등록 키를 역조회**할 때 사용하는 내부 API 계약을 정의한다.
+
+주요 사용 사례는 다음과 같다. 3rd-party 도구가 `teamId`, `keyId` 같은 우리 플랫폼 전용 헤더 없이 provider API Key를 `Authorization` 헤더로 직접 보낸다. 이때 proxy는 들어온 키를 해시한 뒤 각 소유 서비스에 조회하여 어떤 사용자/팀의 어떤 키에 매핑되는지 확인하고, 사용량 귀속 및 상태 게이트를 적용한다.
+
+응답에는 평문 키를 **절대 포함하지 않는다**. 응답에는 식별 메타데이터(`keyId`, owner, `status`, `alias`, `scope`)만 포함한다.
+
+## 범위
+
+- 호출자: `services/proxy-service` 및 동일한 해시 → 사용자/팀 매핑이 필요한 내부 서비스
+- 피호출자:
+  - `services/identity-service`: 개인 API Key(`USER` scope)
+  - `services/team-service`: 팀 API Key(`TEAM` scope)
+- 목적: 클라이언트 헤더를 신뢰하지 않고 해시값 기준으로 등록 키를 식별하여 사용량 귀속과 라이프사이클 상태 판단을 수행한다.
+- 정책: 호출자는 키 등록 시 소유 서비스가 사용한 것과 **완전히 동일한 알고리즘**으로 해시를 계산해야 한다. 자세한 내용은 [해시 형식](#해시-형식)을 따른다.
+
+## 해시 형식
+
+두 서비스 모두 아래 방식으로 계산된 `key_hash`를 저장하고 조회한다. 이 형식이 일치하지 않으면 조회는 항상 `404`가 된다.
+
+```text
+sha256( providerName + '\0' + plainKey )  ->  64자 lowercase hex
+```
+
+- `providerName`: 대문자 enum 이름 (`OPENAI`, `ANTHROPIC`, `GOOGLE`, ...)
+- `'\0'`: 구분자로 사용하는 ASCII NUL byte (`0x00`)
+- `plainKey`: 사용자가 입력한 provider 키 평문을 trim 한 값
+- 출력: 공백이나 `0x` prefix 없는 lowercase hex 문자열
+
+참조 구현:
+
+- `services/identity-service/.../util/EncryptionUtil#sha256HexForUniqueness`
+- `services/team-service/.../util/EncryptionUtil#sha256HexForUniqueness`
+
+엔드포인트는 `hashedKey` 입력값의 앞뒤 공백을 제거하고 서버에서 소문자로 정규화한다. 따라서 해시 문자열 대소문자 차이는 허용한다.
+
+## Provider 값
+
+두 엔드포인트는 아래 provider 값을 허용한다. 입력은 대문자 enum 이름만 허용한다.
+
+- `OPENAI`
+- `ANTHROPIC`
+- `GOOGLE`
+- `META`
+- `MISTRAL`
+- `COHERE`
+- `GROK`
+
+`team-service`는 추가로 아래 alias를 허용한다.
+
+- `GEMINI` -> `GOOGLE`로 정규화
+- `CLAUDE` -> `CLAUDE` enum (legacy 호환)
+
+소문자 또는 지원하지 않는 provider는 `400`을 반환한다.
+
+---
+
+## 1. Identity-service: 개인 API Key 역조회
+
+### 요청
+
+- Method: `GET`
+- Path: `/internal/v1/api-keys/lookup`
+- Query parameters:
+  - `hashedKey` (required): SHA-256 hex 해시. [해시 형식](#해시-형식)을 따른다.
+  - `provider` (required): AI provider 이름. [Provider 값](#provider-값)을 따른다.
+- Header: 없음
+  - 현재 identity-service의 기존 내부 키 조회 API(`/internal/api-keys/{provider}`)와 동일하게 네트워크 격리를 전제로 한다.
+
+### 응답 (200)
+
+```json
+{
+  "keyId": "12345",
+  "ownerId": 7,
+  "status": "ACTIVE",
+  "alias": "openai-default",
+  "scope": "USER"
+}
+```
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `keyId` | string | 외부 API Key 행의 PK. 문자열로 반환한다. |
+| `ownerId` | number (`Long`) | 키 소유 사용자 ID |
+| `status` | string (enum) | `ACTIVE` / `DELETION_REQUESTED` / `DELETED` |
+| `alias` | string | 사용자가 설정한 별칭 |
+| `scope` | string (literal) | 항상 `"USER"` |
+
+### 에러 의미
+
+- `400`: `hashedKey` 또는 `provider` 누락/blank, 소문자 provider, 지원하지 않는 provider
+- `404`: `(provider, hashedKey)`에 매칭되는 행 없음. 삭제 유예 기간이 끝나 물리 삭제된 행도 조회 관점에서는 `404`다.
+- `409`: `(provider, hashedKey)`에 2건 이상 매칭됨. 전역적으로 모호하므로 호출자가 단일 키를 선택할 수 없다. 자세한 내용은 [모호성 처리](#모호성-처리)를 따른다.
+- `500`: 내부 서버 오류
+
+에러 응답은 서비스 공통 `ApiResponse<Void>` 형식을 따른다.
+
+```json
+{ "success": false, "message": "동일 해시값에 매칭되는 외부 API 키가 2건 이상입니다", "data": null }
+```
+
+---
+
+## 2. Team-service: 팀 API Key 역조회
+
+### 요청
+
+- Method: `GET`
+- Path: `/internal/v1/team-api-keys/lookup`
+- Query parameters:
+  - `hashedKey` (required): SHA-256 hex 해시. [해시 형식](#해시-형식)을 따른다.
+  - `provider` (required): AI provider 이름. [Provider 값](#provider-값)을 따른다.
+- Header:
+  - `Authorization: Bearer <internal-token>` (required)
+  - 기존 team-service 내부 팀 키 조회 API(`/internal/api-keys/{provider}`)와 동일한 내부 토큰 정책을 사용한다.
+
+### 응답 (200)
+
+```json
+{
+  "keyId": "777",
+  "teamId": 42,
+  "ownerUserId": "user-1",
+  "status": "ACTIVE",
+  "alias": "openai-team",
+  "scope": "TEAM"
+}
+```
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `keyId` | string | 팀 API Key 행의 PK. 문자열로 반환한다. |
+| `teamId` | number (`Long`) | 키가 속한 팀 ID |
+| `ownerUserId` | string \| null | 키를 등록한 팀 멤버의 사용자 ID. legacy 행은 `null`일 수 있다. |
+| `status` | string (enum) | `ACTIVE` / `DELETION_REQUESTED` / `DELETED` |
+| `alias` | string | 팀 키 별칭 |
+| `scope` | string (literal) | 항상 `"TEAM"` |
+
+`ownerUserId`는 `team_api_keys.created_by_user_id` 컬럼에서 가져온다. 이 컬럼은 nullable이다. 컬럼 도입 이전에 생성된 기존 행은 다음 재등록 전까지 `null`로 반환될 수 있다.
+
+### 에러 의미
+
+- `400`: `hashedKey` 또는 `provider` 누락/blank, 소문자 provider, 지원하지 않는 provider
+- `403`: `Authorization: Bearer <internal-token>` 누락/오류, 또는 서버에 내부 토큰 미설정
+- `404`: `(provider, hashedKey)`에 매칭되는 행 없음
+- `409`: `(provider, hashedKey)`에 2건 이상 매칭됨. 자세한 내용은 [모호성 처리](#모호성-처리)를 따른다.
+- `500`: 내부 서버 오류
+
+에러 응답은 서비스 공통 `ApiResponse<Void>` 형식을 따른다.
+
+---
+
+## 상태 의미
+
+`status` 필드는 DB 행의 라이프사이클 상태를 그대로 반영한다.
+
+| DB 상태 | 반환 `status` |
+| --- | --- |
+| 행 존재, `deletion_requested_at IS NULL` | `ACTIVE` |
+| 행 존재, `deletion_requested_at IS NOT NULL` | `DELETION_REQUESTED` |
+| purge scheduler에 의해 행이 물리 삭제됨 | `404` (매핑할 행 없음) |
+
+`DELETED` enum 값은 이벤트(`identity.events` / `team.api-key.exchange`)로 수신할 수 있는 상태값을 위해 예약되어 있다. 역조회 엔드포인트는 행이 삭제되면 매핑할 데이터가 없으므로 직접 `DELETED`를 반환하지 않고 `404`를 반환한다.
+
+호출자는 `DELETION_REQUESTED`를 **요청 차단 대상**으로 처리해야 한다. 사용자가 또는 팀 소유자가 키 폐기를 요청한 상태이며, 유예 기간 중이라 행이 남아 있어도 신규 요청에 사용할 키로 보면 안 된다.
+
+## 모호성 처리
+
+기저 테이블의 유일 제약은 다음과 같다.
+
+- `external_api_keys`: `UNIQUE (user_id, provider, key_hash)`
+- `team_api_keys`: `UNIQUE (team_id, provider, key_hash)`
+
+두 제약 모두 owner 단위로 유일성을 보장한다. 따라서 동일한 provider 키가 여러 owner 행에 존재할 수 있다. 예를 들어 두 사용자가 같은 OpenAI 키를 등록하거나, 두 팀이 같은 키를 등록할 수 있다.
+
+이 경우 `(provider, hashedKey)`만으로 전역 조회를 수행하면 어떤 owner를 선택해야 하는지 결정할 수 없다. 그래서 엔드포인트는 `409 Conflict`를 반환한다. 호출자는 명시적인 `userId` / `teamId` 헤더가 있으면 이를 사용해 다른 조회 경로로 재시도하거나, 모호한 요청으로 거절해야 한다.
+
+서버 로그에는 감사 목적으로 매칭 건수와 해시의 앞 8자만 남긴다. 전체 해시와 평문 키는 절대 로그에 남기지 않는다.
+
+## 성능 고려사항
+
+두 테이블 모두 `key_hash`가 유일 제약의 일부이므로 PostgreSQL 인덱스가 이미 존재한다. 다만 현재 유일 제약의 컬럼 순서는 아래와 같다.
+
+- `(user_id, provider, key_hash)`
+- `(team_id, provider, key_hash)`
+
+역조회 쿼리는 `(provider, key_hash)` 조건을 사용한다. 운영 프로파일링에서 많은 행을 스캔하는 핫패스가 확인되면 각 서비스에 `(provider, key_hash)` 전용 인덱스를 추가한다.
+
+proxy는 같은 해시에 대한 성공 조회 결과를 캐시하는 것이 좋다. 동일 클라이언트의 반복 요청마다 DB 조회가 발생하지 않도록 기존 `proxy-service`의 `ApiKeyClient`가 사용하는 `Caffeine` `LoadingCache` 패턴을 재사용한다.
+
+## 보안
+
+- 두 엔드포인트는 내부 전용(`/internal/v1/...`)이며 public API gateway로 노출하지 않는다.
+- `team-service`는 `Authorization: Bearer <internal-token>`을 `team.internal.api-token`과 비교한다. 환경 변수는 `PROXY_TEAM_KEY_SERVICE_INTERNAL_TOKEN`을 사용한다.
+- `identity-service`는 현재 내부 토큰을 검증하지 않는다. 기존 `/internal/api-keys/{provider}`와 동일한 전제로 네트워크 격리에 의존한다.
+- 평문 provider 키는 입력으로 받지 않으며 응답에도 포함하지 않는다. 네트워크를 오가는 값은 SHA-256 해시뿐이다.
+- 모호성 경고 로그에는 해시 앞 8자만 남기며 alias, owner id, 평문 키는 포함하지 않는다.
+
+## 런타임 설정
+
+- `identity-service`
+  - `IDENTITY_API_KEY_ENCRYPTION_SECRET`
+  - 이미 사용 중인 값이다. 저장 암호문용 AES 키 유도에 사용되며, 현재 `EncryptionUtil#sha256HexForUniqueness`는 별도 salt 없이 위 [해시 형식](#해시-형식)만 사용한다.
+- `team-service`
+  - `TEAM_API_KEY_ENCRYPTION_SECRET`
+  - `team.internal.api-token`
+    - `PROXY_TEAM_KEY_SERVICE_INTERNAL_TOKEN`에서 해석된다.
+    - team-service 역조회 호출 시 필수다.
+- `proxy-service`
+  - 팀 역조회에는 기존 `PROXY_TEAM_KEY_SERVICE_INTERNAL_TOKEN`을 재사용한다.
+  - identity-service 역조회에는 현재 신규 환경 변수가 필요 없다.

--- a/services/agent-service/src/main/java/com/zerobugfreinds/ai_agent_service/mq/UsageRecordedEventListener.java
+++ b/services/agent-service/src/main/java/com/zerobugfreinds/ai_agent_service/mq/UsageRecordedEventListener.java
@@ -56,18 +56,17 @@ public class UsageRecordedEventListener {
 				return;
 			}
 
-			String scopeType = resolveScopeType(event.apiKeySource());
-			String scopeId = scopeType.equals("TEAM") ? event.teamId() : event.userId();
-			if (scopeId == null || scopeId.isBlank()) {
-				log.debug("Skip usage.recorded rollup because scopeId is missing. keyId={}, apiKeySource={}",
-						event.apiKeyId(), event.apiKeySource());
+			ResolvedScope resolved = resolveScope(event);
+			if (resolved == null) {
+				log.debug("Skip usage.recorded rollup because scopeId is missing. keyId={}, apiKeySource={}, teamApiKeyId={}",
+						event.apiKeyId(), event.apiKeySource(), event.teamApiKeyId());
 				return;
 			}
 
 			rollupService.add(
 					event.apiKeyId(),
-					scopeType,
-					scopeId,
+					resolved.scopeType(),
+					resolved.scopeId(),
 					event.occurredAt(),
 					tokenUsage.promptTokens(),
 					tokenUsage.completionTokens(),
@@ -79,13 +78,47 @@ public class UsageRecordedEventListener {
 		}
 	}
 
-	private static String resolveScopeType(String apiKeySource) {
-		String source = apiKeySource == null ? "" : apiKeySource.trim().toLowerCase(Locale.ROOT);
-		return switch (source) {
-			case "team" -> "TEAM";
-			case "managed", "mock" -> "PERSONAL";
-			default -> "PERSONAL";
-		};
+	/**
+	 * 사용량 이벤트의 scope 결정.
+	 *
+	 * <p>proxy 가 reverse-lookup 경로로 키를 식별하면 {@code apiKeySource} 가 {@code "team"} 이 아니라
+	 * {@code "reverse_lookup"} 등으로 들어올 수 있다. 이 때도 팀 키이면 {@code teamApiKeyId}/{@code teamId}
+	 * 가 채워지므로, {@code apiKeySource} 만으로 판정하지 않고 페이로드의 team 식별자가 있으면 우선 TEAM 으로
+	 * 본다. 그렇지 않은 경우에만 {@code apiKeySource == "team"} 폴백을 적용하고, 최종적으로 PERSONAL 로 떨어진다.</p>
+	 */
+	static ResolvedScope resolveScope(UsageRecordedEvent event) {
+		String teamApiKeyId = trimToNull(event.teamApiKeyId());
+		String teamId = trimToNull(event.teamId());
+		if (teamApiKeyId != null || teamId != null || isTeamSource(event.apiKeySource())) {
+			String scopeId = teamId != null ? teamId : teamApiKeyId;
+			if (scopeId == null) {
+				return null;
+			}
+			return new ResolvedScope("TEAM", scopeId);
+		}
+		String userId = trimToNull(event.userId());
+		if (userId == null) {
+			return null;
+		}
+		return new ResolvedScope("PERSONAL", userId);
+	}
+
+	private static boolean isTeamSource(String apiKeySource) {
+		if (apiKeySource == null) {
+			return false;
+		}
+		return "team".equals(apiKeySource.trim().toLowerCase(Locale.ROOT));
+	}
+
+	private static String trimToNull(String value) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		return trimmed.isEmpty() ? null : trimmed;
+	}
+
+	record ResolvedScope(String scopeType, String scopeId) {
 	}
 
 	private static Map<String, String> toStringHeaders(Message message) {

--- a/services/agent-service/src/main/java/com/zerobugfreinds/ai_agent_service/service/GeminiAssistantService.java
+++ b/services/agent-service/src/main/java/com/zerobugfreinds/ai_agent_service/service/GeminiAssistantService.java
@@ -72,34 +72,21 @@ public class GeminiAssistantService {
 		}
 	}
 
+	/**
+	 * Runs one Gemini inference per key so model context never mixes multiple keys in a single prompt.
+	 */
 	public Map<Long, AiBudgetForecastResult> inferForecasts(List<BudgetForecastRequest> requests) {
 		if (requests == null || requests.isEmpty()) {
 			return Map.of();
 		}
-		if (properties.apiKey() == null || properties.apiKey().isBlank()) {
-			log.warn("Gemini batch inference skipped: API key missing");
-			return Map.of();
-		}
-		String requestId = UUID.randomUUID().toString();
-		UsageAggregate usageAggregate = new UsageAggregate(requestId, "batch");
-		try {
-			List<Map<String, Object>> payload = requests.stream()
-					.map(this::buildBatchInputMap)
-					.toList();
-			String inputJson = objectMapper.writeValueAsString(payload);
-			String prompt = buildBatchForecastPrompt(inputJson, false);
-			Map<Long, AiBudgetForecastResult> primary = inferBatchByPrompt(requestId, 1, prompt, usageAggregate);
-			if (!primary.isEmpty()) {
-				return primary;
+		Map<Long, AiBudgetForecastResult> results = new LinkedHashMap<>();
+		for (BudgetForecastRequest request : requests) {
+			if (request.keyId() == null) {
+				continue;
 			}
-			String retryPrompt = buildBatchForecastPrompt(inputJson, true);
-			return inferBatchByPrompt(requestId, 2, retryPrompt, usageAggregate);
-		} catch (Exception ex) {
-			log.warn("Gemini batch inference failed: {}", ex.getMessage());
-			return Map.of();
-		} finally {
-			logGeminiUsageSummary(usageAggregate);
+			inferForecast(request).ifPresent(ai -> results.put(request.keyId(), ai));
 		}
+		return results;
 	}
 
 
@@ -162,49 +149,6 @@ public class GeminiAssistantService {
 					""".formatted(LocalDate.now().plusDays(1), LocalDate.now().plusDays(999), inputJson, LocalDate.now(), retryDirective);
 	}
 
-	private String buildBatchForecastPrompt(String inputJson, boolean retryMode) {
-		String retryDirective = retryMode
-				? """
-					[Retry note]
-					Previous output was invalid.
-					You MUST return a valid JSON array.
-					Every item must include keyId and all required fields.
-					"""
-				: "";
-		return """
-					You are a strictly analytical budget forecasting assistant for an AI API usage product.
-					Do NOT output any conversational text.
-					Output ONLY valid raw JSON array.
-
-					[Task]
-					Analyze each input object independently and return one result object per input object.
-					Preserve keyId exactly for mapping.
-
-					[Input JSON array]
-					%s
-
-					[Required output format]
-					Return ONLY one raw JSON array.
-					Never wrap in markdown (no ```json).
-					Each item must contain exactly:
-					{
-					  "keyId": <long>,
-					  "predictedRunOutDate": "yyyy-MM-dd",
-					  "daysUntilRunOut": <integer>,
-					  "healthStatus": "CRITICAL|WARNING|HEALTHY",
-					  "budgetUtilizationPercent": "<string with 2 decimals>",
-					  "assistantMessage": "<one Korean sentence>",
-					  "recommendedActions": ["<Korean action 1>", "<Korean action 2>"],
-					  "anomalySummary": "<Korean one sentence anomaly finding>",
-					  "routingRecommendation": "<Korean one sentence model routing suggestion>",
-					  "estimatedRoutingSavingsPercent": "<string with 2 decimals>"
-					}
-
-					Today's date for reference: %s
-					%s
-					""".formatted(inputJson, LocalDate.now(), retryDirective);
-	}
-
 	private Optional<AiBudgetForecastResult> inferByPrompt(
 			String requestId,
 			String keyId,
@@ -239,60 +183,6 @@ public class GeminiAssistantService {
 			logGeminiUsage(requestId, keyId, attempt, prompt.length(), null, startedAt, usageAggregate);
 			log.warn("Gemini inference attempt failed: {}", ex.getMessage());
 			return Optional.empty();
-		}
-	}
-
-	private Map<Long, AiBudgetForecastResult> inferBatchByPrompt(
-			String requestId,
-			int attempt,
-			String prompt,
-			UsageAggregate usageAggregate
-	) {
-		long startedAt = System.currentTimeMillis();
-		try {
-			String responseBody = callGenerateContent(prompt);
-			if (responseBody == null || responseBody.isBlank()) {
-				logGeminiUsage(requestId, "batch", attempt, prompt.length(), null, startedAt, usageAggregate);
-				log.warn("Gemini batch inference returned empty response body");
-				return Map.of();
-			}
-			JsonNode root = objectMapper.readTree(responseBody);
-			logGeminiUsage(requestId, "batch", attempt, prompt.length(), root.path("usageMetadata"), startedAt, usageAggregate);
-			JsonNode textNode = root.path("candidates").path(0).path("content").path("parts").path(0).path("text");
-			if (textNode.isMissingNode() || textNode.asText().isBlank()) {
-				String blockReason = root.path("promptFeedback").path("blockReason").asText("");
-				if (!blockReason.isBlank()) {
-					log.warn("Gemini batch response blocked: blockReason={}", blockReason);
-				} else {
-					log.warn("Gemini batch response missing text candidate: summary={}", summarizeResponseBody(responseBody));
-				}
-				return Map.of();
-			}
-			String rawJson = extractJsonPayload(textNode.asText().trim());
-			JsonNode forecastArray = objectMapper.readTree(rawJson);
-			if (!forecastArray.isArray()) {
-				return Map.of();
-			}
-			Map<Long, AiBudgetForecastResult> results = new LinkedHashMap<>();
-			for (JsonNode item : forecastArray) {
-				if (!item.isObject()) {
-					continue;
-				}
-				Long parsedKeyId = parseKeyId(item.get("keyId"));
-				if (parsedKeyId == null) {
-					continue;
-				}
-				Optional<AiBudgetForecastResult> parsed = parseAiForecast(item);
-				if (parsed.isEmpty()) {
-					continue;
-				}
-				results.put(parsedKeyId, parsed.get());
-			}
-			return results;
-		} catch (Exception ex) {
-			logGeminiUsage(requestId, "batch", attempt, prompt.length(), null, startedAt, usageAggregate);
-			log.warn("Gemini batch inference attempt failed: {}", ex.getMessage());
-			return Map.of();
 		}
 	}
 
@@ -403,12 +293,6 @@ public class GeminiAssistantService {
 		map.put("recentDailyTokenUsage7d", request.recentDailyTokenUsage7d() != null ? request.recentDailyTokenUsage7d() : List.of());
 		map.put("modelUsageDistribution7d", request.modelUsageDistribution7d() != null ? request.modelUsageDistribution7d() : List.of());
 		map.put("hourlyTokenUsage24h", request.hourlyTokenUsage24h() != null ? request.hourlyTokenUsage24h() : List.of());
-		return map;
-	}
-
-	private Map<String, Object> buildBatchInputMap(BudgetForecastRequest request) {
-		Map<String, Object> map = new LinkedHashMap<>(buildInputMap(request));
-		map.put("keyId", request.keyId());
 		return map;
 	}
 
@@ -546,28 +430,6 @@ public class GeminiAssistantService {
 		}
 		String t = n.asText();
 		return t == null ? null : t;
-	}
-
-	private static Long parseKeyId(JsonNode node) {
-		if (node == null || node.isNull() || node.isMissingNode()) {
-			return null;
-		}
-		if (node.isIntegralNumber()) {
-			return node.asLong();
-		}
-		String raw = node.asText("");
-		if (raw == null) {
-			return null;
-		}
-		String trimmed = raw.trim();
-		if (trimmed.isEmpty()) {
-			return null;
-		}
-		try {
-			return Long.parseLong(trimmed);
-		} catch (NumberFormatException ex) {
-			return null;
-		}
 	}
 
 	private static BigDecimal parseBigDecimalFlexible(JsonNode n) {

--- a/services/agent-service/src/main/java/com/zerobugfreinds/ai_agent_service/service/PolicyRecommendationAgentService.java
+++ b/services/agent-service/src/main/java/com/zerobugfreinds/ai_agent_service/service/PolicyRecommendationAgentService.java
@@ -32,7 +32,6 @@ public class PolicyRecommendationAgentService {
 	private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
 	private static final BigDecimal WARN_THRESHOLD_PERCENT = BigDecimal.valueOf(80);
 	private static final BigDecimal BLOCK_THRESHOLD_PERCENT = BigDecimal.valueOf(100);
-	private static final BigDecimal DEFAULT_CURRENT_MONTHLY_COST_USD = BigDecimal.valueOf(320.00);
 	private static final BigDecimal MILLION = BigDecimal.valueOf(1_000_000);
 	private static final long HIGH_LATENCY_THRESHOLD_MS = 1100L;
 	private static final String RECOMMENDATION_AVAILABLE = "RECOMMENDATION_AVAILABLE";
@@ -108,9 +107,7 @@ public class PolicyRecommendationAgentService {
 		BillingSignalSnapshotService.BillingKeySignal billingSignal =
 				resolveBillingSignal(request.scopeType(), request.scopeId(), request.keyId());
 		UsageProfile usageProfile = buildUsageProfile(request, billingSignal);
-		long totalRequests = usageProfile.totalRequests() > 0
-				? usageProfile.totalRequests()
-				: Math.max(100, request.windowDays() * 140L);
+		long totalRequests = usageProfile.totalRequests();
 		long totalInputTokens = usageProfile.totalInputTokens();
 		long totalOutputTokens = usageProfile.totalOutputTokens();
 		BigDecimal ratio = calculateRatio(totalInputTokens, totalOutputTokens);
@@ -118,9 +115,10 @@ public class PolicyRecommendationAgentService {
 		RecommendationReasonCode reasonCode = resolveReasonCode(request.scopeType(), ratio, averageLatencyMs);
 		RecommendationConfidenceLevel confidenceLevel = usageProfile.confidenceLevel();
 
-		BigDecimal currentMonthlyCost = billingSignal != null && billingSignal.latestEstimatedCostUsd() != null
-				? billingSignal.latestEstimatedCostUsd()
-				: DEFAULT_CURRENT_MONTHLY_COST_USD;
+		if (billingSignal == null || billingSignal.latestEstimatedCostUsd() == null) {
+			throw new IllegalStateException("BILLING_SIGNAL_NOT_AVAILABLE");
+		}
+		BigDecimal currentMonthlyCost = billingSignal.latestEstimatedCostUsd();
 
 		ExternalModelCatalogService.CatalogSnapshot catalogSnapshot = externalModelCatalogService.currentCatalog();
 		List<CandidateCost> rankedCandidates = rankCandidates(
@@ -131,9 +129,51 @@ public class PolicyRecommendationAgentService {
 				reasonCode == RecommendationReasonCode.HIGH_LATENCY
 		);
 		List<CandidateCost> topCandidates = rankedCandidates.stream().limit(3).toList();
-		CandidateCost bestCandidate = topCandidates.isEmpty()
-				? new CandidateCost("UNKNOWN", "fallback-low-cost", currentMonthlyCost, BigDecimal.ZERO, "카탈로그 미연결 fallback", 0, false)
-				: topCandidates.getFirst();
+		if (topCandidates.isEmpty()) {
+			RecommendationQueryResponse noRecommendation = buildNoRecommendationResponse(
+					request.keyId(),
+					request.scopeType(),
+					endAt,
+					request.windowDays(),
+					totalInputTokens,
+					totalOutputTokens,
+					averageLatencyMs,
+					totalRequests
+			);
+			recommendationStore.put(new RecommendationCacheKey(request.scopeType(), request.scopeId(), request.keyId()), noRecommendation);
+			return new OptimizationRecommendationIssuedEvent(
+					UUID.randomUUID().toString(),
+					"OPTIMIZATION_RECOMMENDATION_ISSUED",
+					"v1",
+					endAt,
+					"agent-service",
+					new OptimizationRecommendationIssuedEvent.Tenant(request.scopeType(), request.scopeId()),
+					new OptimizationRecommendationIssuedEvent.Target(request.keyId(), request.scopeType(), null, null),
+					new OptimizationRecommendationIssuedEvent.AnalysisWindow(startAt, endAt, "Asia/Seoul"),
+					new OptimizationRecommendationIssuedEvent.Signals(
+							totalRequests,
+							totalInputTokens,
+							totalOutputTokens,
+							ratio,
+							averageLatencyMs,
+							BigDecimal.valueOf(0.7)
+					),
+					new OptimizationRecommendationIssuedEvent.Recommendation(
+							reasonCode,
+							confidenceLevel,
+							"N/A",
+							List.of(),
+							currentMonthlyCost,
+							currentMonthlyCost,
+							BigDecimal.ZERO,
+							"추천 가능한 모델 후보를 찾을 수 없습니다."
+					),
+					new OptimizationRecommendationIssuedEvent.Delivery(
+							buildDedupeKey(request.scopeType(), request.scopeId(), request.keyId(), reasonCode)
+					)
+			);
+		}
+		CandidateCost bestCandidate = topCandidates.getFirst();
 		BigDecimal recommendedMonthlyCost = bestCandidate.expectedMonthlyCostUsd();
 		BigDecimal estimatedSavingsPct = calculateSavingsPercent(currentMonthlyCost, recommendedMonthlyCost);
 		String primaryModel = bestCandidate.modelName();
@@ -236,18 +276,31 @@ public class PolicyRecommendationAgentService {
 			BillingSignalSnapshotService.BillingKeySignal billingSignal =
 					resolveBillingSignal(request.scopeType(), request.scopeId(), request.keyId());
 			UsageProfile usageProfile = buildUsageProfile(request, billingSignal);
-			long totalRequests = usageProfile.totalRequests() > 0
-					? usageProfile.totalRequests()
-					: Math.max(100, request.windowDays() * 140L);
+			long totalRequests = usageProfile.totalRequests();
 			long totalInputTokens = usageProfile.totalInputTokens();
 			long totalOutputTokens = usageProfile.totalOutputTokens();
 			BigDecimal ratio = calculateRatio(totalInputTokens, totalOutputTokens);
 			Long averageLatencyMs = usageProfile.averageLatencyMs();
 			RecommendationReasonCode reasonCode = resolveReasonCode(request.scopeType(), ratio, averageLatencyMs);
 			RecommendationConfidenceLevel confidenceLevel = usageProfile.confidenceLevel();
-			BigDecimal currentMonthlyCost = billingSignal != null && billingSignal.latestEstimatedCostUsd() != null
-					? billingSignal.latestEstimatedCostUsd()
-					: DEFAULT_CURRENT_MONTHLY_COST_USD;
+			if (billingSignal == null || billingSignal.latestEstimatedCostUsd() == null) {
+				RecommendationQueryResponse noRecommendation = buildNoRecommendationResponse(
+						request.keyId(),
+						request.scopeType(),
+						endAt,
+						request.windowDays(),
+						totalInputTokens,
+						totalOutputTokens,
+						averageLatencyMs,
+						totalRequests
+				);
+				recommendationStore.put(
+						new RecommendationCacheKey(request.scopeType(), request.scopeId(), request.keyId()),
+						noRecommendation
+				);
+				continue;
+			}
+			BigDecimal currentMonthlyCost = billingSignal.latestEstimatedCostUsd();
 			ExternalModelCatalogService.CatalogSnapshot catalogSnapshot = externalModelCatalogService.currentCatalog();
 			List<CandidateCost> rankedCandidates = rankCandidates(
 					currentMonthlyCost,
@@ -257,9 +310,24 @@ public class PolicyRecommendationAgentService {
 					reasonCode == RecommendationReasonCode.HIGH_LATENCY
 			);
 			List<CandidateCost> topCandidates = rankedCandidates.stream().limit(3).toList();
-			CandidateCost bestCandidate = topCandidates.isEmpty()
-					? new CandidateCost("UNKNOWN", "fallback-low-cost", currentMonthlyCost, BigDecimal.ZERO, "카탈로그 미연결 fallback", 0, false)
-					: topCandidates.getFirst();
+			if (topCandidates.isEmpty()) {
+				RecommendationQueryResponse noRecommendation = buildNoRecommendationResponse(
+						request.keyId(),
+						request.scopeType(),
+						endAt,
+						request.windowDays(),
+						totalInputTokens,
+						totalOutputTokens,
+						averageLatencyMs,
+						totalRequests
+				);
+				recommendationStore.put(
+						new RecommendationCacheKey(request.scopeType(), request.scopeId(), request.keyId()),
+						noRecommendation
+				);
+				continue;
+			}
+			CandidateCost bestCandidate = topCandidates.getFirst();
 			BigDecimal recommendedMonthlyCost = bestCandidate.expectedMonthlyCostUsd();
 			BigDecimal estimatedSavingsPct = calculateSavingsPercent(currentMonthlyCost, recommendedMonthlyCost);
 			drafts.add(new BatchDraft(
@@ -298,6 +366,14 @@ public class PolicyRecommendationAgentService {
 		Map<String, RecommendationGeminiService.AiRecommendationResult> overridesByKeyId =
 				recommendationGeminiService.inferRecommendations(promptRequests);
 		Map<String, RecommendationQueryResponse> responses = new LinkedHashMap<>();
+		for (RecommendationAnalyzeRequest request : requests) {
+			RecommendationQueryResponse precomputed = recommendationStore.get(
+					new RecommendationCacheKey(request.scopeType(), request.scopeId(), request.keyId())
+			);
+			if (precomputed != null && RECOMMENDATION_EMPTY.equals(precomputed.status())) {
+				responses.put(request.keyId(), precomputed);
+			}
+		}
 		for (BatchDraft draft : drafts) {
 			RecommendationGeminiService.AiRecommendationResult llmResult = overridesByKeyId.get(draft.request().keyId());
 			GeminiRecommendationOverride llmOverride = llmResult == null
@@ -381,6 +457,32 @@ public class PolicyRecommendationAgentService {
 		return spendUsd
 				.multiply(HUNDRED)
 				.divide(budgetUsd, 2, RoundingMode.HALF_UP);
+	}
+
+	private static RecommendationQueryResponse buildNoRecommendationResponse(
+			String keyId,
+			RecommendationScopeType scopeType,
+			Instant generatedAt,
+			int windowDays,
+			long totalInputTokens,
+			long totalOutputTokens,
+			Long averageLatencyMs,
+			long totalRequests
+	) {
+		return new RecommendationQueryResponse(
+				keyId,
+				scopeType,
+				RECOMMENDATION_EMPTY,
+				generatedAt,
+				new RecommendationQueryResponse.MetricsContext(
+						windowDays,
+						totalInputTokens + totalOutputTokens,
+						totalInputTokens + ":" + totalOutputTokens,
+						averageLatencyMs,
+						totalRequests
+				),
+				null
+		);
 	}
 
 	private static BigDecimal calculateRatio(long inputTokens, long outputTokens) {
@@ -517,8 +619,8 @@ public class PolicyRecommendationAgentService {
 				);
 		if (rollupSummary.totalInputTokens() > 0 || rollupSummary.totalOutputTokens() > 0) {
 			RecommendationConfidenceLevel confidence = rollupSummary.totalRequests() >= 5
-					? RecommendationConfidenceLevel.HIGH
-					: RecommendationConfidenceLevel.MEDIUM;
+					? RecommendationConfidenceLevel.MEDIUM
+					: RecommendationConfidenceLevel.LOW;
 			return new UsageProfile(
 					rollupSummary.totalInputTokens(),
 					rollupSummary.totalOutputTokens(),
@@ -534,7 +636,7 @@ public class PolicyRecommendationAgentService {
 				? dailyTokens
 				: averageDailyTokenUsage.longValue();
 		if (resolvedDailyTokens <= 0) {
-			resolvedDailyTokens = 50_000L + positiveHash(request.keyId()) % 120_000L;
+			resolvedDailyTokens = 1L;
 		}
 
 		PatternProfile profile = resolvePatternProfile(request, billingSignal);
@@ -543,8 +645,8 @@ public class PolicyRecommendationAgentService {
 		long totalOutputTokens = Math.max(1L, totalWindowTokens - totalInputTokens);
 
 		RecommendationConfidenceLevel confidence = dailyTokens > 0 || averageDailyTokenUsage.compareTo(BigDecimal.ZERO) > 0
-				? RecommendationConfidenceLevel.HIGH
-				: RecommendationConfidenceLevel.MEDIUM;
+				? RecommendationConfidenceLevel.MEDIUM
+				: RecommendationConfidenceLevel.LOW;
 		return new UsageProfile(totalInputTokens, totalOutputTokens, profile.avgLatencyMs(), confidence, 0L);
 	}
 

--- a/services/agent-service/src/main/java/com/zerobugfreinds/ai_agent_service/service/RecommendationGeminiService.java
+++ b/services/agent-service/src/main/java/com/zerobugfreinds/ai_agent_service/service/RecommendationGeminiService.java
@@ -75,57 +75,21 @@ public class RecommendationGeminiService {
 		}
 	}
 
+	/**
+	 * Runs one Gemini inference per key so recommendation prompts never mix multiple keys.
+	 */
 	public Map<String, AiRecommendationResult> inferRecommendations(List<AiRecommendationPromptRequest> requests) {
 		if (requests == null || requests.isEmpty()) {
 			return Map.of();
 		}
-		if (properties.apiKey() == null || properties.apiKey().isBlank()) {
-			log.warn("Gemini recommendation batch skipped: API key missing");
-			return Map.of();
-		}
-		String requestId = UUID.randomUUID().toString();
-		UsageAggregate usageAggregate = new UsageAggregate(requestId, "batch");
-		try {
-			String inputJson = objectMapper.writeValueAsString(requests);
-			String prompt = """
-					You are an AI model recommendation assistant for API usage optimization.
-					Return ONLY one raw JSON array.
-					No markdown fences.
-
-					[Input array]
-					%s
-
-					[Rules]
-					- Analyze each item independently.
-					- Preserve every input keyId in output.
-					- Explain recommendation rationale in Korean.
-					- Use one of HIGH, MEDIUM, LOW for confidenceLevel.
-					- Keep reasonMessage concise (<= 2 sentences).
-					- title should be short.
-
-					[Output JSON schema]
-					[
-					  {
-					    "keyId": "string",
-					    "title": "string",
-					    "reasonMessage": "string",
-					    "confidenceLevel": "HIGH|MEDIUM|LOW",
-					    "disclaimer": "string|null"
-					  }
-					]
-					""".formatted(inputJson);
-			Map<String, AiRecommendationResult> primary = inferRecommendationsByPrompt(requestId, 1, prompt, usageAggregate);
-			if (!primary.isEmpty()) {
-				return primary;
+		Map<String, AiRecommendationResult> byKeyId = new LinkedHashMap<>();
+		for (AiRecommendationPromptRequest request : requests) {
+			if (request.keyId() == null || request.keyId().isBlank()) {
+				continue;
 			}
-			String retryPrompt = prompt + "\nDo not omit keyId and required keys. Return valid JSON array only.";
-			return inferRecommendationsByPrompt(requestId, 2, retryPrompt, usageAggregate);
-		} catch (Exception ex) {
-			log.warn("Gemini recommendation batch inference failed: {}", ex.getMessage());
-			return Map.of();
-		} finally {
-			logGeminiUsageSummary(usageAggregate);
+			inferRecommendation(request).ifPresent(result -> byKeyId.put(request.keyId().trim(), result));
 		}
+		return byKeyId;
 	}
 
 	private Optional<AiRecommendationResult> inferRecommendationByPrompt(
@@ -173,67 +137,6 @@ public class RecommendationGeminiService {
 			logGeminiUsage(requestId, keyId, attempt, prompt.length(), null, startedAt, usageAggregate);
 			log.warn("Gemini recommendation attempt failed: {}", ex.getMessage());
 			return Optional.empty();
-		}
-	}
-
-	private Map<String, AiRecommendationResult> inferRecommendationsByPrompt(
-			String requestId,
-			int attempt,
-			String prompt,
-			UsageAggregate usageAggregate
-	) {
-		long startedAt = System.currentTimeMillis();
-		try {
-			String responseBody = callGenerateContent(prompt);
-			if (responseBody == null || responseBody.isBlank()) {
-				logGeminiUsage(requestId, "batch", attempt, prompt.length(), null, startedAt, usageAggregate);
-				return Map.of();
-			}
-			JsonNode root = objectMapper.readTree(responseBody);
-			logGeminiUsage(requestId, "batch", attempt, prompt.length(), root.path("usageMetadata"), startedAt, usageAggregate);
-			JsonNode textNode = root.path("candidates").path(0).path("content").path("parts").path(0).path("text");
-			if (textNode.isMissingNode() || textNode.asText().isBlank()) {
-				return Map.of();
-			}
-			String rawJson = extractJsonPayload(textNode.asText().trim());
-			JsonNode arrayNode = objectMapper.readTree(rawJson);
-			if (!arrayNode.isArray()) {
-				return Map.of();
-			}
-			Map<String, AiRecommendationResult> byKeyId = new LinkedHashMap<>();
-			for (JsonNode recommendation : arrayNode) {
-				String keyId = textOrNull(recommendation.get("keyId"));
-				String title = textOrNull(recommendation.get("title"));
-				String reasonMessage = textOrNull(recommendation.get("reasonMessage"));
-				String confidenceRaw = textOrNull(recommendation.get("confidenceLevel"));
-				String disclaimer = textOrNull(recommendation.get("disclaimer"));
-				if (keyId == null || keyId.isBlank()) {
-					continue;
-				}
-				if (title == null || title.isBlank() || reasonMessage == null || reasonMessage.isBlank() || confidenceRaw == null) {
-					continue;
-				}
-				RecommendationConfidenceLevel confidenceLevel;
-				try {
-					confidenceLevel = RecommendationConfidenceLevel.valueOf(confidenceRaw.trim().toUpperCase());
-				} catch (Exception ex) {
-					continue;
-				}
-				byKeyId.put(
-						keyId.trim(),
-						new AiRecommendationResult(
-								title.trim(),
-								reasonMessage.trim(),
-								confidenceLevel,
-								disclaimer == null || disclaimer.isBlank() ? null : disclaimer.trim()
-						)
-				);
-			}
-			return byKeyId;
-		} catch (Exception ex) {
-			logGeminiUsage(requestId, "batch", attempt, prompt.length(), null, startedAt, usageAggregate);
-			log.warn("Gemini recommendation batch attempt failed: {}", ex.getMessage());
-			return Map.of();
 		}
 	}
 

--- a/services/agent-service/src/test/java/com/zerobugfreinds/ai_agent_service/mq/UsageRecordedEventListenerScopeTest.java
+++ b/services/agent-service/src/test/java/com/zerobugfreinds/ai_agent_service/mq/UsageRecordedEventListenerScopeTest.java
@@ -1,0 +1,134 @@
+package com.zerobugfreinds.ai_agent_service.mq;
+
+import com.eevee.usage.events.AiProvider;
+import com.eevee.usage.events.TokenUsage;
+import com.eevee.usage.events.UsageRecordedEvent;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link UsageRecordedEventListener#resolveScope(UsageRecordedEvent)} 의 분기 보정 검증.
+ *
+ * <p>핵심 회귀 시나리오는 proxy 의 reverse-lookup 경로다. 이 경우 {@code apiKeySource} 가
+ * {@code "team"} 이 아닌 다른 값으로 들어와도 {@code teamApiKeyId}/{@code teamId} 가 채워지므로
+ * scope 은 TEAM 으로 분류되어야 한다. 이 테스트는 이전 구현(=apiKeySource 만 보고 PERSONAL 로 떨어뜨리던
+ * 동작)을 복구하지 못하도록 막는다.</p>
+ */
+class UsageRecordedEventListenerScopeTest {
+
+	@Test
+	void teamSourceWithTeamIdResolvesToTeamScope() {
+		UsageRecordedEvent event = newEvent("user-1", "team-9", "team-key-77", "team");
+
+		UsageRecordedEventListener.ResolvedScope resolved =
+				UsageRecordedEventListener.resolveScope(event);
+
+		assertThat(resolved).isNotNull();
+		assertThat(resolved.scopeType()).isEqualTo("TEAM");
+		assertThat(resolved.scopeId()).isEqualTo("team-9");
+	}
+
+	@Test
+	void reverseLookupSourceWithTeamIdResolvesToTeamScope() {
+		UsageRecordedEvent event = newEvent("user-1", "team-9", "team-key-77", "reverse_lookup");
+
+		UsageRecordedEventListener.ResolvedScope resolved =
+				UsageRecordedEventListener.resolveScope(event);
+
+		assertThat(resolved).isNotNull();
+		assertThat(resolved.scopeType()).isEqualTo("TEAM");
+		assertThat(resolved.scopeId()).isEqualTo("team-9");
+	}
+
+	@Test
+	void teamApiKeyIdWithoutTeamIdStillResolvesToTeamScope() {
+		UsageRecordedEvent event = newEvent("user-1", null, "team-key-77", "reverse_lookup");
+
+		UsageRecordedEventListener.ResolvedScope resolved =
+				UsageRecordedEventListener.resolveScope(event);
+
+		assertThat(resolved).isNotNull();
+		assertThat(resolved.scopeType()).isEqualTo("TEAM");
+		assertThat(resolved.scopeId()).isEqualTo("team-key-77");
+	}
+
+	@Test
+	void managedSourceWithUserIdResolvesToPersonalScope() {
+		UsageRecordedEvent event = newEvent("user-1", null, null, "managed");
+
+		UsageRecordedEventListener.ResolvedScope resolved =
+				UsageRecordedEventListener.resolveScope(event);
+
+		assertThat(resolved).isNotNull();
+		assertThat(resolved.scopeType()).isEqualTo("PERSONAL");
+		assertThat(resolved.scopeId()).isEqualTo("user-1");
+	}
+
+	@Test
+	void teamSourceWithoutAnyTeamIdReturnsNull() {
+		UsageRecordedEvent event = newEvent("user-1", null, null, "team");
+
+		UsageRecordedEventListener.ResolvedScope resolved =
+				UsageRecordedEventListener.resolveScope(event);
+
+		assertThat(resolved).isNull();
+	}
+
+	@Test
+	void blankUserIdAndNoTeamIdentifiersReturnsNull() {
+		UsageRecordedEvent event = newEvent("   ", null, null, "managed");
+
+		UsageRecordedEventListener.ResolvedScope resolved =
+				UsageRecordedEventListener.resolveScope(event);
+
+		assertThat(resolved).isNull();
+	}
+
+	@Test
+	void blankTeamIdentifiersFallBackToPersonalScope() {
+		UsageRecordedEvent event = newEvent("user-1", "  ", "  ", "managed");
+
+		UsageRecordedEventListener.ResolvedScope resolved =
+				UsageRecordedEventListener.resolveScope(event);
+
+		assertThat(resolved).isNotNull();
+		assertThat(resolved.scopeType()).isEqualTo("PERSONAL");
+		assertThat(resolved.scopeId()).isEqualTo("user-1");
+	}
+
+	private static UsageRecordedEvent newEvent(
+			String userId,
+			String teamId,
+			String teamApiKeyId,
+			String apiKeySource
+	) {
+		return new UsageRecordedEvent(
+				UUID.randomUUID(),
+				Instant.now(),
+				"corr-1",
+				userId,
+				"org-1",
+				teamId,
+				"key-1",
+				"alias",
+				teamApiKeyId,
+				"fingerprint",
+				apiKeySource,
+				AiProvider.OPENAI,
+				"gpt-4o",
+				new TokenUsage("gpt-4o", 10L, 5L, 15L, null, null, null, null, null, null),
+				BigDecimal.ZERO,
+				"/v1/chat/completions",
+				"api.openai.com",
+				120L,
+				Boolean.FALSE,
+				Boolean.TRUE,
+				200
+		);
+	}
+}

--- a/services/agent-service/web/src/app/(shell)/agent-key-shared.ts
+++ b/services/agent-service/web/src/app/(shell)/agent-key-shared.ts
@@ -8,6 +8,7 @@ export type AvailableKeyContext = {
   status: string
   budgetStats?: {
     currentSpendUsd: number
+    lifetimeSpendUsd?: number
     remainingBudgetUsd: number
     budgetUsagePercent: number
     isBudgetExceeded: boolean
@@ -32,6 +33,7 @@ export type TeamBoardItem = {
   monthlyBudgetUsd?: number
   budgetStats?: {
     currentSpendUsd: number
+    lifetimeSpendUsd?: number
     remainingBudgetUsd: number
     budgetUsagePercent: number
     isBudgetExceeded: boolean
@@ -60,18 +62,23 @@ export function resolveTargetKeys(
   if (scope === "PERSONAL") {
     return keys
   }
-  return selectedTeamKeys.map((item: TeamBoardItem) => ({
+  return selectedTeamKeys.map((item: TeamBoardItem) => teamBoardItemToAvailableKeyContext(item))
+}
+
+export function teamBoardItemToAvailableKeyContext(item: TeamBoardItem): AvailableKeyContext {
+  return {
     keyId: item.teamApiKeyId,
     teamIdForBilling: item.teamId,
     keyLabel: item.alias,
     provider: item.provider,
     monthlyBudgetUsd: item.monthlyBudgetUsd ?? 0,
     status: item.status,
+    budgetStats: item.budgetStats,
     providerStats: item.providerStats ?? {
       currentSpendUsd: 0,
       averageDailySpendUsd: 0,
       averageDailyTokenUsage: 0,
       recentDailySpendUsd: [],
     },
-  }))
+  }
 }

--- a/services/agent-service/web/src/app/(shell)/analysis-flow.ts
+++ b/services/agent-service/web/src/app/(shell)/analysis-flow.ts
@@ -27,10 +27,13 @@ export async function runBudgetAnalysisFlow(params: {
     setLoadingMessage,
   } = params
   const nextResults: AnalysisResult[] = []
+  const primaryLabel = targetKeys[0]?.keyLabel ?? ""
   setLoadingMessage(
-    scope === "PERSONAL"
-      ? `개인 API 키 사용량을 배치 분석 중입니다... (1/${targetKeys.length})`
-      : `${selectedTeamLabel || `Team ${selectedTeamId}`} 키 사용량을 배치 분석 중입니다... (1/${targetKeys.length})`,
+    targetKeys.length === 1
+      ? `${primaryLabel} 예산·사용량 분석 중...`
+      : scope === "PERSONAL"
+        ? `개인 API 키 사용량을 배치 분석 중입니다... (1/${targetKeys.length})`
+        : `${selectedTeamLabel || `Team ${selectedTeamId}`} 키 사용량을 배치 분석 중입니다... (1/${targetKeys.length})`,
   )
   if (scope === "PERSONAL" && currentUserId == null) {
     return targetKeys.map((keyItem) => ({
@@ -51,43 +54,65 @@ export async function runBudgetAnalysisFlow(params: {
   }
   const forecastByKeyId: Record<number, ForecastInput> = {}
   const billingCycleByKeyId: Record<number, string> = {}
+  const analyzableKeys: AvailableKeyContext[] = []
+  const resultByKeyId: Record<number, AnalysisResult> = {}
   for (const keyItem of targetKeys) {
+    const forecast = resolveForecastInputs(keyItem.providerStats, keyItem.monthlyBudgetUsd)
+    if (forecast.insufficientForForecast) {
+      resultByKeyId[keyItem.keyId] = {
+        keyId: keyItem.keyId,
+        keyLabel: keyItem.keyLabel,
+        provider: keyItem.provider,
+        forecastGaps: forecast.gaps.length > 0 ? forecast.gaps : undefined,
+        error: "사용량 데이터가 없어 소진 예측을 계산할 수 없습니다.",
+      }
+      continue
+    }
     const resolvedTeamIdNumber = Number(resolvedTeamId ?? 0)
     const billingLedgerKey =
       scope === "PERSONAL" ? personalLedgerKey(keyItem.keyId) : teamLedgerKey(resolvedTeamIdNumber, keyItem.keyId)
+    analyzableKeys.push(keyItem)
     billingCycleByKeyId[keyItem.keyId] = (billingByLedgerKey[billingLedgerKey] ?? "").trim()
-    forecastByKeyId[keyItem.keyId] = resolveForecastInputs(keyItem.providerStats, keyItem.monthlyBudgetUsd)
+    forecastByKeyId[keyItem.keyId] = forecast
   }
-  try {
-    const forecastResultByKeyId = await requestBudgetForecastBatch({
-      scope,
-      keyItems: targetKeys,
-      currentUserId,
-      resolvedTeamId: resolvedTeamId == null ? null : Number(resolvedTeamId),
-      forecastByKeyId,
-      billingCycleByKeyId,
-    })
-    for (const keyItem of targetKeys) {
-      const forecast = forecastByKeyId[keyItem.keyId]
-      const data = forecastResultByKeyId[keyItem.keyId]
-      nextResults.push({
-        keyId: keyItem.keyId,
-        keyLabel: keyItem.keyLabel,
-        provider: keyItem.provider,
-        data,
-        forecastGaps: forecast.gaps.length > 0 ? forecast.gaps : undefined,
-        error: data == null ? "분석 결과를 찾을 수 없습니다." : undefined,
+  if (analyzableKeys.length > 0) {
+    try {
+      const forecastResultByKeyId = await requestBudgetForecastBatch({
+        scope,
+        keyItems: analyzableKeys,
+        currentUserId,
+        resolvedTeamId: resolvedTeamId == null ? null : Number(resolvedTeamId),
+        forecastByKeyId,
+        billingCycleByKeyId,
       })
+      for (const keyItem of analyzableKeys) {
+        const forecast = forecastByKeyId[keyItem.keyId]
+        const data = forecastResultByKeyId[keyItem.keyId]
+        resultByKeyId[keyItem.keyId] = {
+          keyId: keyItem.keyId,
+          keyLabel: keyItem.keyLabel,
+          provider: keyItem.provider,
+          data,
+          forecastGaps: forecast.gaps.length > 0 ? forecast.gaps : undefined,
+          error: data == null ? "분석 결과를 찾을 수 없습니다." : undefined,
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "분석 요청 실패"
+      for (const keyItem of analyzableKeys) {
+        resultByKeyId[keyItem.keyId] = {
+          keyId: keyItem.keyId,
+          keyLabel: keyItem.keyLabel,
+          provider: keyItem.provider,
+          error: message,
+        }
+      }
     }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "분석 요청 실패"
-    for (const keyItem of targetKeys) {
-      nextResults.push({
-        keyId: keyItem.keyId,
-        keyLabel: keyItem.keyLabel,
-        provider: keyItem.provider,
-        error: message,
-      })
+  }
+  for (const keyItem of targetKeys) {
+    const result = resultByKeyId[keyItem.keyId]
+    if (result) {
+      nextResults.push(result)
     }
   }
   return nextResults

--- a/services/agent-service/web/src/app/(shell)/analysis-service.ts
+++ b/services/agent-service/web/src/app/(shell)/analysis-service.ts
@@ -27,6 +27,7 @@ export type ForecastInput = {
   modelUsageDistribution7d: Array<{ model: string; percentage: number }>
   hourlyTokenUsage24h: number[]
   gaps: string[]
+  insufficientForForecast: boolean
 }
 
 type BudgetForecastBatchResponse = {

--- a/services/agent-service/web/src/app/(shell)/page.tsx
+++ b/services/agent-service/web/src/app/(shell)/page.tsx
@@ -6,13 +6,19 @@ import {
   type AvailableKeyContext,
   type TeamBoardItem,
   type TeamGroup,
-  resolveTargetKeys,
+  teamBoardItemToAvailableKeyContext,
 } from "./agent-key-shared"
 import type { AnalysisResult } from "./agent-result-shared"
 import { runBudgetAnalysisFlow } from "./analysis-flow"
 import { runRecommendationFlow } from "./recommendation-flow"
 
 type AnalysisAction = "ANALYSIS" | "RECOMMENDATION"
+
+type LoadingTarget = {
+  scope: AnalysisScope
+  keyId: number
+  action: AnalysisAction
+}
 
 type ModelCatalogSnapshot = {
   source: string
@@ -105,6 +111,7 @@ type AvailableContextKeyPayload = {
   status: string
   budgetStats?: {
     currentSpendUsd: number
+    lifetimeSpendUsd?: number
     remainingBudgetUsd: number
     budgetUsagePercent: number
     isBudgetExceeded: boolean
@@ -129,6 +136,65 @@ function formatBillingMetric(value: number | null | undefined): string {
     return "표시 불가 — 결제일 미입력"
   }
   return `${value}일`
+}
+
+/** 과금 웹 `formatUsd`와 동일 규칙(소액 4자리, 미만은 임계 라벨). */
+function formatAgentUsd(value: number): string {
+  if (!Number.isFinite(value)) {
+    return "—"
+  }
+  const decimals = 4
+  const minLabel = 0.0001
+  if (value > 0 && value < minLabel) {
+    return `<$${minLabel.toFixed(decimals)}`
+  }
+  return `$${value.toFixed(decimals)}`
+}
+
+function AgentKeyBudgetSummary({
+  monthlyBudgetUsd,
+  budgetStats,
+}: {
+  monthlyBudgetUsd: number
+  budgetStats?: AvailableKeyContext["budgetStats"]
+}) {
+  const monthSpend = budgetStats?.currentSpendUsd ?? 0
+  const lifetimeSpend = budgetStats?.lifetimeSpendUsd ?? 0
+  const monthly = Number.isFinite(monthlyBudgetUsd) ? monthlyBudgetUsd : 0
+  const remaining = budgetStats?.remainingBudgetUsd ?? Math.max(0, monthly - monthSpend)
+  const pct =
+    budgetStats?.budgetUsagePercent ??
+    (monthly > 0 && Number.isFinite(monthSpend) ? (monthSpend / monthly) * 100 : 0)
+
+  if (monthly <= 0) {
+    return (
+      <div className="space-y-0.5 text-xs text-muted-foreground">
+        <p className="leading-snug">
+          누적 지출(최근 400일) {formatAgentUsd(lifetimeSpend)}
+          <span className="text-[10px] text-muted-foreground"> · 월 예산 미설정</span>
+        </p>
+        <p className="text-[10px] leading-snug">
+          당월 지출 {formatAgentUsd(monthSpend)} (진행률·잔여는 월 예산이 있을 때만 계산)
+        </p>
+        <p className="text-[10px] leading-snug">월 예산은 identity·과금 요약에 값이 있으면 여기에도 맞춰집니다.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-0.5 text-xs text-muted-foreground">
+      <p className="leading-snug">
+        누적 지출(최근 400일) {formatAgentUsd(lifetimeSpend)} / 월 예산 ${monthly.toFixed(2)} (당월 잔여 ${remaining.toFixed(2)})
+      </p>
+      <p className="text-[10px] leading-snug text-muted-foreground">
+        당월 지출 {formatAgentUsd(monthSpend)} · 진행률은 당월 기준
+      </p>
+      <div className="flex items-center justify-between gap-2 text-[11px]">
+        <span className="text-muted-foreground">진행률(당월)</span>
+        <span className="tabular-nums font-medium text-foreground">{pct.toFixed(1)}%</span>
+      </div>
+    </div>
+  )
 }
 
 const MANUAL_BILLING_STORAGE_PREFIX = "agent.manualBillingCycleEnd."
@@ -210,20 +276,28 @@ function resolveForecastInputs(
   modelUsageDistribution7d: Array<{ model: string; percentage: number }>
   hourlyTokenUsage24h: number[]
   gaps: string[]
-  sufficientForForecast: boolean
+  insufficientForForecast: boolean
 } {
   const gaps: string[] = []
   const spendFromPrediction = stats.averageDailySpendUsd
   const tokensFromPrediction = stats.averageDailyTokenUsage
   const billedSpend = stats.currentSpendUsd
+  const recentDailySpendUsd = (stats.recentDailySpendUsd ?? [])
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value) && value >= 0)
+    .slice(-7)
+  const hasUsageEvidence =
+    spendFromPrediction > 0 || tokensFromPrediction > 0 || billedSpend > 0 || recentDailySpendUsd.some((value) => value > 0)
+  const insufficientForForecast = !hasUsageEvidence
+  if (insufficientForForecast) {
+    gaps.push("사용량 이벤트가 없어 소진 예측을 계산할 수 없습니다. 키를 사용한 뒤 다시 시도해 주세요.")
+  }
 
   let averageDailySpendUsd = spendFromPrediction
   if (averageDailySpendUsd <= 0 && billedSpend > 0) {
     averageDailySpendUsd = billedSpend / 7
-  } else if (averageDailySpendUsd <= 0 && billedSpend <= 0 && monthlyBudgetUsd > 0) {
-    averageDailySpendUsd = monthlyBudgetUsd / 30
   } else if (averageDailySpendUsd <= 0) {
-    averageDailySpendUsd = 0.01
+    averageDailySpendUsd = 0.000001
   }
 
   const averageDailyTokenUsage = tokensFromPrediction > 0 ? tokensFromPrediction : 1
@@ -231,11 +305,6 @@ function resolveForecastInputs(
   const estimatedDaysByBudget =
     averageDailySpendUsd > 0 ? Math.max(remainingBudgetUsd / averageDailySpendUsd, 0) : 0
   const remainingTokens = Math.max(Math.round(averageDailyTokenUsage * estimatedDaysByBudget), 1)
-
-  const recentDailySpendUsd = (stats.recentDailySpendUsd ?? [])
-    .map((value) => Number(value))
-    .filter((value) => Number.isFinite(value) && value >= 0)
-    .slice(-7)
 
   const recentDailyTokenUsage7d = Array.from({ length: 7 }, (_, index) => {
     const spend = recentDailySpendUsd[index] ?? averageDailySpendUsd
@@ -252,8 +321,6 @@ function resolveForecastInputs(
     return Math.max(0, Math.round((averageDailyTokenUsage / 24) * multiplier))
   })
 
-  const sufficientForForecast = true
-
   return {
     averageDailySpendUsd,
     averageDailyTokenUsage,
@@ -263,7 +330,7 @@ function resolveForecastInputs(
     modelUsageDistribution7d,
     hourlyTokenUsage24h,
     gaps,
-    sufficientForForecast,
+    insufficientForForecast,
   }
 }
 
@@ -296,7 +363,7 @@ function localizeAssistantMessage(message: string): string {
 }
 
 export default function AgentPage() {
-  const [loadingAction, setLoadingAction] = useState<AnalysisAction | null>(null)
+  const [loadingTarget, setLoadingTarget] = useState<LoadingTarget | null>(null)
   const [loadingMessage, setLoadingMessage] = useState<string>("")
   const [results, setResults] = useState<AnalysisResult[]>([])
   const [keys, setKeys] = useState<AvailableKeyContext[]>([])
@@ -308,6 +375,7 @@ export default function AgentPage() {
   const [currentUserId, setCurrentUserId] = useState<number | null>(null)
   const [modelCatalog, setModelCatalog] = useState<ModelCatalogSnapshot | null>(null)
   const [resultsHydrated, setResultsHydrated] = useState<boolean>(false)
+  const [contextRefreshing, setContextRefreshing] = useState<boolean>(false)
   const modelCatalogStats = useMemo(() => {
     if (!modelCatalog) return null
     const activeModels = modelCatalog.models.filter((model: ModelCatalogSnapshot["models"][number]) => {
@@ -427,14 +495,31 @@ export default function AgentPage() {
     }
   }
 
-  const runAnalysis = async (scope: AnalysisScope, action: AnalysisAction) => {
+  const refreshAvailableContext = async () => {
+    if (contextRefreshing) {
+      return
+    }
+    setContextRefreshing(true)
+    try {
+      await loadAvailableContext()
+    } finally {
+      setContextRefreshing(false)
+    }
+  }
+
+  const runAnalysisForKey = async (scope: AnalysisScope, targetKey: AvailableKeyContext, action: AnalysisAction) => {
     if (scope === "TEAM" && selectedTeamId == null) {
       return
     }
-    const targetKeys: AvailableKeyContext[] = resolveTargetKeys(scope, keys, selectedTeamKeys)
-    if (targetKeys.length === 0) return
+    const targetKeys: AvailableKeyContext[] = [targetKey]
+    const teamIdForFlow =
+      scope === "TEAM" ? (targetKey.teamIdForBilling ?? selectedTeamId) : selectedTeamId
+    const teamLabelForFlow =
+      scope === "TEAM"
+        ? teamGroups.find((group: TeamGroup) => group.teamId === teamIdForFlow)?.teamName ?? selectedTeamLabel
+        : selectedTeamLabel
 
-    setLoadingAction(action)
+    setLoadingTarget({ scope, keyId: targetKey.keyId, action })
     try {
       const nextResults =
         action === "ANALYSIS"
@@ -442,8 +527,8 @@ export default function AgentPage() {
               scope,
               targetKeys,
               currentUserId,
-              selectedTeamId,
-              selectedTeamLabel,
+              selectedTeamId: teamIdForFlow,
+              selectedTeamLabel: teamLabelForFlow,
               billingByLedgerKey,
               personalLedgerKey: ledgerKeyPersonal,
               teamLedgerKey: ledgerKeyTeam,
@@ -454,24 +539,70 @@ export default function AgentPage() {
               scope,
               targetKeys,
               currentUserId,
-              selectedTeamId,
-              selectedTeamLabel,
+              selectedTeamId: teamIdForFlow,
+              selectedTeamLabel: teamLabelForFlow,
               setLoadingMessage,
             })
 
-      // 버튼을 누를 때마다 해당 요청 결과만 화면에 표시한다 (이전 결과는 보관하지 않음).
-      setResults(nextResults)
+      const nextResult = nextResults[0]
+      if (nextResult) {
+        setResults((prev: AnalysisResult[]) => {
+          const previous = prev.find((item: AnalysisResult) => item.keyId === nextResult.keyId)
+          if (!previous) {
+            return [nextResult]
+          }
+          const merged: AnalysisResult = {
+            ...previous,
+            ...nextResult,
+            data: nextResult.data ?? previous.data,
+            recommendation: nextResult.recommendation ?? previous.recommendation,
+            forecastGaps: nextResult.forecastGaps ?? previous.forecastGaps,
+          }
+          return [merged]
+        })
+      }
     } finally {
-      setLoadingAction(null)
+      setLoadingTarget(null)
       setLoadingMessage("")
     }
   }
 
+  const isRowLoading = (scope: AnalysisScope, keyId: number, action: AnalysisAction): boolean =>
+    loadingTarget?.scope === scope && loadingTarget.keyId === keyId && loadingTarget.action === action
+
+  const isAnyLoading = loadingTarget != null
+  const contextActionsDisabled = contextRefreshing || isAnyLoading
+
   return (
     <div className="grid min-h-[70vh] gap-4 p-4 md:grid-cols-12">
       <aside className="space-y-4 rounded-xl border bg-card p-4 md:col-span-3">
+        {isAnyLoading ? (
+          <div
+            className="rounded-lg border border-primary/30 bg-primary/5 px-3 py-2 text-xs shadow-sm"
+            role="status"
+            aria-live="polite"
+          >
+            <p className="font-semibold text-foreground">
+              {loadingTarget?.action === "ANALYSIS" ? "예산·사용량 분석 중" : "모델 추천 분석 중"}
+            </p>
+            <p className="mt-1 text-[11px] leading-snug text-muted-foreground">
+              {loadingMessage || "잠시만 기다려 주세요. 완료되면 오른쪽에 결과가 표시됩니다."}
+            </p>
+          </div>
+        ) : null}
+
         <div className="space-y-2">
-          <h3 className="text-sm font-semibold">개인 API 키</h3>
+          <div className="flex items-center justify-between gap-2">
+            <h3 className="text-sm font-semibold">개인 API 키</h3>
+            <button
+              type="button"
+              className="shrink-0 rounded-md border border-border bg-background px-2 py-1 text-[11px] font-medium text-foreground hover:bg-muted/60 disabled:opacity-60"
+              disabled={contextActionsDisabled}
+              onClick={() => void refreshAvailableContext()}
+            >
+              {contextRefreshing ? "불러오는 중…" : "목록 새로고침"}
+            </button>
+          </div>
           <p className="text-[11px] leading-snug text-muted-foreground">
             키마다 콘솔의 다음 결제·청구일을 넣으면 해당 키 예측에만 반영됩니다. 이 브라우저에만 저장됩니다.
           </p>
@@ -483,18 +614,28 @@ export default function AgentPage() {
               <li key={item.keyId} className="rounded-md border px-2 py-1">
                 {item.keyLabel}
                 <span className="text-xs"> ({item.provider})</span>
-                <div className="text-xs text-muted-foreground">
-                  예산 ${((item.budgetStats?.remainingBudgetUsd ?? item.monthlyBudgetUsd) || 0).toFixed(2)} / 사용률{" "}
-                  {((item.budgetStats?.budgetUsagePercent ?? 0) || 0).toFixed(1)}%
-                </div>
+                <AgentKeyBudgetSummary monthlyBudgetUsd={item.monthlyBudgetUsd} budgetStats={item.budgetStats} />
                 <div className="mt-1 flex flex-col gap-1 border-t border-border/60 pt-1">
-                  <label className="text-[11px] text-muted-foreground" htmlFor={`billing-p-${item.keyId}`}>
-                    다음 결제일
-                  </label>
+                  <div className="flex items-center justify-between gap-2">
+                    <label className="text-[11px] text-muted-foreground" htmlFor={`billing-p-${item.keyId}`}>
+                      다음 결제일
+                    </label>
+                    <span
+                      className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                        (billingByLedgerKey[ledgerKeyPersonal(item.keyId)] ?? "").trim()
+                          ? "bg-emerald-100 text-emerald-800"
+                          : "bg-muted text-muted-foreground"
+                      }`}
+                    >
+                      {(billingByLedgerKey[ledgerKeyPersonal(item.keyId)] ?? "").trim() ? "선택됨" : "미선택"}
+                    </span>
+                  </div>
                   <div className="flex flex-wrap items-center gap-1">
                     <input
                       id={`billing-p-${item.keyId}`}
                       type="date"
+                      title="달력에서 결제일 선택"
+                      aria-label={`${item.keyLabel} 다음 결제일 선택`}
                       className="min-w-0 flex-1 rounded border bg-background px-1 py-0.5 text-xs"
                       value={billingByLedgerKey[ledgerKeyPersonal(item.keyId)] ?? ""}
                       onChange={(event: ChangeEvent<HTMLInputElement>) => {
@@ -518,6 +659,24 @@ export default function AgentPage() {
                       </button>
                     ) : null}
                   </div>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  <button
+                    type="button"
+                    className="rounded-md bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-60"
+                    disabled={isAnyLoading}
+                    onClick={() => void runAnalysisForKey("PERSONAL", item, "ANALYSIS")}
+                  >
+                    {isRowLoading("PERSONAL", item.keyId, "ANALYSIS") ? "분석 중..." : "분석"}
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-md border border-border bg-background px-2 py-1 text-[11px] font-medium disabled:opacity-60"
+                    disabled={isAnyLoading}
+                    onClick={() => void runAnalysisForKey("PERSONAL", item, "RECOMMENDATION")}
+                  >
+                    {isRowLoading("PERSONAL", item.keyId, "RECOMMENDATION") ? "추천 중..." : "추천"}
+                  </button>
                 </div>
               </li>
             ))}
@@ -563,21 +722,36 @@ export default function AgentPage() {
               {selectedTeamKeys.map((item: TeamBoardItem) => (
                 <li key={`${item.teamId}-${item.teamApiKeyId}`} className="rounded-md border px-2 py-1">
                   {item.alias}
-                  <div className="text-xs text-muted-foreground">
-                    예산 ${((item.budgetStats?.remainingBudgetUsd ?? item.monthlyBudgetUsd ?? 0) || 0).toFixed(2)} / 사용률{" "}
-                    {((item.budgetStats?.budgetUsagePercent ?? 0) || 0).toFixed(1)}%
-                  </div>
+                  <AgentKeyBudgetSummary
+                    monthlyBudgetUsd={item.monthlyBudgetUsd ?? 0}
+                    budgetStats={item.budgetStats}
+                  />
                   <div className="mt-1 flex flex-col gap-1 border-t border-border/60 pt-1">
-                    <label
-                      className="text-[11px] text-muted-foreground"
-                      htmlFor={`billing-t-${item.teamId}-${item.teamApiKeyId}`}
-                    >
-                      다음 결제일
-                    </label>
+                    <div className="flex items-center justify-between gap-2">
+                      <label
+                        className="text-[11px] text-muted-foreground"
+                        htmlFor={`billing-t-${item.teamId}-${item.teamApiKeyId}`}
+                      >
+                        다음 결제일
+                      </label>
+                      <span
+                        className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                          (billingByLedgerKey[ledgerKeyTeam(item.teamId, item.teamApiKeyId)] ?? "").trim()
+                            ? "bg-emerald-100 text-emerald-800"
+                            : "bg-muted text-muted-foreground"
+                        }`}
+                      >
+                        {(billingByLedgerKey[ledgerKeyTeam(item.teamId, item.teamApiKeyId)] ?? "").trim()
+                          ? "선택됨"
+                          : "미선택"}
+                      </span>
+                    </div>
                     <div className="flex flex-wrap items-center gap-1">
                       <input
                         id={`billing-t-${item.teamId}-${item.teamApiKeyId}`}
                         type="date"
+                        title="달력에서 결제일 선택"
+                        aria-label={`${item.alias} 다음 결제일 선택`}
                         className="min-w-0 flex-1 rounded border bg-background px-1 py-0.5 text-xs"
                         value={billingByLedgerKey[ledgerKeyTeam(item.teamId, item.teamApiKeyId)] ?? ""}
                         onChange={(event: ChangeEvent<HTMLInputElement>) => {
@@ -602,6 +776,26 @@ export default function AgentPage() {
                       ) : null}
                     </div>
                   </div>
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    <button
+                      type="button"
+                      className="rounded-md bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-60"
+                      disabled={isAnyLoading}
+                      onClick={() => void runAnalysisForKey("TEAM", teamBoardItemToAvailableKeyContext(item), "ANALYSIS")}
+                    >
+                      {isRowLoading("TEAM", item.teamApiKeyId, "ANALYSIS") ? "분석 중..." : "분석"}
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-md border border-border bg-background px-2 py-1 text-[11px] font-medium disabled:opacity-60"
+                      disabled={isAnyLoading}
+                      onClick={() =>
+                        void runAnalysisForKey("TEAM", teamBoardItemToAvailableKeyContext(item), "RECOMMENDATION")
+                      }
+                    >
+                      {isRowLoading("TEAM", item.teamApiKeyId, "RECOMMENDATION") ? "추천 중..." : "추천"}
+                    </button>
+                  </div>
                 </li>
               ))}
               {selectedTeamId != null && selectedTeamKeys.length === 0 ? (
@@ -619,46 +813,15 @@ export default function AgentPage() {
           )}
         </div>
 
-        <div className="grid gap-2">
-          <div className="grid grid-cols-2 gap-2">
-            <button
-              type="button"
-              className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
-              onClick={() => void runAnalysis("PERSONAL", "ANALYSIS")}
-              disabled={loadingAction != null || keys.length === 0}
-            >
-              {loadingAction === "ANALYSIS" ? "분석 로딩..." : "개인 키 분석"}
-            </button>
-            <button
-              type="button"
-              className="w-full rounded-md border bg-background px-4 py-2 text-sm font-medium disabled:opacity-60"
-              onClick={() => void runAnalysis("PERSONAL", "RECOMMENDATION")}
-              disabled={loadingAction != null || keys.length === 0}
-            >
-              {loadingAction === "RECOMMENDATION" ? "추천 로딩..." : "개인 키 추천"}
-            </button>
-          </div>
-          <div className="grid grid-cols-2 gap-2">
-            <button
-              type="button"
-              className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
-              onClick={() => void runAnalysis("TEAM", "ANALYSIS")}
-              disabled={loadingAction != null || selectedTeamId == null || selectedTeamKeys.length === 0}
-            >
-              {loadingAction === "ANALYSIS" ? "분석 로딩..." : "팀 키 분석"}
-            </button>
-            <button
-              type="button"
-              className="w-full rounded-md border bg-background px-4 py-2 text-sm font-medium disabled:opacity-60"
-              onClick={() => void runAnalysis("TEAM", "RECOMMENDATION")}
-              disabled={loadingAction != null || selectedTeamId == null || selectedTeamKeys.length === 0}
-            >
-              {loadingAction === "RECOMMENDATION" ? "추천 로딩..." : "팀 키 추천"}
-            </button>
-          </div>
-        </div>
         <div className="rounded-md border border-dashed bg-muted/30 px-2 py-1.5 text-xs text-muted-foreground">
-          분석/추천 버튼은 각각 해당 요청만 호출합니다.
+          <p>각 키의 분석·추천은 해당 키의 데이터만 AI 요청에 포함합니다.</p>
+          <p className="mt-1 text-[11px] leading-snug">
+            <span className="font-medium">누적 지출(최근 400일)</span>은 billing `summary(from,to)`를 활용한 최근 400일 합입니다.{" "}
+            <span className="font-medium">당월 지출·진행률·잔여</span>는{" "}
+            <span className="font-medium">월 1일~오늘</span>과 동일한 방식으로, 요약·스냅샷을 합친 값입니다.
+            과금 서비스가 오래되면 누적 API가 없을 수 있으니 배포를 맞추고, 숫자가 비면{" "}
+            <span className="font-medium">목록 새로고침</span>을 눌러 보세요.
+          </p>
         </div>
         {modelCatalog ? (
           <div className="rounded-md border border-dashed bg-muted/30 p-2 text-xs text-muted-foreground">
@@ -709,7 +872,7 @@ export default function AgentPage() {
                 <div className="grid gap-3 lg:grid-cols-2">
                   <div className="space-y-2 rounded-md border border-dashed bg-muted/20 p-3 lg:order-2">
                     <p className="text-xs font-medium text-muted-foreground">모델 추천</p>
-                    {loadingAction === "RECOMMENDATION" ? (
+                    {loadingTarget?.keyId === result.keyId && loadingTarget.action === "RECOMMENDATION" ? (
                       <div className="rounded-md border bg-background p-3 text-xs text-muted-foreground">
                         {loadingMessage || "추천 로딩 중..."}
                       </div>
@@ -821,14 +984,25 @@ export default function AgentPage() {
                           ))}
                         </ul>
                       </div>
+                    ) : result.recommendation?.status === "NO_RECOMMENDATION" ? (
+                      <div className="rounded-md border border-dashed bg-background p-3 text-xs text-muted-foreground">
+                        <p>추천 생성 조건을 만족하지 않아 결과가 비어 있습니다.</p>
+                        <p className="mt-1">
+                          생성 시각:{" "}
+                          {result.recommendation.generatedAt
+                            ? new Date(result.recommendation.generatedAt).toLocaleString()
+                            : "N/A"}
+                        </p>
+                        <p className="mt-1">과금 신호/토큰 지표가 쌓인 뒤 다시 시도해 주세요.</p>
+                      </div>
                     ) : (
-                      <p className="text-xs text-muted-foreground">추천 결과가 없습니다. 상단의 추천 버튼을 눌러주세요.</p>
+                      <p className="text-xs text-muted-foreground">추천 결과가 없습니다. 해당 키 옆의 추천을 눌러 주세요.</p>
                     )}
                   </div>
 
                   <div className="space-y-2 rounded-md border border-dashed bg-muted/20 p-3 lg:order-1">
                     <p className="text-xs font-medium text-muted-foreground">예산 분석</p>
-                    {loadingAction === "ANALYSIS" ? (
+                    {loadingTarget?.keyId === result.keyId && loadingTarget.action === "ANALYSIS" ? (
                       <div className="rounded-md border bg-background p-3 text-xs text-muted-foreground">
                         {loadingMessage || "분석 로딩 중..."}
                       </div>
@@ -889,7 +1063,7 @@ export default function AgentPage() {
                         </ul>
                       </>
                     ) : (
-                      <p className="text-xs text-muted-foreground">분석 결과가 없습니다. 상단의 분석 버튼을 눌러주세요.</p>
+                      <p className="text-xs text-muted-foreground">분석 결과가 없습니다. 해당 키 옆의 분석을 눌러 주세요.</p>
                     )}
                   </div>
                 </div>

--- a/services/agent-service/web/src/app/(shell)/recommendation-flow.ts
+++ b/services/agent-service/web/src/app/(shell)/recommendation-flow.ts
@@ -12,10 +12,13 @@ export async function runRecommendationFlow(params: {
 }): Promise<AnalysisResult[]> {
   const { scope, targetKeys, currentUserId, selectedTeamId, selectedTeamLabel, setLoadingMessage } = params
   const nextResults: AnalysisResult[] = []
+  const primaryLabel = targetKeys[0]?.keyLabel ?? ""
   setLoadingMessage(
-    scope === "PERSONAL"
-      ? `개인 API 키 모델 추천을 배치 분석 중입니다... (1/${targetKeys.length})`
-      : `${selectedTeamLabel || `Team ${selectedTeamId}`} 키 모델 추천을 배치 분석 중입니다... (1/${targetKeys.length})`,
+    targetKeys.length === 1
+      ? `${primaryLabel} 모델 추천 분석 중...`
+      : scope === "PERSONAL"
+        ? `개인 API 키 모델 추천을 배치 분석 중입니다... (1/${targetKeys.length})`
+        : `${selectedTeamLabel || `Team ${selectedTeamId}`} 키 모델 추천을 배치 분석 중입니다... (1/${targetKeys.length})`,
   )
   if (scope === "PERSONAL" && currentUserId == null) {
     return targetKeys.map((keyItem) => ({

--- a/services/agent-service/web/src/app/api/v1/agents/available-context/route.ts
+++ b/services/agent-service/web/src/app/api/v1/agents/available-context/route.ts
@@ -44,7 +44,10 @@ type DailyCumulativeTokenSignal = {
 }
 
 type BudgetStats = {
+  /** 서울 달력 당월 1일~오늘 과금 요약(월 예산·진행률·잔여 계산용). */
   currentSpendUsd: number
+  /** `daily_expenditure_agg` 전 기간 합(표시용 누적 지출). */
+  lifetimeSpendUsd: number
   remainingBudgetUsd: number
   budgetUsagePercent: number
   isBudgetExceeded: boolean
@@ -201,11 +204,12 @@ async function fetchWithTimeout(url: string, timeoutMs: number, init?: RequestIn
   }
 }
 
-function buildForwardHeaders(request: Request, email: string | null): HeadersInit {
+function buildForwardHeaders(request: Request, email: string | null, fallbackUserId?: string): HeadersInit {
   const headers: HeadersInit = {}
   const authorization = request.headers.get("authorization")?.trim() ?? ""
   const cookie = request.headers.get("cookie")?.trim() ?? ""
-  const userId = userIdFromHeaders(request).trim()
+  const userIdFromRequest = userIdFromHeaders(request).trim()
+  const userId = userIdFromRequest.length > 0 ? userIdFromRequest : (fallbackUserId ?? "").trim()
 
   if (authorization.length > 0) {
     headers.Authorization = authorization
@@ -213,6 +217,23 @@ function buildForwardHeaders(request: Request, email: string | null): HeadersIni
   if (cookie.length > 0) {
     headers.Cookie = cookie
   }
+  if (userId.length > 0) {
+    headers["x-user-id"] = userId
+  }
+  if (email && email.trim().length > 0) {
+    headers["x-user-email"] = email.trim()
+  }
+  return headers
+}
+
+/**
+ * Billing 내부 호출은 사용자 식별 헤더만 전달한다.
+ * 브라우저 cookie/authorization 전달로 사용자 컨텍스트가 뒤집히는 문제를 방지한다.
+ */
+function buildBillingForwardHeaders(request: Request, email: string | null, fallbackUserId?: string): Record<string, string> {
+  const headers: Record<string, string> = {}
+  const userIdFromRequest = userIdFromHeaders(request).trim()
+  const userId = userIdFromRequest.length > 0 ? userIdFromRequest : (fallbackUserId ?? "").trim()
   if (userId.length > 0) {
     headers["x-user-id"] = userId
   }
@@ -469,10 +490,39 @@ function currentMonthRangeKstMonthToDate(): { from: string; to: string } {
   return { from, to: today }
 }
 
+/**
+ * Billing summary API currently requires from/to and enforces max range days.
+ * We align with current billing maxRangeDays default(400) to compute practical cumulative spend.
+ */
+function rollingRangeKst(days: number): { from: string; to: string } {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
+  const parts = formatter.formatToParts(new Date())
+  const y = Number(parts.find((p) => p.type === "year")?.value ?? "1970")
+  const m = Number(parts.find((p) => p.type === "month")?.value ?? "01")
+  const d = Number(parts.find((p) => p.type === "day")?.value ?? "01")
+  const end = new Date(Date.UTC(y, Math.max(0, m - 1), d))
+  const safeDays = Math.max(1, Math.min(days, 400))
+  const start = new Date(end)
+  start.setUTCDate(start.getUTCDate() - (safeDays - 1))
+  const toIso = (value: Date): string => {
+    const yy = value.getUTCFullYear()
+    const mm = String(value.getUTCMonth() + 1).padStart(2, "0")
+    const dd = String(value.getUTCDate()).padStart(2, "0")
+    return `${yy}-${mm}-${dd}`
+  }
+  return { from: toIso(start), to: toIso(end) }
+}
+
 async function fetchBillingSummaryByKey(
   request: Request,
   keys: Array<{ apiKeyId: number; provider: string }>,
   email: string | null,
+  fallbackUserId?: string,
 ): Promise<Map<number, BillingSummaryRow>> {
   const byKeyId = new Map<number, BillingSummaryRow>()
   const uniqueKeys = Array.from(
@@ -492,7 +542,7 @@ async function fetchBillingSummaryByKey(
   if (uniqueKeys.length === 0) return byKeyId
 
   const { from, to } = currentMonthRangeKstMonthToDate()
-  const baseHeaders = buildForwardHeaders(request, email) as Record<string, string>
+  const baseHeaders = buildBillingForwardHeaders(request, email, fallbackUserId)
   const gatewaySharedSecret = (
     process.env.GATEWAY_SHARED_SECRET ?? "local-dev-gateway-shared-secret-do-not-use-in-prod"
   ).trim()
@@ -529,6 +579,58 @@ async function fetchBillingSummaryByKey(
   return byKeyId
 }
 
+async function fetchBillingLifetimeSpendByKey(
+  request: Request,
+  keys: Array<{ apiKeyId: number; provider: string }>,
+  email: string | null,
+  fallbackUserId?: string,
+): Promise<Map<number, number>> {
+  const byKeyId = new Map<number, number>()
+  const uniqueKeys = Array.from(
+    new Set(
+      keys
+        .map((item) => ({
+          apiKeyId: toNumber(item.apiKeyId, 0),
+          provider: (item.provider ?? "").trim().toUpperCase(),
+        }))
+        .filter((item) => item.apiKeyId > 0 && item.provider.length > 0)
+        .map((item) => `${item.apiKeyId}|${item.provider}`),
+    ),
+  ).map((item) => {
+    const [apiKeyId, provider] = item.split("|")
+    return { apiKeyId: Number(apiKeyId), provider }
+  })
+  if (uniqueKeys.length === 0) return byKeyId
+
+  const baseHeaders = buildBillingForwardHeaders(request, email, fallbackUserId)
+  const gatewaySharedSecret = (
+    process.env.GATEWAY_SHARED_SECRET ?? "local-dev-gateway-shared-secret-do-not-use-in-prod"
+  ).trim()
+  if (gatewaySharedSecret.length > 0) {
+    baseHeaders["x-gateway-auth"] = gatewaySharedSecret
+  }
+  const { from, to } = rollingRangeKst(400)
+
+  for (const key of uniqueKeys) {
+    const query = `/api/v1/expenditure/summary?apiKeyId=${encodeURIComponent(String(key.apiKeyId))}&provider=${encodeURIComponent(key.provider)}&from=${from}&to=${to}`
+    for (const origin of billingServiceOriginCandidates()) {
+      try {
+        const response = await fetchWithTimeout(`${origin}${query}`, CONTEXT_FETCH_TIMEOUT_MS, {
+          method: "GET",
+          headers: baseHeaders,
+        })
+        if (!response.ok) continue
+        const payload = (await response.json()) as ExpenditureSummaryResponse
+        byKeyId.set(key.apiKeyId, toNumber(payload.totalCostUsd, 0))
+        break
+      } catch {
+        // try next candidate
+      }
+    }
+  }
+  return byKeyId
+}
+
 function spendAndBudgetForKey(
   signal: BillingSignal | undefined,
   snapshotMonthlyBudgetUsd: number,
@@ -542,13 +644,19 @@ function spendAndBudgetForKey(
   return { currentSpendUsd, monthlyBudgetUsd }
 }
 
-function buildBudgetStats(monthlyBudgetUsd: number, currentSpendUsd: number): BudgetStats {
+function buildBudgetStats(
+  monthlyBudgetUsd: number,
+  currentSpendUsd: number,
+  lifetimeSpendUsd: number,
+): BudgetStats {
   const normalizedBudget = monthlyBudgetUsd > 0 ? monthlyBudgetUsd : 0
   const normalizedSpend = currentSpendUsd > 0 ? currentSpendUsd : 0
+  const normalizedLifetime = Math.max(0, Number.isFinite(lifetimeSpendUsd) ? lifetimeSpendUsd : 0)
   const remainingBudgetUsd = Math.max(normalizedBudget - normalizedSpend, 0)
   const budgetUsagePercent = normalizedBudget > 0 ? (normalizedSpend / normalizedBudget) * 100 : 0
   return {
     currentSpendUsd: normalizedSpend,
+    lifetimeSpendUsd: normalizedLifetime,
     remainingBudgetUsd,
     budgetUsagePercent: Math.max(budgetUsagePercent, 0),
     isBudgetExceeded: normalizedBudget > 0 && normalizedSpend >= normalizedBudget,
@@ -629,7 +737,11 @@ export async function GET(request: Request) {
       ...keys.map((item) => ({ apiKeyId: item.keyId, provider: item.provider })),
       ...teamApiKeys.map((item) => ({ apiKeyId: item.teamApiKeyId, provider: item.provider })),
     ]
-    const billingSummaryByKey = await fetchBillingSummaryByKey(request, allKnownKeys, resolvedEmailHeader)
+    const fallbackBillingUserId = currentUserId != null ? String(currentUserId) : undefined
+    const [billingSummaryByKey, lifetimeSpendByKey] = await Promise.all([
+      fetchBillingSummaryByKey(request, allKnownKeys, resolvedEmailHeader, fallbackBillingUserId),
+      fetchBillingLifetimeSpendByKey(request, allKnownKeys, resolvedEmailHeader, fallbackBillingUserId),
+    ])
     const usageSignalByTeamAndUser = new Map<string, UsagePredictionSignal>()
     const usageSignalByTeam = new Map<string, UsagePredictionSignal>()
     for (const signal of usagePredictionSignals) {
@@ -696,7 +808,11 @@ export async function GET(request: Request) {
         toNumber(key.monthlyBudgetUsd, 0),
         billingRow,
       )
-      const budgetStats = buildBudgetStats(monthlyBudgetUsd, currentSpendUsd)
+      const budgetStats = buildBudgetStats(
+        monthlyBudgetUsd,
+        currentSpendUsd,
+        lifetimeSpendByKey.get(key.keyId) ?? 0,
+      )
       const averageDailySpendUsd = toNumber(personalUsageSignal?.averageDailySpendUsd7d, 0)
       const averageDailyTokenUsage = Math.max(
         toNumber(personalUsageSignal?.averageDailyTokenUsage7d, 0),
@@ -740,7 +856,11 @@ export async function GET(request: Request) {
           toNumber(key.monthlyBudgetUsd, 0),
           billingRow,
         )
-        const budgetStats = buildBudgetStats(monthlyBudgetUsd, currentSpendUsd)
+        const budgetStats = buildBudgetStats(
+          monthlyBudgetUsd,
+          currentSpendUsd,
+          lifetimeSpendByKey.get(keyId) ?? 0,
+        )
         const averageDailySpendUsd = toNumber(personalUsageSignal?.averageDailySpendUsd7d, 0)
         const averageDailyTokenUsage = Math.max(
           toNumber(personalUsageSignal?.averageDailyTokenUsage7d, 0),
@@ -781,7 +901,11 @@ export async function GET(request: Request) {
         snapshotBudget,
         billingSummaryByKey.get(key.keyId),
       )
-      const mergedBudgetStats = buildBudgetStats(merged.monthlyBudgetUsd, merged.currentSpendUsd)
+      const mergedBudgetStats = buildBudgetStats(
+        merged.monthlyBudgetUsd,
+        merged.currentSpendUsd,
+        lifetimeSpendByKey.get(key.keyId) ?? 0,
+      )
       personalKeysById.set(key.keyId, {
         ...current,
         ...key,
@@ -805,7 +929,11 @@ export async function GET(request: Request) {
         toNumber(item.monthlyBudgetUsd, 0),
         billingRow,
       )
-      const budgetStats = buildBudgetStats(monthlyBudgetUsd, currentSpendUsd)
+      const budgetStats = buildBudgetStats(
+        monthlyBudgetUsd,
+        currentSpendUsd,
+        lifetimeSpendByKey.get(item.teamApiKeyId) ?? 0,
+      )
       const usageSignal =
         currentUserId == null
           ? usageSignalByTeam.get(String(item.teamId)) ?? null

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/SecurityConfig.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
 						.requestMatchers("/api/auth/logout").permitAll()
 						.requestMatchers("/api/identity/v1/users/**").permitAll()
 						.requestMatchers("/internal/api-keys/**").permitAll()
+						.requestMatchers("/internal/v1/api-keys/**").permitAll()
 						.requestMatchers("/internal/users/**").permitAll()
 						.requestMatchers("/error").permitAll()
 						.anyRequest().authenticated()

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.zerobugfreinds.identity_service.controller;
 
 import com.zerobugfreinds.identity_service.common.ApiResponse;
+import com.zerobugfreinds.identity_service.exception.AmbiguousExternalApiKeyHashException;
 import com.zerobugfreinds.identity_service.exception.ApiKeyLimitExceededException;
 import com.zerobugfreinds.identity_service.exception.AuthContractViolationException;
 import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyAliasException;
@@ -89,6 +90,13 @@ public class GlobalExceptionHandler {
 	@ResponseStatus(HttpStatus.CONFLICT)
 	public ApiResponse<Void> handleDuplicateExternalApiKeyAlias(DuplicateExternalApiKeyAliasException ex) {
 		return failWithFallback(ex.getMessage(), "이미 사용 중인 API 키 별칭입니다");
+	}
+
+	@ExceptionHandler(AmbiguousExternalApiKeyHashException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ApiResponse<Void> handleAmbiguousExternalApiKeyHash(AmbiguousExternalApiKeyHashException ex) {
+		log.warn("identity ambiguous external api key lookup message={}", ex.getMessage());
+		return failWithFallback(ex.getMessage(), "동일 해시값에 매칭되는 외부 API 키가 2건 이상입니다");
 	}
 
 	@ExceptionHandler(ExternalApiKeyNotFoundException.class)

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/InternalApiKeyLookupController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/InternalApiKeyLookupController.java
@@ -1,0 +1,61 @@
+package com.zerobugfreinds.identity_service.controller;
+
+import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
+import com.zerobugfreinds.identity_service.dto.InternalApiKeyLookupResponse;
+import com.zerobugfreinds.identity_service.service.ExternalApiKeyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Locale;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+/**
+ * 외부 API 키 역조회(Reverse Lookup) 내부 API.
+ *
+ * <p>Proxy 등 내부 호출자가 클라이언트에게 받은 외부 API 키의 해시값으로
+ * 어느 사용자/키에 매핑되는지 식별할 때 사용한다. 평문 키는 응답에 포함하지 않는다.</p>
+ *
+ * <p>경로를 {@code /internal/v1/api-keys} 로 분리해 기존 사용자별 단순 조회 API
+ * ({@link InternalApiKeyController}) 와 충돌하지 않는다.</p>
+ */
+@RestController
+@RequestMapping("/internal/v1/api-keys")
+public class InternalApiKeyLookupController {
+
+	private final ExternalApiKeyService externalApiKeyService;
+
+	public InternalApiKeyLookupController(ExternalApiKeyService externalApiKeyService) {
+		this.externalApiKeyService = externalApiKeyService;
+	}
+
+	@GetMapping("/lookup")
+	public ResponseEntity<InternalApiKeyLookupResponse> lookupByHashedKey(
+			@RequestParam("hashedKey") String hashedKey,
+			@RequestParam("provider") String provider
+	) {
+		ExternalApiKeyProvider parsedProvider = parseProvider(provider);
+		InternalApiKeyLookupResponse response =
+				externalApiKeyService.lookupByHashedKey(parsedProvider, hashedKey);
+		return ResponseEntity.ok(response);
+	}
+
+	private static ExternalApiKeyProvider parseProvider(String provider) {
+		if (provider == null || provider.isBlank()) {
+			throw new ResponseStatusException(BAD_REQUEST, "provider는 필수입니다");
+		}
+		String normalized = provider.trim();
+		if (!normalized.equals(normalized.toUpperCase(Locale.ROOT))) {
+			throw new ResponseStatusException(BAD_REQUEST, "provider는 대문자 enum 이름만 허용합니다");
+		}
+		try {
+			return ExternalApiKeyProvider.valueOf(normalized);
+		} catch (IllegalArgumentException ex) {
+			throw new ResponseStatusException(BAD_REQUEST, "지원하지 않는 provider입니다: " + provider, ex);
+		}
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/InternalApiKeyLookupResponse.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/dto/InternalApiKeyLookupResponse.java
@@ -1,0 +1,24 @@
+package com.zerobugfreinds.identity_service.dto;
+
+/**
+ * Proxy 등 내부 호출자가 클라이언트가 보낸 외부 API 키의 해시를 기준으로
+ * 어떤 사용자/키에 매핑되는지를 역추적할 때 반환하는 응답.
+ *
+ * <p>평문 키는 절대 포함하지 않는다. 상태값으로 키의 라이프사이클 단계를
+ * 명확히 노출하여 호출자가 활성/삭제 예정 등을 직접 판단할 수 있게 한다.</p>
+ *
+ * @param keyId   외부 API 키 행의 PK
+ * @param ownerId 키 소유자(사용자) ID
+ * @param status  키 상태값 (ACTIVE / DELETION_REQUESTED / DELETED)
+ * @param alias   사용자가 설정한 별칭
+ * @param scope   고정값 "USER" — 팀 키와 구분하기 위함
+ */
+public record InternalApiKeyLookupResponse(
+		String keyId,
+		Long ownerId,
+		String status,
+		String alias,
+		String scope
+) {
+	public static final String SCOPE_USER = "USER";
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/exception/AmbiguousExternalApiKeyHashException.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/exception/AmbiguousExternalApiKeyHashException.java
@@ -1,0 +1,15 @@
+package com.zerobugfreinds.identity_service.exception;
+
+/**
+ * 동일한 (provider, keyHash) 조합으로 여러 행이 매칭되어 단일 키로 식별할 수 없을 때 발생한다.
+ *
+ * <p>외부 API 키 테이블의 유일 제약은 (user_id, provider, key_hash) 이므로,
+ * 서로 다른 사용자가 동일한 외부 API 키를 등록한 경우 역조회 결과가 2건 이상이 될 수 있다.
+ * 이때 호출자(예: proxy-service)가 단일 키를 확정할 수 없으므로 409 Conflict 로 응답한다.</p>
+ */
+public class AmbiguousExternalApiKeyHashException extends RuntimeException {
+
+	public AmbiguousExternalApiKeyHashException(String message) {
+		super(message);
+	}
+}

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
@@ -82,5 +82,12 @@ public interface ExternalApiKeyRepository extends JpaRepository<ExternalApiKeyEn
 
 	List<ExternalApiKeyEntity> findAllByPermanentDeletionAtIsNotNullAndPermanentDeletionAtBefore(Instant now);
 
+	/**
+	 * Proxy 등 내부 호출에서 사용자 ID 없이 (provider, keyHash) 만으로 역조회할 때 사용한다.
+	 * 유일 제약은 (user_id, provider, key_hash) 이므로 이론상 여러 사용자가 동일한 외부 키를
+	 * 등록한 경우 2건 이상 조회될 수 있다. 호출자에서 결과 건수를 검증한다.
+	 */
+	List<ExternalApiKeyEntity> findAllByProviderAndKeyHash(ExternalApiKeyProvider provider, String keyHash);
+
 	void deleteAllByUserId(Long userId);
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
@@ -5,8 +5,10 @@ import com.zerobugfreinds.identity.events.ExternalApiKeyDeletedEvent;
 import com.zerobugfreinds.identity.events.ExternalApiKeyBudgetChangedEvent;
 import com.zerobugfreinds.identity.events.ExternalApiKeyStatus;
 import com.zerobugfreinds.identity.events.ExternalApiKeyStatusChangedEvent;
+import com.zerobugfreinds.identity_service.dto.InternalApiKeyLookupResponse;
 import com.zerobugfreinds.identity_service.dto.InternalApiKeyResponse;
 import com.zerobugfreinds.identity_service.entity.ExternalApiKeyEntity;
+import com.zerobugfreinds.identity_service.exception.AmbiguousExternalApiKeyHashException;
 import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyAliasException;
 import com.zerobugfreinds.identity_service.exception.DuplicateExternalApiKeyException;
 import com.zerobugfreinds.identity_service.exception.ExternalApiKeyAlreadyPendingDeletionException;
@@ -213,6 +215,56 @@ public class ExternalApiKeyService {
 		publishExternalApiKeyBudgetChanged(entity, ExternalApiKeyStatus.ACTIVE);
 
 		return entity;
+	}
+
+	/**
+	 * Proxy 등 내부 호출자가 클라이언트에게서 받은 외부 API 키의 해시값으로
+	 * 어느 사용자의 어떤 키인지 역추적할 때 사용한다.
+	 *
+	 * <p>해시는 등록 시 사용한 {@link com.zerobugfreinds.identity_service.util.EncryptionUtil#sha256HexForUniqueness}
+	 * 와 동일한 방식(provider name + NUL + 평문 키 → SHA-256 hex)을 가정한다.</p>
+	 *
+	 * <p>활성 키와 삭제 예정 키 모두 결과에 포함하여, 호출자가 상태값(ACTIVE / DELETION_REQUESTED)
+	 * 을 보고 게이트 처리할 수 있게 한다. 동일 해시로 여러 행이 매칭되면
+	 * {@link AmbiguousExternalApiKeyHashException} 으로 409 Conflict 를 유도한다.</p>
+	 */
+	@Transactional(readOnly = true)
+	public InternalApiKeyLookupResponse lookupByHashedKey(ExternalApiKeyProvider provider, String hashedKey) {
+		if (provider == null) {
+			throw new IllegalArgumentException("provider는 필수입니다");
+		}
+		if (!StringUtils.hasText(hashedKey)) {
+			throw new IllegalArgumentException("hashedKey는 필수입니다");
+		}
+		ExternalApiKeyProvider normalizedProvider = normalizeProvider(provider);
+		String normalizedHash = hashedKey.trim().toLowerCase();
+		List<ExternalApiKeyEntity> matches =
+				externalApiKeyRepository.findAllByProviderAndKeyHash(normalizedProvider, normalizedHash);
+		if (matches.isEmpty()) {
+			throw new ExternalApiKeyNotFoundException("해당 해시값에 매칭되는 외부 API 키를 찾을 수 없습니다");
+		}
+		if (matches.size() > 1) {
+			log.warn(
+					"[AUDIT] external_api_key_lookup_ambiguous provider={} matchCount={} hashPrefix={}",
+					normalizedProvider.name(),
+					matches.size(),
+					normalizedHash.length() >= 8 ? normalizedHash.substring(0, 8) : normalizedHash
+			);
+			throw new AmbiguousExternalApiKeyHashException(
+					"동일한 해시값에 매칭되는 외부 API 키가 2건 이상입니다"
+			);
+		}
+		ExternalApiKeyEntity entity = matches.get(0);
+		ExternalApiKeyStatus status = entity.isPendingDeletion()
+				? ExternalApiKeyStatus.DELETION_REQUESTED
+				: ExternalApiKeyStatus.ACTIVE;
+		return new InternalApiKeyLookupResponse(
+				String.valueOf(entity.getId()),
+				entity.getUserId(),
+				status.name(),
+				entity.getKeyAlias(),
+				InternalApiKeyLookupResponse.SCOPE_USER
+		);
 	}
 
 	@Transactional(readOnly = true)

--- a/services/identity-service/src/test/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyLookupServiceTest.java
+++ b/services/identity-service/src/test/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyLookupServiceTest.java
@@ -1,0 +1,156 @@
+package com.zerobugfreinds.identity_service.service;
+
+import com.zerobugfreinds.identity_service.domain.ExternalApiKeyProvider;
+import com.zerobugfreinds.identity_service.dto.InternalApiKeyLookupResponse;
+import com.zerobugfreinds.identity_service.entity.ExternalApiKeyEntity;
+import com.zerobugfreinds.identity_service.exception.AmbiguousExternalApiKeyHashException;
+import com.zerobugfreinds.identity_service.exception.ExternalApiKeyNotFoundException;
+import com.zerobugfreinds.identity_service.repository.ExternalApiKeyRepository;
+import com.zerobugfreinds.identity_service.repository.UserRepository;
+import com.zerobugfreinds.identity_service.util.EncryptionUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExternalApiKeyLookupServiceTest {
+
+	private static final String SAMPLE_HASH =
+			"a1b2c3d4e5f60718293a4b5c6d7e8f9001122334455667788990aabbccddeeff";
+
+	@Mock
+	private ExternalApiKeyRepository externalApiKeyRepository;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private EncryptionUtil encryptionUtil;
+	@Mock
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@InjectMocks
+	private ExternalApiKeyService externalApiKeyService;
+
+	@BeforeEach
+	void setUp() {
+		externalApiKeyService = new ExternalApiKeyService(
+				externalApiKeyRepository,
+				userRepository,
+				encryptionUtil,
+				applicationEventPublisher
+		);
+	}
+
+	@Test
+	void lookupByHashedKey_singleActiveMatch_returnsActiveResponse() {
+		ExternalApiKeyEntity entity = newEntity(11L, 7L, "openai-default", false);
+		when(externalApiKeyRepository.findAllByProviderAndKeyHash(
+				eq(ExternalApiKeyProvider.OPENAI), eq(SAMPLE_HASH)
+		)).thenReturn(List.of(entity));
+
+		InternalApiKeyLookupResponse response =
+				externalApiKeyService.lookupByHashedKey(ExternalApiKeyProvider.OPENAI, SAMPLE_HASH);
+
+		assertThat(response.keyId()).isEqualTo("11");
+		assertThat(response.ownerId()).isEqualTo(7L);
+		assertThat(response.status()).isEqualTo("ACTIVE");
+		assertThat(response.alias()).isEqualTo("openai-default");
+		assertThat(response.scope()).isEqualTo(InternalApiKeyLookupResponse.SCOPE_USER);
+	}
+
+	@Test
+	void lookupByHashedKey_singleDeletionPendingMatch_returnsDeletionRequestedResponse() {
+		ExternalApiKeyEntity entity = newEntity(22L, 9L, "anthropic-old", true);
+		when(externalApiKeyRepository.findAllByProviderAndKeyHash(
+				eq(ExternalApiKeyProvider.ANTHROPIC), eq(SAMPLE_HASH)
+		)).thenReturn(List.of(entity));
+
+		InternalApiKeyLookupResponse response =
+				externalApiKeyService.lookupByHashedKey(ExternalApiKeyProvider.ANTHROPIC, SAMPLE_HASH);
+
+		assertThat(response.keyId()).isEqualTo("22");
+		assertThat(response.status()).isEqualTo("DELETION_REQUESTED");
+	}
+
+	@Test
+	void lookupByHashedKey_normalizesUppercaseHashBeforeQuery() {
+		ExternalApiKeyEntity entity = newEntity(33L, 5L, "google-default", false);
+		when(externalApiKeyRepository.findAllByProviderAndKeyHash(
+				eq(ExternalApiKeyProvider.GOOGLE), eq(SAMPLE_HASH)
+		)).thenReturn(List.of(entity));
+
+		InternalApiKeyLookupResponse response =
+				externalApiKeyService.lookupByHashedKey(ExternalApiKeyProvider.GOOGLE, "  " + SAMPLE_HASH.toUpperCase() + "  ");
+
+		assertThat(response.keyId()).isEqualTo("33");
+	}
+
+	@Test
+	void lookupByHashedKey_noMatch_throwsNotFound() {
+		when(externalApiKeyRepository.findAllByProviderAndKeyHash(
+				eq(ExternalApiKeyProvider.OPENAI), eq(SAMPLE_HASH)
+		)).thenReturn(List.of());
+
+		assertThatThrownBy(() ->
+				externalApiKeyService.lookupByHashedKey(ExternalApiKeyProvider.OPENAI, SAMPLE_HASH)
+		).isInstanceOf(ExternalApiKeyNotFoundException.class);
+	}
+
+	@Test
+	void lookupByHashedKey_multipleMatches_throwsConflict() {
+		ExternalApiKeyEntity first = newEntity(101L, 1L, "shared-key-1", false);
+		ExternalApiKeyEntity second = newEntity(102L, 2L, "shared-key-2", false);
+		when(externalApiKeyRepository.findAllByProviderAndKeyHash(
+				eq(ExternalApiKeyProvider.OPENAI), eq(SAMPLE_HASH)
+		)).thenReturn(List.of(first, second));
+
+		assertThatThrownBy(() ->
+				externalApiKeyService.lookupByHashedKey(ExternalApiKeyProvider.OPENAI, SAMPLE_HASH)
+		).isInstanceOf(AmbiguousExternalApiKeyHashException.class);
+	}
+
+	@Test
+	void lookupByHashedKey_blankHash_throwsBadRequest() {
+		assertThatThrownBy(() ->
+				externalApiKeyService.lookupByHashedKey(ExternalApiKeyProvider.OPENAI, "  ")
+		).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("hashedKey");
+	}
+
+	@Test
+	void lookupByHashedKey_nullProvider_throwsBadRequest() {
+		assertThatThrownBy(() ->
+				externalApiKeyService.lookupByHashedKey(null, SAMPLE_HASH)
+		).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("provider");
+	}
+
+	private static ExternalApiKeyEntity newEntity(Long id, Long userId, String alias, boolean pendingDeletion) {
+		ExternalApiKeyEntity entity = ExternalApiKeyEntity.register(
+				userId,
+				ExternalApiKeyProvider.OPENAI,
+				alias,
+				SAMPLE_HASH,
+				"encrypted",
+				BigDecimal.ONE
+		);
+		ReflectionTestUtils.setField(entity, "id", id);
+		if (pendingDeletion) {
+			entity.markPendingDeletion(Instant.now(), 7, true);
+		}
+		return entity;
+	}
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/config/SecurityConfig.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
 				.exceptionHandling(exception -> exception.authenticationEntryPoint(restAuthenticationEntryPoint))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers("/internal/api-keys/**").permitAll()
+						.requestMatchers("/internal/v1/team-api-keys/**").permitAll()
 						.requestMatchers("/internal/teams/**").permitAll()
 						.requestMatchers("/internal/v1/teams/**").permitAll()
 						.requestMatchers("/internal/v1/users/**").permitAll()

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/GlobalExceptionHandler.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.zerobugfreinds.team_service.controller;
 
 import com.zerobugfreinds.team_service.common.ApiResponse;
+import com.zerobugfreinds.team_service.exception.AmbiguousTeamApiKeyHashException;
 import com.zerobugfreinds.team_service.exception.DuplicateTeamMemberException;
 import com.zerobugfreinds.team_service.exception.DuplicateTeamInvitationException;
 import com.zerobugfreinds.team_service.exception.ForbiddenTeamAccessException;
@@ -93,6 +94,12 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(TeamApiKeyNotFoundException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	public ApiResponse<Void> handleTeamApiKeyNotFound(TeamApiKeyNotFoundException ex) {
+		return ApiResponse.fail(ex.getMessage());
+	}
+
+	@ExceptionHandler(AmbiguousTeamApiKeyHashException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ApiResponse<Void> handleAmbiguousTeamApiKeyHash(AmbiguousTeamApiKeyHashException ex) {
 		return ApiResponse.fail(ex.getMessage());
 	}
 

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/InternalTeamApiKeyLookupController.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/InternalTeamApiKeyLookupController.java
@@ -1,0 +1,41 @@
+package com.zerobugfreinds.team_service.controller;
+
+import com.zerobugfreinds.team_service.dto.InternalTeamApiKeyLookupResponse;
+import com.zerobugfreinds.team_service.service.TeamApiKeyLookupService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 팀 API 키 역조회(Reverse Lookup) 내부 API.
+ *
+ * <p>Proxy 등 내부 호출자가 클라이언트에게 받은 외부 API 키의 해시값으로
+ * 어느 팀/등록 멤버/키에 매핑되는지 식별할 때 사용한다. 평문 키는 응답에 포함하지 않는다.</p>
+ *
+ * <p>경로를 {@code /internal/v1/team-api-keys} 로 분리해 기존 팀별 단순 조회 API
+ * ({@link InternalTeamApiKeyController}) 와 충돌하지 않는다.</p>
+ */
+@RestController
+@RequestMapping("/internal/v1/team-api-keys")
+public class InternalTeamApiKeyLookupController {
+
+    private final TeamApiKeyLookupService teamApiKeyLookupService;
+
+    public InternalTeamApiKeyLookupController(TeamApiKeyLookupService teamApiKeyLookupService) {
+        this.teamApiKeyLookupService = teamApiKeyLookupService;
+    }
+
+    @GetMapping("/lookup")
+    public ResponseEntity<InternalTeamApiKeyLookupResponse> lookupByHashedKey(
+            @RequestParam("hashedKey") String hashedKey,
+            @RequestParam("provider") String provider,
+            @RequestHeader(name = "Authorization", required = false) String authorizationHeader
+    ) {
+        InternalTeamApiKeyLookupResponse response =
+                teamApiKeyLookupService.lookupByHashedKey(provider, hashedKey, authorizationHeader);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/InternalTeamApiKeyLookupResponse.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/InternalTeamApiKeyLookupResponse.java
@@ -1,0 +1,26 @@
+package com.zerobugfreinds.team_service.dto;
+
+/**
+ * Proxy 등 내부 호출자가 클라이언트에게 받은 팀 API 키의 해시값으로
+ * 어느 팀/등록 멤버/키에 매핑되는지 식별할 때 반환하는 응답.
+ *
+ * <p>평문 키는 절대 포함하지 않는다. 상태값으로 키의 라이프사이클 단계를
+ * 명확히 노출하여 호출자가 활성/삭제 예정 등을 직접 판단할 수 있게 한다.</p>
+ *
+ * @param keyId        팀 API 키 행의 PK
+ * @param teamId       소속 팀 ID
+ * @param ownerUserId  키를 등록한 멤버의 사용자 ID (legacy 행은 null 일 수 있음)
+ * @param status       키 상태값 (ACTIVE / DELETION_REQUESTED / DELETED)
+ * @param alias        팀 키 별칭
+ * @param scope        고정값 "TEAM" — 개인 키와 구분하기 위함
+ */
+public record InternalTeamApiKeyLookupResponse(
+        String keyId,
+        Long teamId,
+        String ownerUserId,
+        String status,
+        String alias,
+        String scope
+) {
+    public static final String SCOPE_TEAM = "TEAM";
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/entity/TeamApiKeyEntity.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/entity/TeamApiKeyEntity.java
@@ -46,6 +46,13 @@ public class TeamApiKeyEntity {
     @Column(name = "key_alias", nullable = false, length = 100)
     private String keyAlias;
 
+    /**
+     * 키를 등록한 멤버의 사용자 ID. 역조회 응답의 ownerUserId 로 사용한다.
+     * 컬럼 도입 이전 행과의 호환을 위해 nullable 로 둔다.
+     */
+    @Column(name = "created_by_user_id", length = 100)
+    private String createdByUserId;
+
     @Column(name = "key_hash", nullable = false, length = 64)
     private String keyHash;
 
@@ -86,8 +93,21 @@ public class TeamApiKeyEntity {
             String encryptedKey,
             BigDecimal monthlyBudgetUsd
     ) {
+        return register(teamId, null, provider, keyAlias, keyHash, encryptedKey, monthlyBudgetUsd);
+    }
+
+    public static TeamApiKeyEntity register(
+            Long teamId,
+            String createdByUserId,
+            TeamApiKeyProvider provider,
+            String keyAlias,
+            String keyHash,
+            String encryptedKey,
+            BigDecimal monthlyBudgetUsd
+    ) {
         TeamApiKeyEntity entity = new TeamApiKeyEntity();
         entity.teamId = teamId;
+        entity.createdByUserId = createdByUserId;
         entity.provider = provider;
         entity.keyAlias = keyAlias;
         entity.keyHash = keyHash;
@@ -140,6 +160,10 @@ public class TeamApiKeyEntity {
 
     public Long getTeamId() {
         return teamId;
+    }
+
+    public String getCreatedByUserId() {
+        return createdByUserId;
     }
 
     public TeamApiKeyProvider getProvider() {

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/exception/AmbiguousTeamApiKeyHashException.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/exception/AmbiguousTeamApiKeyHashException.java
@@ -1,0 +1,15 @@
+package com.zerobugfreinds.team_service.exception;
+
+/**
+ * 동일한 (provider, keyHash) 조합으로 여러 팀의 키가 매칭되어 단일 키로 식별할 수 없을 때 발생한다.
+ *
+ * <p>팀 API 키 테이블의 유일 제약은 (team_id, provider, key_hash) 이므로,
+ * 서로 다른 팀이 동일한 외부 API 키를 등록한 경우 역조회 결과가 2건 이상이 될 수 있다.
+ * 이때 호출자(예: proxy-service)가 단일 키를 확정할 수 없으므로 409 Conflict 로 응답한다.</p>
+ */
+public class AmbiguousTeamApiKeyHashException extends RuntimeException {
+
+    public AmbiguousTeamApiKeyHashException(String message) {
+        super(message);
+    }
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamApiKeyRepository.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamApiKeyRepository.java
@@ -47,5 +47,12 @@ public interface TeamApiKeyRepository extends JpaRepository<TeamApiKeyEntity, Lo
             TeamApiKeyProvider provider
     );
 
+    /**
+     * Proxy 등 내부 호출에서 teamId 없이 (provider, keyHash) 만으로 역조회할 때 사용한다.
+     * 유일 제약은 (team_id, provider, key_hash) 이므로 서로 다른 팀이 동일한 외부 키를
+     * 등록한 경우 2건 이상 조회될 수 있다. 호출자에서 결과 건수를 검증한다.
+     */
+    List<TeamApiKeyEntity> findAllByProviderAndKeyHash(TeamApiKeyProvider provider, String keyHash);
+
     List<TeamApiKeyEntity> findAllByPermanentDeletionAtIsNotNullAndPermanentDeletionAtBefore(Instant now);
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyLookupService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyLookupService.java
@@ -1,0 +1,118 @@
+package com.zerobugfreinds.team_service.service;
+
+import com.zerobugfreinds.team_service.domain.TeamApiKeyProvider;
+import com.zerobugfreinds.team_service.dto.InternalTeamApiKeyLookupResponse;
+import com.zerobugfreinds.team_service.entity.TeamApiKeyEntity;
+import com.zerobugfreinds.team_service.event.TeamApiKeyStatus;
+import com.zerobugfreinds.team_service.exception.AmbiguousTeamApiKeyHashException;
+import com.zerobugfreinds.team_service.exception.InternalRequestUnauthorizedException;
+import com.zerobugfreinds.team_service.exception.TeamApiKeyNotFoundException;
+import com.zerobugfreinds.team_service.repository.TeamApiKeyRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * 팀 API 키 역조회(Reverse Lookup) 서비스.
+ *
+ * <p>Proxy 등 내부 호출자가 클라이언트가 보낸 외부 API 키의 해시값으로
+ * 어느 팀/등록 멤버/키에 매핑되는지 식별할 때 사용한다. 평문 키는 응답에 포함하지 않는다.</p>
+ */
+@Service
+public class TeamApiKeyLookupService {
+
+    private static final Logger log = LoggerFactory.getLogger(TeamApiKeyLookupService.class);
+
+    private final TeamApiKeyRepository teamApiKeyRepository;
+    private final String internalToken;
+
+    public TeamApiKeyLookupService(
+            TeamApiKeyRepository teamApiKeyRepository,
+            @Value("${team.internal.api-token:${PROXY_TEAM_KEY_SERVICE_INTERNAL_TOKEN:}}") String internalToken
+    ) {
+        this.teamApiKeyRepository = teamApiKeyRepository;
+        this.internalToken = internalToken;
+    }
+
+    @Transactional(readOnly = true)
+    public InternalTeamApiKeyLookupResponse lookupByHashedKey(
+            String providerRaw,
+            String hashedKey,
+            String authorizationHeader
+    ) {
+        validateInternalToken(authorizationHeader);
+        TeamApiKeyProvider provider = normalizeProvider(providerRaw);
+        String normalizedHash = normalizeHash(hashedKey);
+
+        List<TeamApiKeyEntity> matches = teamApiKeyRepository.findAllByProviderAndKeyHash(provider, normalizedHash);
+        if (matches.isEmpty()) {
+            throw new TeamApiKeyNotFoundException("해당 해시값에 매칭되는 팀 API 키를 찾을 수 없습니다");
+        }
+        if (matches.size() > 1) {
+            log.warn(
+                    "Ambiguous team api key lookup provider={} matchCount={} hashPrefix={}",
+                    provider.name(),
+                    matches.size(),
+                    normalizedHash.length() >= 8 ? normalizedHash.substring(0, 8) : normalizedHash
+            );
+            throw new AmbiguousTeamApiKeyHashException(
+                    "동일한 해시값에 매칭되는 팀 API 키가 2건 이상입니다"
+            );
+        }
+        TeamApiKeyEntity entity = matches.get(0);
+        TeamApiKeyStatus status = entity.isDeletionPending()
+                ? TeamApiKeyStatus.DELETION_REQUESTED
+                : TeamApiKeyStatus.ACTIVE;
+        return new InternalTeamApiKeyLookupResponse(
+                String.valueOf(entity.getId()),
+                entity.getTeamId(),
+                entity.getCreatedByUserId(),
+                status.name(),
+                entity.getKeyAlias(),
+                InternalTeamApiKeyLookupResponse.SCOPE_TEAM
+        );
+    }
+
+    private void validateInternalToken(String authorizationHeader) {
+        if (!StringUtils.hasText(internalToken)) {
+            throw new InternalRequestUnauthorizedException("내부 인증 토큰이 서버에 설정되지 않았습니다");
+        }
+        if (!StringUtils.hasText(authorizationHeader) || !authorizationHeader.startsWith("Bearer ")) {
+            throw new InternalRequestUnauthorizedException("내부 인증 토큰이 필요합니다");
+        }
+        String bearerToken = authorizationHeader.substring("Bearer ".length()).trim();
+        if (!internalToken.equals(bearerToken)) {
+            throw new InternalRequestUnauthorizedException("내부 인증 토큰이 올바르지 않습니다");
+        }
+    }
+
+    private static TeamApiKeyProvider normalizeProvider(String providerRaw) {
+        if (!StringUtils.hasText(providerRaw)) {
+            throw new IllegalArgumentException("provider는 필수입니다");
+        }
+        return switch (providerRaw.trim()) {
+            case "OPENAI" -> TeamApiKeyProvider.OPENAI;
+            case "ANTHROPIC" -> TeamApiKeyProvider.ANTHROPIC;
+            case "GOOGLE", "GEMINI" -> TeamApiKeyProvider.GOOGLE;
+            case "META" -> TeamApiKeyProvider.META;
+            case "MISTRAL" -> TeamApiKeyProvider.MISTRAL;
+            case "COHERE" -> TeamApiKeyProvider.COHERE;
+            case "CLAUDE" -> TeamApiKeyProvider.CLAUDE;
+            case "GROK" -> TeamApiKeyProvider.GROK;
+            default -> throw new IllegalArgumentException("provider는 대문자 enum 이름만 허용합니다: " + providerRaw);
+        };
+    }
+
+    private static String normalizeHash(String hashedKey) {
+        if (!StringUtils.hasText(hashedKey)) {
+            throw new IllegalArgumentException("hashedKey는 필수입니다");
+        }
+        return hashedKey.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamApiKeyService.java
@@ -99,7 +99,15 @@ public class TeamApiKeyService {
 
         String encrypted = encryptionUtil.encryptAes256Gcm(normalizedExternalKey);
         TeamApiKeyEntity saved = teamApiKeyRepository.save(
-                TeamApiKeyEntity.register(teamId, provider, normalizedAlias, keyHash, encrypted, monthlyBudgetUsd)
+                TeamApiKeyEntity.register(
+                        teamId,
+                        StringUtils.hasText(actorUserId) ? actorUserId.trim() : null,
+                        provider,
+                        normalizedAlias,
+                        keyHash,
+                        encrypted,
+                        monthlyBudgetUsd
+                )
         );
         TeamApiKeyNotifyContext ctx = teamApiKeyNotifyContext(teamId);
         Instant occurredAt = Instant.now();

--- a/services/team-service/src/test/java/com/zerobugfreinds/team_service/service/TeamApiKeyLookupServiceTest.java
+++ b/services/team-service/src/test/java/com/zerobugfreinds/team_service/service/TeamApiKeyLookupServiceTest.java
@@ -1,0 +1,194 @@
+package com.zerobugfreinds.team_service.service;
+
+import com.zerobugfreinds.team_service.domain.TeamApiKeyProvider;
+import com.zerobugfreinds.team_service.dto.InternalTeamApiKeyLookupResponse;
+import com.zerobugfreinds.team_service.entity.TeamApiKeyEntity;
+import com.zerobugfreinds.team_service.exception.AmbiguousTeamApiKeyHashException;
+import com.zerobugfreinds.team_service.exception.InternalRequestUnauthorizedException;
+import com.zerobugfreinds.team_service.exception.TeamApiKeyNotFoundException;
+import com.zerobugfreinds.team_service.repository.TeamApiKeyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TeamApiKeyLookupServiceTest {
+
+    private static final String INTERNAL_TOKEN = "internal-token";
+    private static final String SAMPLE_HASH =
+            "a1b2c3d4e5f60718293a4b5c6d7e8f9001122334455667788990aabbccddeeff";
+
+    @Test
+    void lookupByHashedKey_singleActiveMatch_returnsActiveResponse() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, INTERNAL_TOKEN);
+
+        TeamApiKeyEntity entity = newEntity(101L, 42L, "openai-team", "user-1", false);
+        when(repository.findAllByProviderAndKeyHash(eq(TeamApiKeyProvider.OPENAI), eq(SAMPLE_HASH)))
+                .thenReturn(List.of(entity));
+
+        InternalTeamApiKeyLookupResponse response =
+                service.lookupByHashedKey("OPENAI", SAMPLE_HASH, "Bearer " + INTERNAL_TOKEN);
+
+        assertThat(response.keyId()).isEqualTo("101");
+        assertThat(response.teamId()).isEqualTo(42L);
+        assertThat(response.ownerUserId()).isEqualTo("user-1");
+        assertThat(response.status()).isEqualTo("ACTIVE");
+        assertThat(response.alias()).isEqualTo("openai-team");
+        assertThat(response.scope()).isEqualTo(InternalTeamApiKeyLookupResponse.SCOPE_TEAM);
+    }
+
+    @Test
+    void lookupByHashedKey_singleDeletionPendingMatch_returnsDeletionRequestedResponse() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, INTERNAL_TOKEN);
+
+        TeamApiKeyEntity entity = newEntity(202L, 7L, "anthropic-team", "user-2", true);
+        when(repository.findAllByProviderAndKeyHash(eq(TeamApiKeyProvider.ANTHROPIC), eq(SAMPLE_HASH)))
+                .thenReturn(List.of(entity));
+
+        InternalTeamApiKeyLookupResponse response =
+                service.lookupByHashedKey("ANTHROPIC", SAMPLE_HASH, "Bearer " + INTERNAL_TOKEN);
+
+        assertThat(response.status()).isEqualTo("DELETION_REQUESTED");
+    }
+
+    @Test
+    void lookupByHashedKey_geminiAlias_normalizedToGoogle() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, INTERNAL_TOKEN);
+
+        TeamApiKeyEntity entity = newEntity(303L, 9L, "gemini-team", null, false);
+        when(repository.findAllByProviderAndKeyHash(eq(TeamApiKeyProvider.GOOGLE), eq(SAMPLE_HASH)))
+                .thenReturn(List.of(entity));
+
+        InternalTeamApiKeyLookupResponse response =
+                service.lookupByHashedKey("GEMINI", SAMPLE_HASH.toUpperCase(), "Bearer " + INTERNAL_TOKEN);
+
+        assertThat(response.keyId()).isEqualTo("303");
+        assertThat(response.ownerUserId()).isNull();
+    }
+
+    @Test
+    void lookupByHashedKey_noMatch_throwsNotFound() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, INTERNAL_TOKEN);
+
+        when(repository.findAllByProviderAndKeyHash(eq(TeamApiKeyProvider.OPENAI), eq(SAMPLE_HASH)))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() ->
+                service.lookupByHashedKey("OPENAI", SAMPLE_HASH, "Bearer " + INTERNAL_TOKEN)
+        ).isInstanceOf(TeamApiKeyNotFoundException.class);
+    }
+
+    @Test
+    void lookupByHashedKey_multipleMatches_throwsConflict() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, INTERNAL_TOKEN);
+
+        TeamApiKeyEntity first = newEntity(401L, 1L, "shared-1", "user-a", false);
+        TeamApiKeyEntity second = newEntity(402L, 2L, "shared-2", "user-b", false);
+        when(repository.findAllByProviderAndKeyHash(eq(TeamApiKeyProvider.OPENAI), eq(SAMPLE_HASH)))
+                .thenReturn(List.of(first, second));
+
+        assertThatThrownBy(() ->
+                service.lookupByHashedKey("OPENAI", SAMPLE_HASH, "Bearer " + INTERNAL_TOKEN)
+        ).isInstanceOf(AmbiguousTeamApiKeyHashException.class);
+    }
+
+    @Test
+    void lookupByHashedKey_blankHash_throwsBadRequest() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, INTERNAL_TOKEN);
+
+        assertThatThrownBy(() ->
+                service.lookupByHashedKey("OPENAI", "  ", "Bearer " + INTERNAL_TOKEN)
+        ).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("hashedKey");
+    }
+
+    @Test
+    void lookupByHashedKey_unknownProvider_throwsBadRequest() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, INTERNAL_TOKEN);
+
+        assertThatThrownBy(() ->
+                service.lookupByHashedKey("unknown-provider", SAMPLE_HASH, "Bearer " + INTERNAL_TOKEN)
+        ).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("provider");
+    }
+
+    @Test
+    void lookupByHashedKey_lowercaseProvider_throwsBadRequest() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, INTERNAL_TOKEN);
+
+        assertThatThrownBy(() ->
+                service.lookupByHashedKey("openai", SAMPLE_HASH, "Bearer " + INTERNAL_TOKEN)
+        ).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("대문자");
+    }
+
+    @Test
+    void lookupByHashedKey_missingAuthHeader_throwsUnauthorized() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, INTERNAL_TOKEN);
+
+        assertThatThrownBy(() ->
+                service.lookupByHashedKey("openai", SAMPLE_HASH, null)
+        ).isInstanceOf(InternalRequestUnauthorizedException.class);
+    }
+
+    @Test
+    void lookupByHashedKey_wrongBearerToken_throwsUnauthorized() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, INTERNAL_TOKEN);
+
+        assertThatThrownBy(() ->
+                service.lookupByHashedKey("openai", SAMPLE_HASH, "Bearer wrong-token")
+        ).isInstanceOf(InternalRequestUnauthorizedException.class);
+    }
+
+    @Test
+    void lookupByHashedKey_serverHasNoConfiguredToken_throwsUnauthorized() {
+        TeamApiKeyRepository repository = mock(TeamApiKeyRepository.class);
+        TeamApiKeyLookupService service = new TeamApiKeyLookupService(repository, "");
+
+        assertThatThrownBy(() ->
+                service.lookupByHashedKey("openai", SAMPLE_HASH, "Bearer any")
+        ).isInstanceOf(InternalRequestUnauthorizedException.class)
+                .hasMessageContaining("서버에 설정되지");
+    }
+
+    private static TeamApiKeyEntity newEntity(
+            Long id,
+            Long teamId,
+            String alias,
+            String createdByUserId,
+            boolean pendingDeletion
+    ) {
+        TeamApiKeyEntity entity = TeamApiKeyEntity.register(
+                teamId,
+                createdByUserId,
+                TeamApiKeyProvider.OPENAI,
+                alias,
+                SAMPLE_HASH,
+                "encrypted",
+                BigDecimal.ONE
+        );
+        ReflectionTestUtils.setField(entity, "id", id);
+        if (pendingDeletion) {
+            entity.markDeletionRequested(Instant.now(), 7, true);
+        }
+        return entity;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호 등

(해당 이슈 번호로 교체)

## 작업 내용
- **해당 서비스**: identity-service, team-service (proxy-service 호출 측은 별도 PR)
> 3rd-party 도구가 `teamId` / `keyId` 같은 우리 플랫폼 전용 헤더 없이 provider API Key 평문만 보내는 시나리오를 지원하기 위해, **API Key 해시값으로 사용자/팀·키 ID·상태를 역추적할 수 있는 내부 API**를 두 서비스에 추가했습니다. proxy-service가 매 호출마다 참조할 수 있도록 단건 응답·인덱스 기반 조회로 구성했고, 평문 키는 응답에 절대 포함하지 않습니다.

## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용

### identity-service — 개인 API Key 역조회
- 신규 엔드포인트 `GET /internal/v1/api-keys/lookup?hashedKey=...&provider=...`
- DTO `InternalApiKeyLookupResponse(keyId, ownerId, status, alias, scope="USER")`
- `ExternalApiKeyRepository#findAllByProviderAndKeyHash` 추가 (전역 조회용, ambiguity 검출 위해 `List<>` 반환)
- `ExternalApiKeyService#lookupByHashedKey` — `ACTIVE` / `DELETION_REQUESTED` 상태 구분, purge된 행은 자연스럽게 404
- 다건 매칭 시 `AmbiguousExternalApiKeyHashException` → 409 Conflict (`GlobalExceptionHandler` 매핑 추가)
- `SecurityConfig` 에 `/internal/v1/api-keys/**` permitAll 추가

### team-service — 팀 API Key 역조회
- 신규 엔드포인트 `GET /internal/v1/team-api-keys/lookup?hashedKey=...&provider=...`
- DTO `InternalTeamApiKeyLookupResponse(keyId, teamId, ownerUserId, status, alias, scope="TEAM")`
- `TeamApiKeyEntity` 에 nullable `created_by_user_id` 컬럼 추가 → `TeamApiKeyService.register()` 에서 `actorUserId` 저장하여 `ownerUserId` 로 노출 (legacy 행은 null)
- `TeamApiKeyRepository#findAllByProviderAndKeyHash` 추가
- 신규 `TeamApiKeyLookupService` — 기존 `TeamInternalApiKeyResolveService` 와 동일한 `Authorization: Bearer <internal-token>` 정책 사용 (`team.internal.api-token`/`PROXY_TEAM_KEY_SERVICE_INTERNAL_TOKEN`)
- 다건 매칭 시 `AmbiguousTeamApiKeyHashException` → 409 Conflict
- `SecurityConfig` 에 `/internal/v1/team-api-keys/**` permitAll 추가

### 공통
- `provider` 파라미터는 **대문자 enum 이름만** 허용 (`OPENAI`, `ANTHROPIC`, `GOOGLE`, `META`, `MISTRAL`, `COHERE`, `GROK`). team-service 만 `GEMINI` → `GOOGLE` 별칭 허용. 소문자나 미지원 값은 `400`.
- `hashedKey` 는 SHA-256 hex (등록 시 `EncryptionUtil#sha256HexForUniqueness` 와 동일 알고리즘). 입력값 trim + 소문자 정규화로 대소문자 차이 허용.
- 평문 키는 어떤 경로에서도 송수신·로그 출력 금지. ambiguity 로그는 hash 앞 8자만 남김.
- 컨트랙트 문서: `docs/contracts/proxy-api-key-reverse-lookup-internal-api.md` 신규 추가 (한국어, 두 엔드포인트 통합 계약)

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부 — **N/A** (이번 PR에는 캐시 코드 변경 없음. proxy-service 호출 측에서 기존 `ApiKeyClient` Caffeine LoadingCache 패턴 재사용 권장만 문서에 명시)
- [ ] **RabbitMQ**: 메시지 발행/소비 로직 포함 여부 — **N/A** (역조회 read API. 키 라이프사이클 이벤트는 기존 `identity.events` / `team.api-key.exchange` 그대로)
- [x] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부
  - `team_api_keys.created_by_user_id` (`VARCHAR(100)`, nullable) 컬럼 추가
  - `ddl-auto=update` 환경에서 자동 적용. 기존 행은 NULL 유지(legacy 호환), 신규 등록부터 `actorUserId` 저장
  - 새 Entity 추가는 없음. `external_api_keys` / `team_api_keys` 의 기존 unique index 그대로 활용

## 📸 스크린샷 / 테스트 결과 (선택)

신규 단위 테스트 추가, 두 서비스 모두 `gradle test` 그린.

- `identity-service` `ExternalApiKeyLookupServiceTest` — **7 passed / 0 failed**
  - 단건 active / 단건 deletion-pending / hash 정규화 / not-found / 다건 conflict / blank hash / null provider
- `team-service` `TeamApiKeyLookupServiceTest` — **11 passed / 0 failed**
  - 단건 active / 단건 deletion-pending / `GEMINI`→`GOOGLE` 별칭 / not-found / 다건 conflict / blank hash / unknown provider / 소문자 provider 거부 / 누락 Bearer / 잘못된 Bearer / 서버 내부 토큰 미설정

기존 테스트 회귀 없음 (`TeamInternalApiKeyResolveServiceTest` 등 모두 통과).

## 리뷰 요구사항
- **provider 대문자 정책** 일관성 검토: 신규 lookup API 만 대문자 enum 이름을 강제하고, 기존 forward lookup `/internal/api-keys/{provider}` 의 path-segment 기반 소문자 입력은 호환성 유지를 위해 그대로 둡니다. 두 정책이 한 서비스에 공존해도 문제없는지 봐주세요.
- **인증 정책 차이**: `team-service` 역조회는 Bearer 토큰을 검증하지만, `identity-service` 역조회는 기존 `/internal/api-keys/{provider}` 와 동일하게 토큰 검증 없이 네트워크 격리에만 의존합니다. identity-service 쪽도 Bearer 검증을 도입할지 여부 의견 부탁드립니다.
- **`ownerUserId` nullable 호환**: 컬럼 도입 이전 행의 `ownerUserId` 가 null 로 응답됩니다. proxy 측에서 null 케이스 어떻게 처리할지(차단 vs 통과) 합의가 필요합니다.
- **모호성(409) 폴백**: 동일 해시가 여러 owner 에 존재하면 409 인데, proxy 가 401/403 으로 떨어뜨릴지 명시적 헤더 재요구로 갈지 정책 의견 부탁드립니다.