### PR TITLE
Feat/team

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,8 @@ REDIS_PORT=6379
 TEAM_SERVICE_PORT=8094
 # TEAM_SERVICE_HOST_PORT — 루트 docker-compose.yml 의 team-service `ports:` 호스트 바인딩만 (기본 8093). TEAM_SERVICE_PORT(8094)와 이름을 나눠 Docker Desktop 이 호스트 8094를 선점하는 유형 B 충돌을 피한다.
 TEAM_SERVICE_HOST_PORT=8093
+# team-service → billing month-rollup (TeamController BFF). bootRun/IDE: localhost. Compose team-service sets http://billing-service:8095 in docker-compose.yml.
+TEAM_BILLING_SERVICE_BASE_URL=http://billing-service:8095
 BILLING_SERVICE_PORT=8095
 # Gateway → billing-service HTTP (Compose 네트워크 기본)
 GATEWAY_BILLING_URI=http://billing-service:8095

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -528,6 +528,8 @@ services:
       TEAM_API_KEY_ENCRYPTION_SECRET: ${TEAM_API_KEY_ENCRYPTION_SECRET:-change-this-team-api-key-encryption-secret-min-32-chars}
       PROXY_TEAM_KEY_SERVICE_INTERNAL_TOKEN: ${PROXY_TEAM_KEY_SERVICE_INTERNAL_TOKEN:-change-this-team-internal-api-token}
       TEAM_SERVICE_PORT: 8093
+      # team-service → billing (month-rollup BFF). Override on host if billing is not on this URL.
+      TEAM_BILLING_SERVICE_BASE_URL: ${TEAM_BILLING_SERVICE_BASE_URL:-http://billing-service:8095}
     depends_on:
       postgres-team:
         condition: service_healthy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,6 +97,7 @@
 - 다른 애플리케이션 서비스(Identity, Usage Tracking, Team 등)도 기본은 **호스트 로컬 실행**으로 두되, 팀 합의에 따라 루트 Compose `profile: web`/서비스별 Compose에 포함해 함께 기동할 수 있다.
 - **team-service**는 `TEAM_SERVICE_PORT` 없으면 기본 **8093**, **billing-service**는 `BILLING_SERVICE_PORT` 없으면 기본 **8095** — 기본값끼리는 포트가 겹치지 않는다. `scripts/bootrun.ps1`·`bootrun.sh`는 team **8094**·billing **8095**를 넣어 과거(둘 다 8093) 충돌을 피한다. API Gateway **`GATEWAY_BILLING_URI`** 기본은 **`http://localhost:8095`** 와 billing 기본 포트가 일치한다(Compose 게이트웨이는 `host.docker.internal:8095`). 스모크: `scripts/verify-expenditure-chain.ps1` / `verify-expenditure-chain.sh`.
 - 루트 Compose의 **`team-service`**(`profiles: web`)는 **호스트 포트 매핑**에 **`TEAM_SERVICE_HOST_PORT`**(기본 **8093**)를 쓰고, 호스트에서 JVM으로 기동할 때의 **`TEAM_SERVICE_PORT`**(예: **8094**)와 변수명을 분리한다. 과거에는 둘 다 `TEAM_SERVICE_PORT`로 치환되어 `.env`에 **8094**를 두면 Compose가 호스트 **8094**를 Docker에 바인딩하고, 같은 머신에서 `bootRun`이 **8094**를 다시 쓰려 할 때(점유 PID가 **java**가 아니라 **Docker / wslrelay**인 유형) 충돌이 났다. **`TEAM_SERVICE_HOST_PORT`**는 Compose 전용, **`TEAM_SERVICE_PORT`**는 호스트 JVM용으로 구분한다. **`team-web`**는 같은 Compose 스택에서는 기본 **`http://team-service:8093`**, 호스트에서만 team을 띄울 때는 **`WEB_TEAM_SERVICE_URL`**을 호스트 포트에 맞춘다(`.env.example`).
+- Team Service가 Billing 월 롤업을 서버 간 호출할 때는 `team.billing.base-url`(`TEAM_BILLING_SERVICE_BASE_URL`)을 사용한다. 호스트 `bootRun` 기본은 `http://localhost:8095`, 루트 Compose `team-service` 기본은 `http://billing-service:8095`로 맞춘다.
 
 ---
 

--- a/docs/contracts/proxy-team-key-internal-api.md
+++ b/docs/contracts/proxy-team-key-internal-api.md
@@ -17,6 +17,8 @@ resolving **team-scoped** provider keys.
 - Query:
   - `teamId` (required): numeric team id
   - `userId` (required): request user id / subject for membership verification
+  - `apiKeyId` (optional): team API key PK (numeric-string). If present, resolve by exact key id first.
+  - `alias` (optional): key alias. Used when `apiKeyId` is absent.
 - Header:
   - `Authorization: Bearer <internal-token>` (required)
 
@@ -67,7 +69,10 @@ For team requests, `team-service` resolves keys with these fixed rules:
 1. Lookup by `teamId`.
 2. Normalize provider alias (`gemini` -> `google`).
 3. Exclude deletion-pending keys (`deletionRequestedAt IS NULL`).
-4. Select only the newest active key (`createdAt DESC`, first row).
+4. Selection priority:
+   - if `apiKeyId` exists: exact match by `(id, teamId, provider)` (and active state)
+   - else if `alias` exists: newest active key by `(teamId, provider, alias)` + `createdAt DESC`
+   - else: newest active key by `(teamId, provider)` + `createdAt DESC`
 5. If no active key exists, return `404`.
 
 Personal key fallback is not allowed for team requests.

--- a/docs/contracts/web-team-bff.md
+++ b/docs/contracts/web-team-bff.md
@@ -1,6 +1,6 @@
 # Web(Next.js) ↔ Team Service BFF 계약
 
-버전: 0.15  
+버전: 0.16  
 관련: [web-split-boundary.md](./web-split-boundary.md), [web-identity-bff.md](./web-identity-bff.md) — `/teams` UI 소유·경로: §2.3, [identity-auth-api-contract.md](../identity-auth-api-contract.md) §14(Identity → Team 사용자 동기화 MQ)
 
 ---
@@ -28,6 +28,7 @@
 | `POST /api/team/v1/me/team-invitations/{invitationId}/reject` | Team BFF `POST ...` → Gateway `POST ...` → Team Service `POST /api/v1/me/team-invitations/{invitationId}/reject` |
 | `GET /api/team/v1/teams/{id}/api-keys` | Team BFF `GET /api/team/v1/teams/{id}/api-keys` → Gateway `GET ...` → Team Service `GET /api/v1/teams/{id}/api-keys` |
 | `POST /api/team/v1/teams/{id}/api-keys` | Team BFF `POST /api/team/v1/teams/{id}/api-keys` → Gateway `POST ...` → Team Service `POST /api/v1/teams/{id}/api-keys` |
+| `GET /api/team/v1/teams/{id}/expenditure/team-api-keys/month-spend` | Team BFF `GET ...` → Gateway `GET ...` → Team Service `GET /api/v1/teams/{id}/expenditure/team-api-keys/month-spend` → Team Service 내부 Billing 호출 `POST /api/v1/expenditure/team/month-rollup` |
 | `PUT /api/team/v1/teams/{teamId}/api-keys/{keyId}` | Team BFF `PUT ...` → Gateway `PUT ...` → Team Service `PUT /api/v1/teams/{teamId}/api-keys/{keyId}` |
 | `DELETE /api/team/v1/teams/{teamId}/api-keys/{keyId}` | Team BFF `DELETE ...` → Gateway `DELETE ...` → Team Service `DELETE /api/v1/teams/{teamId}/api-keys/{keyId}` (선택 쿼리 `gracePeriodDays`) |
 | `POST /api/team/v1/teams/{teamId}/api-keys/{keyId}/deletion/cancel` | Team BFF `POST ...` → Gateway `POST ...` → Team Service `POST /api/v1/teams/{teamId}/api-keys/{keyId}/deletion/cancel` |
@@ -189,6 +190,16 @@
   - 실패:
     - `403` (`success=false`): 팀 멤버가 아닌 사용자의 조회 시도
     - `404` (`success=false`): 대상 팀이 존재하지 않는 경우
+- `GET /api/team/v1/teams/{id}/expenditure/team-api-keys/month-spend`
+  - 목적: 팀 멤버 집합 기준 월 지출 롤업(`billing-service` `POST /api/v1/expenditure/team/month-rollup`) 조회
+  - 쿼리: `month` (선택, `YYYY-MM-01`). 생략 시 KST 기준 현재 월의 1일 사용
+  - 처리 규칙:
+    - Team Service가 요청 사용자(`X-User-Id`)의 팀 접근 권한을 검증한다.
+    - 전달 월은 **달의 1일만 허용**한다(아니면 `400`).
+    - Team Service가 팀 멤버 userId 목록을 만든 뒤 Billing으로 서버 간 호출한다.
+    - Gateway가 넣은 `X-User-Id`와 `X-Gateway-Auth`를 Billing 호출로 전달한다.
+  - 성공: `200`, `data = { totalCostUsd, byUser[] }`
+  - 실패: `400`(유효하지 않은 month/teamId), `403`(팀 접근 불가), `401`(`X-User-Id` 누락), `502`(Billing 연결 실패)
 - 레거시 호환: 내부 저장값/경로에 `GEMINI`가 남아 있어도 외부 BFF 계약의 provider 표기는 `GOOGLE`로 통일한다.
   - 내부 키 조회 API(`GET /internal/team-api-keys/{provider}`)는 `provider=gemini` 별칭을 입력받아 `GOOGLE`로 정규화한다(코드: `TeamInternalApiKeyResolveService`).
   - 부팅 시 `TeamApiKeyProviderMigrationInitializer`가 `team_api_keys`의 `GEMINI` 값을 `GOOGLE`로 정리한다.
@@ -201,6 +212,7 @@
 ### 6.1 내부 API (notification/billing/agent 등 서비스 간 조회)
 
 - Team Service는 내부 호출용으로 `GET /internal/teams/{id}`를 제공한다.
+- Team Service는 Billing 월 롤업 내부 호출을 위해 `team.billing.base-url` 설정을 사용한다(환경 변수 `TEAM_BILLING_SERVICE_BASE_URL`, 기본 `http://localhost:8095`).
 - 응답 `data`는 `teamId`, `teamName`, `createdBy`, `createdAt`를 포함한다.
 - 내부 멤버십 검증용으로 `GET /internal/v1/teams/{teamId}/members/{userId}/verify`를 제공한다.
   - 응답 `data`: `teamId`, `userId`, `isValid`

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "eslint": "^9",
     "json-stable-stringify-without-jsonify": "^1.0.1",
     "next": "15.2.4",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
     "styled-jsx": "^5.1.7",
     "vitest": "^4.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,12 @@ importers:
       next:
         specifier: 15.2.4
         version: 15.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
       styled-jsx:
         specifier: ^5.1.7
         version: 5.1.7(react@19.2.4)
@@ -517,10 +523,10 @@ importers:
         version: link:../../../packages/ui
       '@module-federation/bridge-react-webpack-plugin':
         specifier: ^2.4.0
-        version: 2.4.0(node-fetch@2.7.0(encoding@0.1.13))
+        version: 2.4.0(node-fetch@3.3.2)
       '@module-federation/nextjs-mf':
         specifier: ^8.8.64
-        version: 8.8.64(@rspack/core@1.7.11(@swc/helpers@0.5.21))(next@15.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-jsx@5.1.7(react@19.2.4))(typescript@5.9.3)(webpack@5.97.1)
+        version: 8.8.64(@rspack/core@1.7.11(@swc/helpers@0.5.21))(next@15.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(node-fetch@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-jsx@5.1.7(react@19.2.4))(typescript@5.9.3)(webpack@5.97.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -593,7 +599,7 @@ importers:
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.4))
       '@module-federation/nextjs-mf':
         specifier: ^8.8.64
-        version: 8.8.64(@rspack/core@1.7.11(@swc/helpers@0.5.21))(next@15.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(node-fetch@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-jsx@5.1.7(react@19.2.4))(typescript@5.9.3)(webpack@5.97.1)
+        version: 8.8.64(@rspack/core@1.7.11(@swc/helpers@0.5.21))(next@15.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-jsx@5.1.7(react@19.2.4))(typescript@5.9.3)(webpack@5.97.1)
       lucide-react:
         specifier: ^1.6.0
         version: 1.7.0(react@19.2.4)
@@ -6835,9 +6841,9 @@ snapshots:
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/bridge-react-webpack-plugin@2.4.0(node-fetch@2.7.0(encoding@0.1.13))':
+  '@module-federation/bridge-react-webpack-plugin@2.4.0(node-fetch@3.3.2)':
     dependencies:
-      '@module-federation/sdk': 2.4.0(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/sdk': 2.4.0(node-fetch@3.3.2)
       '@types/semver': 7.5.8
       semver: 7.6.3
     transitivePeerDependencies:
@@ -7200,9 +7206,9 @@ snapshots:
     optionalDependencies:
       node-fetch: 3.3.2
 
-  '@module-federation/sdk@2.4.0(node-fetch@2.7.0(encoding@0.1.13))':
+  '@module-federation/sdk@2.4.0(node-fetch@3.3.2)':
     optionalDependencies:
-      node-fetch: 2.7.0(encoding@0.1.13)
+      node-fetch: 3.3.2
 
   '@module-federation/third-party-dts-extractor@2.3.2':
     dependencies:

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/InternalApiKeyController.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/controller/InternalApiKeyController.java
@@ -9,9 +9,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
-
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 /**
  * Proxy 내부 호출용 API 키 조회 API.
@@ -29,13 +26,13 @@ public class InternalApiKeyController {
 	@GetMapping("/{provider}")
 	public ResponseEntity<InternalApiKeyResponse> getByProvider(
 			@PathVariable String provider,
-			@RequestParam String userId
+			@RequestParam String userId,
+			@RequestParam(name = "apiKeyId", required = false) String apiKeyId,
+			@RequestParam(name = "alias", required = false) String alias
 	) {
-		try {
-			ExternalApiKeyProvider externalApiKeyProvider = ExternalApiKeyProvider.fromInternalPathSegment(provider);
-			return ResponseEntity.ok(externalApiKeyService.resolveInternalKey(userId, externalApiKeyProvider));
-		} catch (IllegalArgumentException ex) {
-			throw new ResponseStatusException(BAD_REQUEST, ex.getMessage(), ex);
-		}
+		ExternalApiKeyProvider externalApiKeyProvider = ExternalApiKeyProvider.fromInternalPathSegment(provider);
+		return ResponseEntity.ok(
+				externalApiKeyService.resolveInternalKey(userId, externalApiKeyProvider, apiKeyId, alias)
+		);
 	}
 }

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/repository/ExternalApiKeyRepository.java
@@ -59,6 +59,18 @@ public interface ExternalApiKeyRepository extends JpaRepository<ExternalApiKeyEn
 			ExternalApiKeyProvider provider
 	);
 
+	Optional<ExternalApiKeyEntity> findByIdAndUserIdAndProviderAndDeletionRequestedAtIsNull(
+			Long id,
+			Long userId,
+			ExternalApiKeyProvider provider
+	);
+
+	Optional<ExternalApiKeyEntity> findFirstByUserIdAndProviderAndKeyAliasAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(
+			Long userId,
+			ExternalApiKeyProvider provider,
+			String keyAlias
+	);
+
 	@Query("""
 			select coalesce(sum(e.monthlyBudgetUsd), 0)
 			from ExternalApiKeyEntity e

--- a/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
+++ b/services/identity-service/src/main/java/com/zerobugfreinds/identity_service/service/ExternalApiKeyService.java
@@ -308,7 +308,12 @@ public class ExternalApiKeyService {
 	}
 
 	@Transactional(readOnly = true)
-	public InternalApiKeyResponse resolveInternalKey(String userId, ExternalApiKeyProvider provider) {
+	public InternalApiKeyResponse resolveInternalKey(
+			String userId,
+			ExternalApiKeyProvider provider,
+			String apiKeyId,
+			String alias
+	) {
 		Long resolvedUserId = resolveInternalLookupUserId(userId);
 		if (resolvedUserId == null) {
 			throw new IllegalArgumentException("userId는 필수입니다");
@@ -317,11 +322,46 @@ public class ExternalApiKeyService {
 			throw new IllegalArgumentException("provider는 필수입니다");
 		}
 		ExternalApiKeyProvider normalizedProvider = normalizeProvider(provider);
-		ExternalApiKeyEntity entity = externalApiKeyRepository
-				.findTopByUserIdAndProviderAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(resolvedUserId, normalizedProvider)
-				.orElseThrow(() -> new ExternalApiKeyNotFoundException("등록된 API 키를 찾을 수 없습니다"));
+		ExternalApiKeyEntity entity = selectInternalKey(resolvedUserId, normalizedProvider, apiKeyId, alias);
 		String plainKey = encryptionUtil.decryptAes256Gcm(entity.getEncryptedKey());
 		return new InternalApiKeyResponse(plainKey, String.valueOf(entity.getId()));
+	}
+
+	/**
+	 * 사용자 범위의 활성 외부 API 키만 조회한다. 팀 키로의 폴백은 하지 않는다.
+	 *
+	 * <p>우선순위: {@code apiKeyId}가 있으면 ID 매칭, 없으면 {@code alias} 최신 건, 둘 다 없으면 해당
+	 * provider의 최신 활성 키.</p>
+	 */
+	private ExternalApiKeyEntity selectInternalKey(
+			Long userId,
+			ExternalApiKeyProvider provider,
+			String apiKeyId,
+			String alias
+	) {
+		if (StringUtils.hasText(apiKeyId)) {
+			long keyId;
+			try {
+				keyId = Long.parseLong(apiKeyId.trim());
+			} catch (NumberFormatException ex) {
+				throw new IllegalArgumentException("apiKeyId는 숫자여야 합니다", ex);
+			}
+			return externalApiKeyRepository
+					.findByIdAndUserIdAndProviderAndDeletionRequestedAtIsNull(keyId, userId, provider)
+					.orElseThrow(() -> new ExternalApiKeyNotFoundException("등록된 API 키를 찾을 수 없습니다"));
+		}
+		if (StringUtils.hasText(alias)) {
+			return externalApiKeyRepository
+					.findFirstByUserIdAndProviderAndKeyAliasAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(
+							userId,
+							provider,
+							alias.trim()
+					)
+					.orElseThrow(() -> new ExternalApiKeyNotFoundException("등록된 API 키를 찾을 수 없습니다"));
+		}
+		return externalApiKeyRepository
+				.findTopByUserIdAndProviderAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(userId, provider)
+				.orElseThrow(() -> new ExternalApiKeyNotFoundException("등록된 API 키를 찾을 수 없습니다"));
 	}
 
 	private Long resolveInternalLookupUserId(String userIdOrEmail) {

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/config/BillingRestClientConfiguration.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/config/BillingRestClientConfiguration.java
@@ -1,0 +1,20 @@
+package com.zerobugfreinds.team_service.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class BillingRestClientConfiguration {
+
+    @Bean
+    RestClient billingServiceRestClient(
+            @Value("${team.billing.base-url:http://localhost:8095}") String billingBaseUrl
+    ) {
+        String base = StringUtils.hasText(billingBaseUrl) ? billingBaseUrl.trim() : "http://localhost:8095";
+        base = base.replaceAll("/+$", "");
+        return RestClient.builder().baseUrl(base).build();
+    }
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/InternalTeamApiKeyController.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/InternalTeamApiKeyController.java
@@ -25,10 +25,19 @@ public class InternalTeamApiKeyController {
             @RequestParam("teamId") Long teamId,
             @RequestParam("userId") String userId,
             @RequestParam(name = "userEmail", required = false) String userEmail,
+            @RequestParam(name = "apiKeyId", required = false) String apiKeyId,
+            @RequestParam(name = "alias", required = false) String alias,
             @RequestHeader(name = "Authorization", required = false) String authorizationHeader
     ) {
-        InternalTeamApiKeyResponse response =
-                teamInternalApiKeyResolveService.resolve(provider, teamId, userId, userEmail, authorizationHeader);
+        InternalTeamApiKeyResponse response = teamInternalApiKeyResolveService.resolve(
+                provider,
+                teamId,
+                userId,
+                userEmail,
+                authorizationHeader,
+                apiKeyId,
+                alias
+        );
         return ResponseEntity.ok(response);
     }
 }

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/TeamController.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/controller/TeamController.java
@@ -1,6 +1,8 @@
 package com.zerobugfreinds.team_service.controller;
 
 import com.zerobugfreinds.team_service.common.ApiResponse;
+import com.zerobugfreinds.team_service.dto.BillingTeamMonthRollupRequest;
+import com.zerobugfreinds.team_service.dto.BillingTeamMonthRollupResponse;
 import com.zerobugfreinds.team_service.dto.CreateTeamRequest;
 import com.zerobugfreinds.team_service.dto.InviteTeamMemberRequest;
 import com.zerobugfreinds.team_service.dto.RegisterTeamApiKeyRequest;
@@ -12,11 +14,14 @@ import com.zerobugfreinds.team_service.dto.UpdateTeamApiKeyRequest;
 import com.zerobugfreinds.team_service.dto.TeamSummaryResponse;
 import com.zerobugfreinds.team_service.security.TeamContextHolder;
 import com.zerobugfreinds.team_service.service.TeamApiKeyService;
+import com.zerobugfreinds.team_service.service.TeamBillingRollupClient;
 import com.zerobugfreinds.team_service.service.TeamService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -29,6 +34,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @RestController
@@ -36,10 +43,16 @@ import java.util.List;
 public class TeamController {
 	private final TeamService teamService;
 	private final TeamApiKeyService teamApiKeyService;
+	private final TeamBillingRollupClient teamBillingRollupClient;
 
-	public TeamController(TeamService teamService, TeamApiKeyService teamApiKeyService) {
+	public TeamController(
+			TeamService teamService,
+			TeamApiKeyService teamApiKeyService,
+			TeamBillingRollupClient teamBillingRollupClient
+	) {
 		this.teamService = teamService;
 		this.teamApiKeyService = teamApiKeyService;
+		this.teamBillingRollupClient = teamBillingRollupClient;
 	}
 
 	@PostMapping("/teams")
@@ -192,6 +205,32 @@ public class TeamController {
 	) {
 		List<TeamApiKeySummaryResponse> apiKeys = teamApiKeyService.getTeamApiKeys(currentUserId(), resolveTeamId(teamId));
 		return ResponseEntity.ok(ApiResponse.ok("팀 API 키 목록 조회에 성공했습니다", apiKeys));
+	}
+
+	/**
+	 * 팀 멤버 기준 월별 지출 합계(billing {@code monthly_expenditure_agg} 롤업). 게이트웨이의 {@code X-User-Id}·
+	 * {@code X-Gateway-Auth}를 billing 호출에 그대로 전달한다.
+	 */
+	@GetMapping("/teams/{id}/expenditure/team-api-keys/month-spend")
+	public ResponseEntity<ApiResponse<BillingTeamMonthRollupResponse>> getTeamApiKeysMonthSpend(
+			HttpServletRequest request,
+			@PathVariable("id") Long teamId,
+			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate month
+	) {
+		Long resolved = resolveTeamId(teamId);
+		if (resolved <= 0) {
+			throw new IllegalArgumentException("teamId must be positive");
+		}
+		LocalDate monthStart = month != null
+				? month
+				: LocalDate.now(ZoneId.of("Asia/Seoul")).withDayOfMonth(1);
+		if (monthStart.getDayOfMonth() != 1) {
+			throw new IllegalArgumentException("month must be the first day of a calendar month (YYYY-MM-01).");
+		}
+		List<String> members = teamService.getTeamMemberUserIds(currentUserId(), resolved);
+		BillingTeamMonthRollupRequest body = new BillingTeamMonthRollupRequest(members, monthStart);
+		BillingTeamMonthRollupResponse rollup = teamBillingRollupClient.postTeamMonthRollup(request, body);
+		return ResponseEntity.ok(ApiResponse.ok("팀 월 지출 조회에 성공했습니다", rollup));
 	}
 
 	private static String currentUserId() {

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/BillingTeamMonthRollupRequest.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/BillingTeamMonthRollupRequest.java
@@ -1,0 +1,10 @@
+package com.zerobugfreinds.team_service.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * billing-service {@code POST /api/v1/expenditure/team/month-rollup} 요청 본문과 동일한 형태.
+ */
+public record BillingTeamMonthRollupRequest(List<String> userIds, LocalDate monthStartDate) {
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/BillingTeamMonthRollupResponse.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/BillingTeamMonthRollupResponse.java
@@ -1,0 +1,10 @@
+package com.zerobugfreinds.team_service.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * billing-service {@code TeamMonthRollupResponse} JSON 과 호환되는 응답 DTO.
+ */
+public record BillingTeamMonthRollupResponse(BigDecimal totalCostUsd, List<BillingUserMonthCost> byUser) {
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/BillingUserMonthCost.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/dto/BillingUserMonthCost.java
@@ -1,0 +1,6 @@
+package com.zerobugfreinds.team_service.dto;
+
+import java.math.BigDecimal;
+
+public record BillingUserMonthCost(String userId, BigDecimal costUsd) {
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamApiKeyRepository.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/repository/TeamApiKeyRepository.java
@@ -47,6 +47,18 @@ public interface TeamApiKeyRepository extends JpaRepository<TeamApiKeyEntity, Lo
             TeamApiKeyProvider provider
     );
 
+    Optional<TeamApiKeyEntity> findByIdAndTeamIdAndProviderAndDeletionRequestedAtIsNull(
+            Long id,
+            Long teamId,
+            TeamApiKeyProvider provider
+    );
+
+    Optional<TeamApiKeyEntity> findFirstByTeamIdAndProviderAndKeyAliasAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(
+            Long teamId,
+            TeamApiKeyProvider provider,
+            String keyAlias
+    );
+
     /**
      * Proxy 등 내부 호출에서 teamId 없이 (provider, keyHash) 만으로 역조회할 때 사용한다.
      * 유일 제약은 (team_id, provider, key_hash) 이므로 서로 다른 팀이 동일한 외부 키를

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamBillingRollupClient.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamBillingRollupClient.java
@@ -1,0 +1,55 @@
+package com.zerobugfreinds.team_service.service;
+
+import com.zerobugfreinds.team_service.dto.BillingTeamMonthRollupRequest;
+import com.zerobugfreinds.team_service.dto.BillingTeamMonthRollupResponse;
+import com.zerobugfreinds.team_service.security.GatewayHeaderContextFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class TeamBillingRollupClient {
+
+    private static final String HDR_GATEWAY_AUTH = "X-Gateway-Auth";
+
+    private final RestClient billingServiceRestClient;
+
+    public TeamBillingRollupClient(RestClient billingServiceRestClient) {
+        this.billingServiceRestClient = billingServiceRestClient;
+    }
+
+    public BillingTeamMonthRollupResponse postTeamMonthRollup(
+            HttpServletRequest incoming,
+            BillingTeamMonthRollupRequest body
+    ) {
+        String userId = incoming.getHeader(GatewayHeaderContextFilter.USER_ID_HEADER);
+        if (!StringUtils.hasText(userId)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "X-User-Id가 필요합니다");
+        }
+        String gatewayAuth = incoming.getHeader(HDR_GATEWAY_AUTH);
+        try {
+            return billingServiceRestClient.post()
+                    .uri("/api/v1/expenditure/team/month-rollup")
+                    .header(GatewayHeaderContextFilter.USER_ID_HEADER, userId.trim())
+                    .headers(h -> {
+                        if (StringUtils.hasText(gatewayAuth)) {
+                            h.set(HDR_GATEWAY_AUTH, gatewayAuth.trim());
+                        }
+                    })
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .body(BillingTeamMonthRollupResponse.class);
+        } catch (RestClientResponseException e) {
+            throw new ResponseStatusException(HttpStatus.resolve(e.getStatusCode().value()), e.getMessage(), e);
+        } catch (RestClientException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "billing-service 연결 실패", e);
+        }
+    }
+}

--- a/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamInternalApiKeyResolveService.java
+++ b/services/team-service/src/main/java/com/zerobugfreinds/team_service/service/TeamInternalApiKeyResolveService.java
@@ -50,7 +50,9 @@ public class TeamInternalApiKeyResolveService {
             Long teamId,
             String userId,
             String userEmail,
-            String authorizationHeader
+            String authorizationHeader,
+            String apiKeyId,
+            String alias
     ) {
         validateInternalToken(authorizationHeader);
         validateInputs(teamId, userId);
@@ -77,14 +79,49 @@ public class TeamInternalApiKeyResolveService {
             throw new ForbiddenTeamAccessException("팀 멤버만 팀 API 키를 조회할 수 있습니다");
         }
 
-        TeamApiKeyEntity entity = teamApiKeyRepository
-                .findFirstByTeamIdAndProviderAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(teamId, provider)
-                .orElseThrow(() -> new TeamApiKeyNotFoundException("해당 팀에 활성 상태 API 키가 없습니다"));
+        TeamApiKeyEntity entity = selectTeamInternalKey(teamId, provider, apiKeyId, alias);
 
         String plainKey = encryptionUtil.decryptAes256Gcm(entity.getEncryptedKey());
         log.info("Internal team key lookup success teamId={} provider={} user={} keyId={}",
                 teamId, provider.name(), mask(userId), entity.getId());
         return new InternalTeamApiKeyResponse(plainKey, String.valueOf(entity.getId()));
+    }
+
+    /**
+     * 팀 범위의 활성 API 키만 조회한다. 사용자(개인) 키로의 폴백은 하지 않는다.
+     *
+     * <p>우선순위: {@code apiKeyId}가 있으면 ID 매칭, 없으면 {@code alias} 최신 건, 둘 다 없으면 해당
+     * provider의 최신 활성 키.</p>
+     */
+    private TeamApiKeyEntity selectTeamInternalKey(
+            Long teamId,
+            TeamApiKeyProvider provider,
+            String apiKeyId,
+            String alias
+    ) {
+        if (StringUtils.hasText(apiKeyId)) {
+            long keyId;
+            try {
+                keyId = Long.parseLong(apiKeyId.trim());
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("apiKeyId는 숫자여야 합니다", ex);
+            }
+            return teamApiKeyRepository
+                    .findByIdAndTeamIdAndProviderAndDeletionRequestedAtIsNull(keyId, teamId, provider)
+                    .orElseThrow(() -> new TeamApiKeyNotFoundException("해당 팀에 활성 상태 API 키가 없습니다"));
+        }
+        if (StringUtils.hasText(alias)) {
+            return teamApiKeyRepository
+                    .findFirstByTeamIdAndProviderAndKeyAliasAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(
+                            teamId,
+                            provider,
+                            alias.trim()
+                    )
+                    .orElseThrow(() -> new TeamApiKeyNotFoundException("해당 팀에 활성 상태 API 키가 없습니다"));
+        }
+        return teamApiKeyRepository
+                .findFirstByTeamIdAndProviderAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(teamId, provider)
+                .orElseThrow(() -> new TeamApiKeyNotFoundException("해당 팀에 활성 상태 API 키가 없습니다"));
     }
 
     private void validateInternalToken(String authorizationHeader) {
@@ -116,7 +153,7 @@ public class TeamInternalApiKeyResolveService {
         return switch (providerRaw.trim().toLowerCase(Locale.ROOT)) {
             case "openai" -> TeamApiKeyProvider.OPENAI;
             case "anthropic" -> TeamApiKeyProvider.ANTHROPIC;
-            case "google" -> TeamApiKeyProvider.GOOGLE;
+            case "google", "gemini" -> TeamApiKeyProvider.GOOGLE;
             default -> throw new IllegalArgumentException("지원하지 않는 provider입니다: " + providerRaw);
         };
     }

--- a/services/team-service/src/main/resources/application.properties
+++ b/services/team-service/src/main/resources/application.properties
@@ -19,6 +19,7 @@ team.internal.api-token=${PROXY_TEAM_KEY_SERVICE_INTERNAL_TOKEN:change-this-team
 
 server.port=${TEAM_SERVICE_PORT:8093}
 identity.service.url=${IDENTITY_SERVICE_URL:http://host.docker.internal:8090}
+team.billing.base-url=${TEAM_BILLING_SERVICE_BASE_URL:http://localhost:8095}
 
 # 팀 도메인 이벤트 발행 (RabbitMQ). JSON 본문 eventType + 동일 값 AMQP 헤더 eventType.
 team.member-added-event.exchange=${TEAM_MEMBER_ADDED_EVENT_EXCHANGE:team.events}

--- a/services/team-service/src/test/java/com/zerobugfreinds/team_service/service/TeamInternalApiKeyResolveServiceTest.java
+++ b/services/team-service/src/test/java/com/zerobugfreinds/team_service/service/TeamInternalApiKeyResolveServiceTest.java
@@ -19,8 +19,10 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +31,7 @@ class TeamInternalApiKeyResolveServiceTest {
     @Test
     void resolve_missingTeamId_throwsBadRequest() {
         TeamInternalApiKeyResolveService service = newService("internal-token");
-        assertThatThrownBy(() -> service.resolve("google", null, "member@test.com", null, "Bearer internal-token"))
+        assertThatThrownBy(() -> service.resolve("google", null, "member@test.com", null, "Bearer internal-token", null, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("teamId");
     }
@@ -44,7 +46,7 @@ class TeamInternalApiKeyResolveServiceTest {
 
         when(teamMemberRepository.existsByTeamIdAndUserId(10L, "outsider@test.com")).thenReturn(false);
 
-        assertThatThrownBy(() -> service.resolve("openai", 10L, "outsider@test.com", null, "Bearer internal-token"))
+        assertThatThrownBy(() -> service.resolve("openai", 10L, "outsider@test.com", null, "Bearer internal-token", null, null))
                 .isInstanceOf(ForbiddenTeamAccessException.class);
     }
 
@@ -61,7 +63,7 @@ class TeamInternalApiKeyResolveServiceTest {
                 15L, TeamApiKeyProvider.GOOGLE
         )).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.resolve("google", 15L, "member@test.com", null, "Bearer internal-token"))
+        assertThatThrownBy(() -> service.resolve("google", 15L, "member@test.com", null, "Bearer internal-token", null, null))
                 .isInstanceOf(TeamApiKeyNotFoundException.class);
     }
 
@@ -91,7 +93,7 @@ class TeamInternalApiKeyResolveServiceTest {
         when(encryptionUtil.decryptAes256Gcm("encrypted-value")).thenReturn("AIza-real-key");
 
         InternalTeamApiKeyResponse response =
-                service.resolve("google", 22L, "member@test.com", null, "Bearer internal-token");
+                service.resolve("google", 22L, "member@test.com", null, "Bearer internal-token", null, null);
 
         assertThat(response.plainKey()).isEqualTo("AIza-real-key");
         assertThat(response.keyId()).isEqualTo("777");
@@ -103,14 +105,14 @@ class TeamInternalApiKeyResolveServiceTest {
     @Test
     void resolve_requiresInternalTokenWhenConfigured() {
         TeamInternalApiKeyResolveService service = newService("internal-token");
-        assertThatThrownBy(() -> service.resolve("openai", 20L, "member@test.com", null, null))
+        assertThatThrownBy(() -> service.resolve("openai", 20L, "member@test.com", null, null, null, null))
                 .isInstanceOf(InternalRequestUnauthorizedException.class);
     }
 
     @Test
     void resolve_withoutConfiguredToken_throwsForbidden() {
         TeamInternalApiKeyResolveService service = newService("");
-        assertThatThrownBy(() -> service.resolve("openai", 30L, "member@test.com", null, "Bearer any"))
+        assertThatThrownBy(() -> service.resolve("openai", 30L, "member@test.com", null, "Bearer any", null, null))
                 .isInstanceOf(InternalRequestUnauthorizedException.class)
                 .hasMessageContaining("서버에 설정되지");
     }
@@ -151,7 +153,7 @@ class TeamInternalApiKeyResolveServiceTest {
         when(encryptionUtil.decryptAes256Gcm("enc")).thenReturn("sk-plain");
 
         InternalTeamApiKeyResponse response =
-                service.resolve("openai", 10L, "42", null, "Bearer internal-token");
+                service.resolve("openai", 10L, "42", null, "Bearer internal-token", null, null);
 
         assertThat(response.plainKey()).isEqualTo("sk-plain");
     }
@@ -169,9 +171,127 @@ class TeamInternalApiKeyResolveServiceTest {
                 45L, TeamApiKeyProvider.OPENAI
         )).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.resolve("openai", 45L, "member@test.com", null, "Bearer internal-token"))
+        assertThatThrownBy(() -> service.resolve("openai", 45L, "member@test.com", null, "Bearer internal-token", null, null))
                 .isInstanceOf(TeamApiKeyNotFoundException.class)
                 .hasMessageContaining("활성 상태 API 키");
+    }
+
+    @Test
+    void resolve_withApiKeyId_usesIdLookupAndSkipsLatestQuery() {
+        TeamMemberRepository teamMemberRepository = mock(TeamMemberRepository.class);
+        TeamApiKeyRepository teamApiKeyRepository = mock(TeamApiKeyRepository.class);
+        EncryptionUtil encryptionUtil = mock(EncryptionUtil.class);
+        TeamInternalApiKeyResolveService service = newService(
+                teamMemberRepository, teamApiKeyRepository, encryptionUtil, "internal-token");
+
+        TeamApiKeyEntity entity = TeamApiKeyEntity.register(
+                22L,
+                TeamApiKeyProvider.GOOGLE,
+                "google-key",
+                "hash",
+                "encrypted-value",
+                BigDecimal.ONE
+        );
+        ReflectionTestUtils.setField(entity, "id", 777L);
+        ReflectionTestUtils.setField(entity, "createdAt", Instant.now());
+
+        when(teamMemberRepository.existsByTeamIdAndUserId(22L, "member@test.com")).thenReturn(true);
+        when(teamApiKeyRepository.findByIdAndTeamIdAndProviderAndDeletionRequestedAtIsNull(
+                777L, 22L, TeamApiKeyProvider.GOOGLE
+        )).thenReturn(Optional.of(entity));
+        when(encryptionUtil.decryptAes256Gcm("encrypted-value")).thenReturn("AIza-real-key");
+
+        InternalTeamApiKeyResponse response = service.resolve(
+                "google", 22L, "member@test.com", null, "Bearer internal-token", "777", null);
+
+        assertThat(response.plainKey()).isEqualTo("AIza-real-key");
+        assertThat(response.keyId()).isEqualTo("777");
+        verify(teamApiKeyRepository).findByIdAndTeamIdAndProviderAndDeletionRequestedAtIsNull(
+                777L, 22L, TeamApiKeyProvider.GOOGLE);
+        verify(teamApiKeyRepository, never()).findFirstByTeamIdAndProviderAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(
+                any(), any());
+    }
+
+    @Test
+    void resolve_withAlias_usesAliasLookup() {
+        TeamMemberRepository teamMemberRepository = mock(TeamMemberRepository.class);
+        TeamApiKeyRepository teamApiKeyRepository = mock(TeamApiKeyRepository.class);
+        EncryptionUtil encryptionUtil = mock(EncryptionUtil.class);
+        TeamInternalApiKeyResolveService service = newService(
+                teamMemberRepository, teamApiKeyRepository, encryptionUtil, "internal-token");
+
+        TeamApiKeyEntity entity = TeamApiKeyEntity.register(
+                22L,
+                TeamApiKeyProvider.GOOGLE,
+                "my-alias",
+                "hash",
+                "encrypted-value",
+                BigDecimal.ONE
+        );
+        ReflectionTestUtils.setField(entity, "id", 888L);
+        ReflectionTestUtils.setField(entity, "createdAt", Instant.now());
+
+        when(teamMemberRepository.existsByTeamIdAndUserId(22L, "member@test.com")).thenReturn(true);
+        when(teamApiKeyRepository.findFirstByTeamIdAndProviderAndKeyAliasAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(
+                22L, TeamApiKeyProvider.GOOGLE, "my-alias"
+        )).thenReturn(Optional.of(entity));
+        when(encryptionUtil.decryptAes256Gcm("encrypted-value")).thenReturn("AIza-alias-key");
+
+        InternalTeamApiKeyResponse response = service.resolve(
+                "google", 22L, "member@test.com", null, "Bearer internal-token", null, "my-alias");
+
+        assertThat(response.plainKey()).isEqualTo("AIza-alias-key");
+        verify(teamApiKeyRepository).findFirstByTeamIdAndProviderAndKeyAliasAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(
+                22L, TeamApiKeyProvider.GOOGLE, "my-alias");
+        verify(teamApiKeyRepository, never()).findByIdAndTeamIdAndProviderAndDeletionRequestedAtIsNull(
+                any(), any(), any());
+    }
+
+    @Test
+    void resolve_invalidApiKeyId_throwsIllegalArgumentException() {
+        TeamMemberRepository teamMemberRepository = mock(TeamMemberRepository.class);
+        TeamApiKeyRepository teamApiKeyRepository = mock(TeamApiKeyRepository.class);
+        EncryptionUtil encryptionUtil = mock(EncryptionUtil.class);
+        TeamInternalApiKeyResolveService service = newService(
+                teamMemberRepository, teamApiKeyRepository, encryptionUtil, "internal-token");
+
+        when(teamMemberRepository.existsByTeamIdAndUserId(22L, "member@test.com")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.resolve(
+                "google", 22L, "member@test.com", null, "Bearer internal-token", "not-a-number", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("apiKeyId");
+    }
+
+    @Test
+    void resolve_geminiProvider_resolvesAsGoogle() {
+        TeamMemberRepository teamMemberRepository = mock(TeamMemberRepository.class);
+        TeamApiKeyRepository teamApiKeyRepository = mock(TeamApiKeyRepository.class);
+        EncryptionUtil encryptionUtil = mock(EncryptionUtil.class);
+        TeamInternalApiKeyResolveService service = newService(
+                teamMemberRepository, teamApiKeyRepository, encryptionUtil, "internal-token");
+
+        TeamApiKeyEntity entity = TeamApiKeyEntity.register(
+                22L,
+                TeamApiKeyProvider.GOOGLE,
+                "google-key",
+                "hash",
+                "enc",
+                BigDecimal.ONE
+        );
+        ReflectionTestUtils.setField(entity, "id", 1L);
+        ReflectionTestUtils.setField(entity, "createdAt", Instant.now());
+
+        when(teamMemberRepository.existsByTeamIdAndUserId(22L, "member@test.com")).thenReturn(true);
+        when(teamApiKeyRepository.findFirstByTeamIdAndProviderAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(
+                22L, TeamApiKeyProvider.GOOGLE
+        )).thenReturn(Optional.of(entity));
+        when(encryptionUtil.decryptAes256Gcm("enc")).thenReturn("plain");
+
+        service.resolve("gemini", 22L, "member@test.com", null, "Bearer internal-token", null, null);
+
+        verify(teamApiKeyRepository).findFirstByTeamIdAndProviderAndDeletionRequestedAtIsNullOrderByCreatedAtDesc(
+                22L, TeamApiKeyProvider.GOOGLE);
     }
 
     private static TeamInternalApiKeyResolveService newService(String token) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #166  
- (추가 연관 이슈가 있으면 번호 더 기입)

## 작업 내용
- **해당 서비스**: Identity / Team / Billing 연동 / 문서(`docs`)
- 내부 API 키 조회 경로를 `apiKeyId`, `alias` 기반으로도 선택할 수 있도록 확장했습니다.
- Team 서비스에 팀 멤버 월 지출 롤업 조회 API를 추가하고, Billing 서비스 호출용 `RestClient` 및 설정값(`TEAM_BILLING_SERVICE_BASE_URL`)을 반영했습니다.
- 위 코드 변경사항과 실제 동작 규칙이 맞도록 아키텍처/계약 문서를 최신화했습니다.

## ✨ 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- Identity 내부 키 조회 API 확장
  - `GET /internal/api-keys/{provider}`에 optional query `apiKeyId`, `alias` 지원
  - 조회 우선순위: `apiKeyId` > `alias` > 최신 활성 키
- Team 내부 키 조회 API 확장
  - `GET /internal/api-keys/{provider}`에 optional query `apiKeyId`, `alias` 지원
  - `gemini` provider alias를 `google`로 정규화 처리
- Team 월 지출 롤업 API 추가
  - `GET /api/v1/teams/{id}/expenditure/team-api-keys/month-spend`
  - month 파라미터는 `YYYY-MM-01` 규칙 강제
  - 팀 멤버 목록 기반으로 Billing `POST /api/v1/expenditure/team/month-rollup` 호출
  - Gateway 헤더(`X-User-Id`, `X-Gateway-Auth`) 전달
- 설정/환경 변수 반영
  - `team.billing.base-url`
  - `TEAM_BILLING_SERVICE_BASE_URL` (`.env.example`, `docker-compose.yml`, `application.properties`)
- 문서 반영
  - `docs/contracts/proxy-team-key-internal-api.md`
  - `docs/contracts/web-team-bff.md` (v0.16)
  - `docs/architecture.md`

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [x] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부  
  - 스키마 변경은 없고, 조회 로직/DTO 추가 중심입니다.

## 📸 스크린샷 / 테스트 결과 (선택)
- `TeamInternalApiKeyResolveServiceTest`에 `apiKeyId`, `alias`, `gemini` alias 시나리오 테스트 추가/수정
- 문서 변경은 코드 동작과 계약 정합성 확인 기준으로 반영

## 리뷰 요구사항
- 내부 키 조회 우선순위(`apiKeyId > alias > latest`)가 Proxy 호출 흐름과 충돌 없는지 확인 부탁드립니다.
- Team 월 지출 롤업 API의 month 검증(월 1일 강제)과 Billing 연동 헤더 전달 정책이 운영 환경 기대와 맞는지 중점 리뷰 부탁드립니다.
- 문서 계약(`web-team-bff`, `proxy-team-key-internal-api`, `architecture`)이 현재 구현과 정확히 일치하는지 확인 부탁드립니다.