### PR TITLE
[fix] enable_compute_stack = true로 수정

### DIFF
--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -16,7 +16,7 @@ ecr_repository_prefix  = "ai-api-usage-monitor"
 # ecr_untagged_image_expire_days = 14
 
 # Optional compute (VPC + ALB + ASG).
-enable_compute_stack       = false
+enable_compute_stack       = true
 compute_environment_label  = "staging"
 # alb_target_port          = 80
 # ALB health: default probes web-edge :8080 /healthz (no Host allowlist). Use "traffic-port" to probe alb_target_port instead.

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -82,7 +82,7 @@ variable "deploy_iam_role_name" {
 variable "enable_compute_stack" {
   type        = bool
   description = "When true, creates VPC (simple public layout), ALB, target group, ASG, launch template, and EC2 instance profile for ECR pull + SSM."
-  default     = false
+  default     = true
 }
 
 variable "compute_environment_label" {


### PR DESCRIPTION
infra/terraform/terraform.tfvars.example

enable_compute_stack = false → true
infra/terraform/variables.tf

enable_compute_stack 변수 default를 false → true 로 변경 (tfvars 없이 apply할 때도 컴퓨트 스택이 켜지도록)

## #️⃣ 연관된 이슈
- 없음

## 작업 내용
- **해당 서비스**: 
> 

  
## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- 

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
 - 

## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- 
