### PR TITLE
[fix] discover targets and roll instances

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -40,6 +40,10 @@ module "compute" {
   health_check_port     = var.alb_health_check_port
   vpc_cidr              = var.vpc_cidr
   public_subnet_cidrs   = var.public_subnet_cidrs
+
+  git_clone_at_boot = var.compute_git_clone_at_boot
+  github_org        = var.github_org
+  github_repo       = var.github_repo
 }
 
 check "staging_rds_needs_compute_vpc" {

--- a/infra/terraform/modules/compute_stack/main.tf
+++ b/infra/terraform/modules/compute_stack/main.tf
@@ -194,6 +194,21 @@ resource "aws_iam_instance_profile" "ec2_instance" {
 }
 
 locals {
+  deploy_path = "/opt/${var.project_name}"
+  # Rolling deploy (gha-roll-instance.sh) expects repo root at SSM_DEPLOY_ROOT with scripts/deploy/on-instance-compose-roll.sh.
+  user_data_setup_commands = var.git_clone_at_boot ? [
+    "dnf install -y git",
+    "rm -rf \"${local.deploy_path}\"",
+    "git clone --depth 1 \"https://github.com/${var.github_org}/${var.github_repo}.git\" \"${local.deploy_path}\"",
+    "chown root:root \"${local.deploy_path}\"",
+    "chmod 755 \"${local.deploy_path}\"",
+    ] : [
+    "mkdir -p \"${local.deploy_path}\"",
+    "chown root:root \"${local.deploy_path}\"",
+    "chmod 755 \"${local.deploy_path}\"",
+  ]
+  user_data_setup = join("\n", [for c in local.user_data_setup_commands : "    ${c}"])
+
   user_data = <<-EOT
     #!/bin/bash
     set -euo pipefail
@@ -210,9 +225,7 @@ locals {
         -o /usr/local/lib/docker/cli-plugins/docker-compose
       chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
     fi
-    mkdir -p /opt/${var.project_name}
-    chown root:root /opt/${var.project_name}
-    chmod 755 /opt/${var.project_name}
+    ${local.user_data_setup}
   EOT
 }
 

--- a/infra/terraform/modules/compute_stack/variables.tf
+++ b/infra/terraform/modules/compute_stack/variables.tf
@@ -12,6 +12,22 @@ variable "ecr_repository_prefix" {
   type = string
 }
 
+variable "git_clone_at_boot" {
+  type        = bool
+  description = "Clone GitHub repo into /opt/<project_name> on first boot (public HTTPS). When false, only create empty deploy dir."
+  default     = true
+}
+
+variable "github_org" {
+  type        = string
+  description = "GitHub org or user for HTTPS clone URL (must match OIDC trust)."
+}
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub repository name for HTTPS clone URL."
+}
+
 variable "instance_type" {
   type = string
 }

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -18,6 +18,9 @@ ecr_repository_prefix  = "ai-api-usage-monitor"
 # Optional compute (VPC + ALB + ASG).
 enable_compute_stack       = true
 compute_environment_label  = "staging"
+# Public GitHub repo only. For private repos: compute_git_clone_at_boot = false and clone /opt/<project_name> yourself (e.g. deploy key).
+# compute_git_clone_at_boot  = false
+
 # alb_target_port          = 80
 # ALB health: default probes web-edge :8080 /healthz (no Host allowlist). Use "traffic-port" to probe alb_target_port instead.
 # alb_health_check_port    = "8080"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -91,6 +91,12 @@ variable "compute_environment_label" {
   default     = "staging"
 }
 
+variable "compute_git_clone_at_boot" {
+  type        = bool
+  description = "When enable_compute_stack is true, clone https://github.com/<github_org>/<github_repo> into /opt/<project_name> on first instance boot so SSM rolling deploy finds scripts/deploy/. Requires a reachable public clone URL. Set false for private repos and clone that directory manually (or use your own bootstrap)."
+  default     = true
+}
+
 variable "compute_instance_type" {
   type        = string
   description = "EC2 instance type for the optional ASG."


### PR DESCRIPTION
변경 요약
infra/terraform/variables.tf

compute_git_clone_at_boot (기본 true): 첫 부팅 시 공개 HTTPS로 https://github.com/<github_org>/<github_repo>.git 를 /opt/<project_name> 에 shallow clone. infra/terraform/main.tf

module "compute"에 git_clone_at_boot, github_org, github_repo 전달. infra/terraform/modules/compute_stack/variables.tf

위에 대응하는 git_clone_at_boot, github_org, github_repo 변수 추가. infra/terraform/modules/compute_stack/main.tf

user-data에서 기존 빈 mkdir만 하던 부분을
git_clone_at_boot == true: git 설치 → 기존 디렉터리 제거 → git clone --depth 1 → chown/chmod false: 예전처럼 빈 디렉터리만 생성.
infra/terraform/terraform.tfvars.example

비공개 저장소일 때 compute_git_clone_at_boot = false 로 두고 수동 clone 하라는 주석 추가.

## #️⃣ 연관된 이슈
- 없음

## 작업 내용
- **해당 서비스**: 
> 

  
## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- 

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
 - 

## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- 
