### PR TITLE
Fix: EC2에 이미지 읽어올 수 있도록 권한 부여

### DIFF
--- a/infra/terraform/modules/compute_stack/main.tf
+++ b/infra/terraform/modules/compute_stack/main.tf
@@ -158,6 +158,13 @@ resource "aws_iam_role_policy_attachment" "ssm_core" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+# Pull images from any ECR repository in this account/region (includes ecr:BatchGetImage, etc.).
+# Complements the scoped inline policy below; use when Docker/ECR API needs full read-only surface.
+resource "aws_iam_role_policy_attachment" "ec2_ecr_readonly" {
+  role       = aws_iam_role.ec2_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
 resource "aws_iam_role_policy" "ecr_pull" {
   name = "${var.project_name}-ecr-pull-${var.environment_label}"
   role = aws_iam_role.ec2_instance.id


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 없음

## 작업 내용
- **해당 서비스**: 
> 현재 EC2 인스턴스가 ECR에서 이미지를 pull 하려고 할 때 ecr:BatchGetImage 권한이 없어서 실패했습니다. 따라서 테라폼 코드에서 EC2 인스턴스에 할당된 IAM Role을 찾은 후(주로 aws_iam_role 리소스), 해당 Role에 AmazonEC2ContainerRegistryReadOnly AWS 관리형 정책을 연결(Attachment)하는 코드를 추가했습니다. 

  
## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [x] 인프라/설정 변경 (`chore`)

## 📝 상세 내용
- 

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

## 📸 스크린샷 / 테스트 결과 (선택)
 - 

## 리뷰 요구사항 
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- 
