### PR TITLE
Docs/architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 # <Team Project> AI Usage & Billing Platform (MSA) 아키텍처 문서
-버전: 0.6.5
+버전: 0.6.6
 
 ---
 
@@ -9,7 +9,8 @@
   - 본 문서(`architecture.md`)는 **이 팀 프로젝트의 구조·스택·서비스 분해**를 다룬다. 위 이론 문서는 구현과 무관한 **일반 설명**을 위한 참고 자료이다.
 - **이벤트 소비·발행 흐름**(Proxy `UsageRecordedEvent` → usage·billing 소비, Billing `UsageCostFinalizedEvent` → usage 등): 본 문서 **§6**, 공유 타입·AMQP는 [`libs/usage-events`](../libs/usage-events) · 상세는 [`docs/billing-service-overview-20260412.md`](billing-service-overview-20260412.md)(부록 A 포함) · Billing이 RabbitMQ로 **추가 발행**하는 스트림(개인 키 예산 임계·팀 API 키 예산 임계·비용 정정 완료 등)은 [`docs/billing-outbound-events.md`](billing-outbound-events.md)
 - **팀 도메인 이벤트 → 인앱 알림**: Team Service 발행 `team.events` / notification-service 소비·인앱 저장 — 본 문서 **§4.9·§6**, 페이로드 계약은 [`docs/contracts/web-team-bff.md`](contracts/web-team-bff.md) §6.2
-- **사용량·집계·대시보드 관점**: 본 문서 **§6·§11**, 다이어그램은 [`docs/c4-architecture-diagrams.md`](c4-architecture-diagrams.md)
+- **MSA 구조도 한눈에 (as-is)**: [`docs/msa-architecture-overview.md`](msa-architecture-overview.md) — 서비스·DB·web-edge·Gateway·RabbitMQ 요약 다이어그램
+- **사용량·집계·대시보드·C4 상세**: 본 문서 **§6·§11**, C4 모델·컴포넌트는 [`docs/c4-architecture-diagrams.md`](c4-architecture-diagrams.md) (v1.0)
 - **서비스별 DB 구성·서비스 간 데이터 전달**(물리/논리 PostgreSQL, 타 서비스 DB 직접 접근 금지, API vs RabbitMQ, 조회 성능): [`docs/msa-database-and-service-integration.md`](msa-database-and-service-integration.md)
 - **Agent Service 이벤트 스냅샷/어시스턴트 개요**: [`docs/agent-service-overview-20260430.md`](agent-service-overview-20260430.md)
 - **회원 탈퇴 — 설계·계약·서비스별 요구사항 (정본)**: [`docs/account-deletion.md`](account-deletion.md)

--- a/docs/c4-architecture-diagrams.md
+++ b/docs/c4-architecture-diagrams.md
@@ -3,14 +3,17 @@
 이 문서는 목표 설계가 아니라, 현재 저장소에 존재하는 구현 코드 기준으로
 시스템 아키텍처를 C4 모델(C1 → C4)로 정리한다.
 
-**문서 버전:** 0.9 (web-edge `:8888` 단일 진입·Gateway 계층·Proxy→Usage RabbitMQ 비동기 흐름 정합 반영)
+**문서 버전:** 1.0 (`agent-service`·`agent-web`·`postgres-agent`·web-edge `/agent`·Team `web`/DB 반영; `docs/architecture.md` v0.6.6·`docs/repository-structure.md` §2.1과 정합)
+
+**MSA 한눈 요약(다이어그램 모음):** [`docs/msa-architecture-overview.md`](msa-architecture-overview.md) — 본 문서는 C4·컴포넌트·코드 수준 상세를 담는다.
 
 분석 대상:
 - **`services/identity-service/web`** (정본: 랜딩·인증·설정/org UI + `/api/auth/**`·`/api/identity/**` BFF)
 - **`services/usage-service/web`** (정본: 대시보드 UI + `/api/usage/**` BFF → 게이트웨이)
-- **`services/team-service/web`** (정본: 팀 생성/조회/초대 UI + `/api/team/v1/**` BFF)
+- **`services/team-service/web`** (정본: 팀 생성/조회/초대 UI + `/teams/api/**`·`/api/team/v1/**` BFF)
 - **`services/billing-service/web`** (정본: 지출·비용 UI + `/api/expenditure/**` BFF → 게이트웨이 `/api/v1/expenditure/**`; 팀 월 롤업은 전용 `POST …/team/month-rollup`에서 멤버 검증 후 동일 게이트웨이로 전달)
 - **`services/notification-service/web`** (정본: 인앱 알림 UI + BFF → `notification-service` REST)
+- **`services/agent-service/web`** (정본: Agent UI `basePath=/agent` + `/agent/api/v1/agents/**` BFF → `agent-service` REST, Gateway 경유 없음)
 - `apps/web` (과도기·레거시; 안내용 `README` 위주 — 런타임 정본 아님)
 - `services/api-gateway-service`
 - `services/proxy-service`
@@ -19,10 +22,18 @@
 - `services/team-service`
 - `services/billing-service`
 - `services/notification-service`
+- `services/agent-service`
 - `libs/usage-events`
+- `docker/web-edge/nginx.conf.template`, `docker-compose.yml`
 - 서비스별 `application.yml`/`application.properties`
 - `test-report/` (팀·실험 보고·원인 분석 메모, 런타임 코드 아님)
 - `experiment-logic/` (로컬·네트워크·호출 경로 등 실험 정리, 런타임 코드 아님)
+
+**논리 서비스만 문서에 있고 별도 `services/` 배포 단위가 없는 것:** Quota Service(§4.8), Analytics & Reporting(§4.7), 독립 API Key Service(§4.4 — 구현은 `identity-service` 경계). 아래 다이어그램은 **실제 폴더·Compose 기준 as-is** 만 표시한다.
+
+## MSA 한 장 요약 (As-Is)
+
+전체 구조·web-edge·Gateway·이벤트·배포 다이어그램은 **[`msa-architecture-overview.md`](msa-architecture-overview.md)** 에 모았다. 아래 C1부터는 동일 as-is 기준의 **시스템 컨텍스트·컨테이너·컴포넌트** 상세이다.
 
 ## C1 - System Context
 
@@ -37,10 +48,12 @@ flowchart TB
     subgraph platform["AI Usage Platform (As-Is)"]
       direction TB
       webEdge["web-edge<br/>nginx :8888"]
-      identityWeb["Identity Web<br/>services/identity-service/web"]
-      usageWeb["Usage Web<br/>services/usage-service/web"]
-      billingWeb["Billing Web<br/>services/billing-service/web"]
-      notifWeb["Notification Web<br/>services/notification-service/web"]
+      identityWeb["Identity Web"]
+      usageWeb["Usage Web"]
+      billingWeb["Billing Web"]
+      teamWeb["Team Web<br/>basePath=/teams"]
+      notifWeb["Notification Web"]
+      agentWeb["Agent Web<br/>basePath=/agent"]
       gateway["API Gateway Service"]
       proxy["Proxy Service"]
       identity["Identity Service (Spring)"]
@@ -48,6 +61,7 @@ flowchart TB
       billing["Billing Service (Spring)"]
       team["Team Service (Spring)"]
       notification["Notification Service (NestJS)"]
+      agent["Agent Service (Spring)"]
     end
 
     subgraph ext["External systems"]
@@ -63,40 +77,56 @@ flowchart TB
       appDb["PostgreSQL (app)"]
       usageDb["PostgreSQL (usage_db)"]
       billingDb["PostgreSQL (billing_db)"]
+      teamDb["PostgreSQL (team_db)"]
       notifDb["PostgreSQL (notification_db)"]
+      agentDb["PostgreSQL (agent_db)"]
     end
 
     browser -->|HTTP 8888| webEdge
     webEdge -->|/| identityWeb
     webEdge -->|/dashboard*| usageWeb
     webEdge -->|/billing*| billingWeb
+    webEdge -->|/teams*| teamWeb
     webEdge -->|/notifications*| notifWeb
+    webEdge -->|/agent*| agentWeb
     webEdge -->|/api/v1*| gateway
     identityWeb -->|BFF /api/auth·identity| identity
     usageWeb -->|BFF /api/usage| gateway
     billingWeb -->|BFF → /api/v1/expenditure| gateway
+    teamWeb -->|BFF /teams/api · /api/team/v1| team
     notifWeb -->|BFF| notification
+    agentWeb -->|BFF /agent/api/v1/agents| agent
     client -->|Auth API| identity
     client -->|AI API via web-edge| webEdge
     gateway -->|/proxy| proxy
     gateway -->|/api/v1/expenditure| billing
+    gateway -->|/api/v1/usage etc.| usage
+    gateway -->|/api/team etc.| team
 
     proxy -->|relay| openai
     proxy -->|relay| anthropic
     proxy -->|relay| google
     proxy -->|internal /internal/api-keys| identity
-    proxy -->|publish| rabbit
+    proxy -->|publish usage.recorded| rabbit
 
     usage -->|consume usage.recorded| rabbit
     usage -->|consume usage.cost.finalized| rabbit
     billing -->|consume usage.recorded| rabbit
-    billing -->|publish usage.cost.finalized| rabbit
+    billing -->|publish billing.events| rabbit
+    team -->|publish team.events| rabbit
     team -->|consume account-deletion| rabbit
+    identity -->|publish identity.events| rabbit
+    notification -->|consume billing·team·identity| rabbit
+    agent -->|consume identity·usage snapshots| rabbit
     billing -.->|optional GET budget| identity
+    team -.->|HTTP user verify · billing rollup| identity
+    team -.->|HTTP| billing
     identity -->|JPA| appDb
     usage -->|JPA| usageDb
     billing -->|JPA| billingDb
+    team -->|JPA| teamDb
     notification -->|Prisma| notifDb
+    agent -->|JPA| agentDb
 ```
 
 ## C2 - Container Diagram
@@ -109,24 +139,29 @@ Person(client, "Developer/User", "Auth and AI API consumer")
 Person(browserUser, "Browser user", "Web UI and same-origin BFF")
 
 System_Boundary(platform, "AI Usage Platform") {
-    Container(webEdge, "web-edge", "Nginx", "단일 진입점 :8888; /api/v1*→Gateway; path 기반 web 분기")
+    Container(webEdge, "web-edge", "Nginx", "단일 진입점 :8888; path→각 web; /api/v1*→Gateway")
     Container(idWeb, "Identity Web", "Next.js 15", "랜딩·인증·설정; /api/auth/* · /api/identity/* BFF")
     Container(usWeb, "Usage Web", "Next.js 15", "대시보드 /dashboard; BFF → Gateway")
     Container(billWeb, "Billing Web", "Next.js 15", "지출·비용; /api/expenditure/* BFF → Gateway /api/v1/expenditure")
-    Container(ntfWeb, "Notification Web", "Next.js 15", "인앱 알림; BFF → notification-service REST")
-    Container(gateway, "API Gateway", "Spring Cloud Gateway", "JWT; /api/v1/ai→/proxy; trust headers; /api/v1/expenditure→Billing")
-    Container(proxy, "Proxy Service", "Spring WebFlux", "Relay; usage parse; MQ publish; key→Identity")
-    Container(identity, "Identity Service", "Spring + JPA", "Signup/login, JWT")
-    Container(usage, "Usage Service", "Spring + MQ + JPA", "Consume usage-recorded + usage.cost.finalized; usage log + api key metadata")
-    Container(billing, "Billing Service", "Spring + MQ + JPA", "Consume usage-recorded; cost aggregates; publish usage.cost.finalized; optional Identity budget HTTP")
-    Container(team, "Team Service", "Spring + JPA + MQ", "Team domain + account deletion coordination listener")
-    Container(notification, "Notification Service", "NestJS + Prisma", "In-app notifications API + team.events MQ consumer")
+    Container(teamWeb, "Team Web", "Next.js", "팀 UI /teams; BFF /teams/api · /api/team/v1 → team-service")
+    Container(ntfWeb, "Notification Web", "Next.js 15", "인앱 알림 /notifications; BFF → notification-service REST")
+    Container(agentWeb, "Agent Web", "Next.js 15", "Agent UI /agent; BFF → agent-service REST (Gateway 미경유)")
+    Container(gateway, "API Gateway", "Spring Cloud Gateway", "JWT; /api/v1/ai→/proxy; trust headers; domain HTTP routes")
+    Container(proxy, "Proxy Service", "Spring WebFlux", "Relay; usage parse; MQ publish; key→Identity; DB 없음")
+    Container(identity, "Identity Service", "Spring + JPA", "Signup/login, JWT, org, external API keys")
+    Container(usage, "Usage Service", "Spring + MQ + JPA", "Consume usage-recorded + usage.cost.finalized; usage log")
+    Container(billing, "Billing Service", "Spring + MQ + JPA", "Consume usage-recorded; aggregates; publish billing.events")
+    Container(team, "Team Service", "Spring + JPA + MQ", "Team domain; publish team.events; account-deletion listener")
+    Container(notification, "Notification Service", "NestJS + Prisma", "In-app API; consume billing·team·identity events")
+    Container(agent, "Agent Service", "Spring + MQ + JPA", "Snapshots; budget/policy assistants; consume identity·usage events")
 
-    ContainerQueue(rabbit, "RabbitMQ", "AMQP", "usage.events(usage.recorded), billing.events(usage.cost.finalized), account-deletion events")
+    ContainerQueue(rabbit, "RabbitMQ", "AMQP", "usage.events, billing.events, identity.events, team.events")
     ContainerDb(appDb, "PostgreSQL (app)", "RDB", "Identity domain data")
     ContainerDb(usageDb, "PostgreSQL (usage_db)", "RDB", "Usage logs")
     ContainerDb(billingDb, "PostgreSQL (billing_db)", "RDB", "Billing aggregates")
+    ContainerDb(teamDb, "PostgreSQL (team_db)", "RDB", "Team domain data")
     ContainerDb(notifDb, "PostgreSQL (notification_db)", "RDB", "In-app notifications")
+    ContainerDb(agentDb, "PostgreSQL (agent_db)", "RDB", "Agent snapshots & signals")
 }
 
 System_Ext(openai, "OpenAI API", "LLM provider")
@@ -137,32 +172,42 @@ Rel(browserUser, webEdge, "HTTP :8888 단일 진입", "HTTP")
 Rel(webEdge, idWeb, "default /", "HTTP")
 Rel(webEdge, usWeb, "/dashboard* + usage BFF", "HTTP")
 Rel(webEdge, billWeb, "/billing* + expenditure BFF", "HTTP")
+Rel(webEdge, teamWeb, "/teams* + team BFF paths", "HTTP")
 Rel(webEdge, ntfWeb, "/notifications* + notification BFF", "HTTP")
+Rel(webEdge, agentWeb, "/agent* + agent BFF", "HTTP")
 Rel(webEdge, gateway, "/api/v1*", "HTTP")
 Rel(idWeb, identity, "auth/settings/org BFF → Identity REST", "HTTPS")
 Rel(usWeb, gateway, "usage BFF → /api/v1/usage/...", "HTTPS")
 Rel(billWeb, gateway, "expenditure BFF → /api/v1/expenditure", "HTTPS")
+Rel(teamWeb, team, "team BFF → team-service REST", "HTTPS")
 Rel(ntfWeb, notification, "notification BFF → REST", "HTTPS")
+Rel(agentWeb, agent, "agent BFF → /api/v1/agents (direct)", "HTTPS")
 Rel(client, identity, "auth API direct", "HTTPS")
 Rel(client, webEdge, "AI request /api/v1/ai/**", "HTTP")
 Rel(gateway, proxy, "forward + trust headers", "HTTP")
 Rel(gateway, billing, "billing-http route", "HTTP")
+Rel(gateway, usage, "usage-http route", "HTTP")
+Rel(gateway, team, "team-http route", "HTTP")
 
 Rel(proxy, identity, "internal API keys per user", "HTTP")
 Rel(proxy, openai, "relay", "HTTPS")
 Rel(proxy, anthropic, "relay", "HTTPS")
 Rel(proxy, google, "relay", "HTTPS")
-Rel(proxy, rabbit, "publish events", "AMQP")
+Rel(proxy, rabbit, "publish usage.recorded", "AMQP")
 
-Rel(usage, rabbit, "consume usage-service.queue + usage-service.usage-cost-finalized.queue", "AMQP")
-Rel(billing, rabbit, "consume billing-service.queue", "AMQP")
-Rel(billing, rabbit, "publish usage.cost.finalized", "AMQP")
-Rel(team, rabbit, "consume team.account-deletion.requested.queue", "AMQP")
+Rel(usage, rabbit, "consume usage-service.queue + usage-cost-finalized", "AMQP")
+Rel(billing, rabbit, "consume billing-service.queue; publish billing.events", "AMQP")
+Rel(team, rabbit, "publish team.events; consume account-deletion", "AMQP")
+Rel(identity, rabbit, "publish identity.events", "AMQP")
+Rel(notification, rabbit, "consume billing·team·identity", "AMQP")
+Rel(agent, rabbit, "consume identity·usage snapshot events", "AMQP")
 Rel(billing, identity, "optional monthly budget HTTP", "HTTPS")
 Rel(identity, appDb, "read/write", "JPA")
 Rel(usage, usageDb, "read/write", "JPA")
 Rel(billing, billingDb, "read/write", "JPA")
+Rel(team, teamDb, "read/write", "JPA")
 Rel(notification, notifDb, "read/write", "Prisma")
+Rel(agent, agentDb, "read/write", "JPA")
 ```
 
 ## C3 - Component Diagram (Cross-Service Runtime Flow)
@@ -234,7 +279,7 @@ flowchart TB
   BL -.->|IdentityBudgetClient (optional)| ID
 ```
 
-**C3 보충:** `Notification Service` 는 브라우저 BFF → REST·DB 경로 외에도 team 도메인 RabbitMQ 이벤트를 소비한다. 본 절 핵심은 Proxy→MQ→Usage/Billing 비동기 체인이며, 알림 경로는 `docs/architecture.md` §6·§12 및 `docs/contracts/web-notification-bff.md`를 함께 본다.
+**C3 보충:** `Notification Service` 는 브라우저 BFF → REST·DB 경로 외에도 `billing.events`·`team.events`·`identity.events` 를 소비한다. `Agent Service` 는 `identity.events`(외부 API 키 스냅샷) 및 usage 관련 스냅샷 이벤트를 소비해 `agent_db` 에 적재한다(상세: [`docs/agent-service-overview-20260430.md`](agent-service-overview-20260430.md)). 본 절 핵심은 Proxy→MQ→Usage/Billing 비동기 체인이며, 알림·Agent 경로는 `docs/architecture.md` §6·§12 및 각 계약 문서를 함께 본다.
 
 ## C4 - Code Diagram (Proxy Relay Core)
 
@@ -669,6 +714,15 @@ flowchart TD
 **Notification Web (정본)**  
 - `services/notification-service/web/src/app/api/notification/[[...path]]/route.ts`  
 
+**Agent Web (정본)**  
+- `services/agent-service/web/src/app/api/v1/agents/**/route.ts` (BFF → `agent-service` REST)  
+- `services/agent-service/web/src/components/agent/agent-shell.tsx`  
+
+**Agent Service (Spring)**  
+- `services/agent-service/src/main/java/com/zerobugfreinds/ai_agent_service/mq/` (Identity·usage 이벤트 소비)  
+- `services/agent-service/src/main/java/com/zerobugfreinds/ai_agent_service/service/IdentityApiKeySnapshotService.java`  
+- `services/agent-service/README.md`  
+
 **Billing Service (Spring)**  
 - `services/billing-service/src/main/java/com/eevee/billingservice/consumer/BillingUsageRecordedEventListener.java`  
 - `services/billing-service/src/main/java/com/eevee/billingservice/service/BillingRecordedService.java`  
@@ -690,7 +744,8 @@ flowchart TD
 - `services/proxy-service/src/main/java/com/eevee/proxyservice/provider/GoogleProviderHandler.java`
 - `services/proxy-service/src/main/java/com/eevee/proxyservice/security/UserContext.java`
 - `services/proxy-service/src/main/java/com/eevee/proxyservice/mq/UsageEventPublisher.java`
-- `docker-compose.yml` (프록시·게이트웨이·RabbitMQ·`postgres-billing`·`postgres-notification`·선택 `billing-web`/`notification-web` 프로파일; 호스트 `bootRun` 전제는 `architecture.md`·본 문서 C1 참고)
+- `docker-compose.yml` (프록시·게이트웨이·RabbitMQ·서비스별 `postgres-*`·`profile: web` 시 `*-web`·`web-edge`; 호스트 `bootRun` 전제는 `architecture.md`·본 문서 C1 참고)
+- `docker/web-edge/nginx.conf.template` (`/teams`·`/agent`·`/dashboard`·`/billing`·`/notifications` 분기)
 - `test-report/`, `experiment-logic/` (문서 전용, 위 § 저장소 문서·실험 디렉터리)
 - `services/usage-service/src/main/java/com/eevee/usageservice/consumer/UsageRecordedEventListener.java`
 - `services/usage-service/src/main/java/com/eevee/usageservice/service/UsageRecordedService.java`

--- a/docs/msa-architecture-overview.md
+++ b/docs/msa-architecture-overview.md
@@ -1,0 +1,313 @@
+# MSA 아키텍처 개요 (As-Is)
+
+**문서 버전:** 1.0  
+**기준:** 저장소 코드 · [`architecture.md`](architecture.md) v0.6.6 · [`c4-architecture-diagrams.md`](c4-architecture-diagrams.md) v1.0 · [`repository-structure.md`](repository-structure.md) §2.1
+
+본 문서는 **목표 설계가 아니라** 현재 `services/`·`docker-compose.yml`·Gateway 라우트 기준 **한눈에 보는 MSA 구조도**를 모은다. 서비스 책임·이벤트 페이로드·계약의 정본은 각 링크 문서를 본다.
+
+---
+
+## 0. 관련 문서
+
+| 주제 | 문서 |
+|------|------|
+| 서비스 분해·스택·이벤트 상세 | [`architecture.md`](architecture.md) |
+| C4 모델·컴포넌트·코드 다이어그램 | [`c4-architecture-diagrams.md`](c4-architecture-diagrams.md) |
+| 폴더·모노레포·`web/` 배치 | [`repository-structure.md`](repository-structure.md) |
+| DB 분리·서비스 간 연동 규칙 | [`msa-database-and-service-integration.md`](msa-database-and-service-integration.md) |
+| web-edge 경로·BFF 경계 | [`contracts/web-split-boundary.md`](contracts/web-split-boundary.md) |
+| Gateway·Proxy 신뢰 경계 | [`contracts/gateway-proxy.md`](contracts/gateway-proxy.md) |
+| Agent 도메인 | [`agent-service-overview-20260430.md`](agent-service-overview-20260430.md) |
+
+**문서에만 있고 별도 `services/` 배포 단위가 없는 것:** Quota(§4.8), Analytics & Reporting(§4.7), 독립 API Key Service(§4.4 — 구현은 `identity-service`).
+
+---
+
+## 1. MSA 전체 구조 (서비스 · DB · 메시징)
+
+각 마이크로서비스는 **전용 PostgreSQL**만 사용한다. 타 서비스 DB에 JDBC 등으로 **직접 접근하지 않는다**. 서비스 간 연동은 **HTTP API** 또는 **RabbitMQ**만 쓴다.
+
+```mermaid
+flowchart TB
+    subgraph clients["클라이언트"]
+        BR["Browser"]
+        CL["Developer / API Client"]
+    end
+
+    subgraph edge["단일 진입점"]
+        WE["web-edge<br/>nginx :8888"]
+    end
+
+    subgraph webs["services/*/web — Next.js BFF"]
+        IW["identity-web<br/>/ · /login · /settings"]
+        UW["usage-web<br/>basePath /dashboard"]
+        BW["billing-web<br/>basePath /billing"]
+        TW["team-web<br/>basePath /teams"]
+        NW["notification-web<br/>/notifications"]
+        AW["agent-web<br/>basePath /agent"]
+    end
+
+    subgraph gateway["API 계층"]
+        GW["api-gateway-service<br/>Spring Cloud Gateway"]
+        PX["proxy-service<br/>WebFlux · DB 없음"]
+    end
+
+    subgraph services["마이크로서비스 (services/)"]
+        ID["identity-service<br/>Spring + JPA"]
+        US["usage-service<br/>Spring + JPA"]
+        BL["billing-service<br/>Spring + JPA"]
+        TM["team-service<br/>Spring + JPA"]
+        NT["notification-service<br/>NestJS + Prisma"]
+        AG["agent-service<br/>Spring + JPA"]
+    end
+
+    subgraph infra["공유 인프라"]
+        RMQ["RabbitMQ"]
+        REDIS["Redis<br/>quota 캐시 등"]
+    end
+
+    subgraph dbs["서비스별 전용 DB"]
+        DB1[("identity_db")]
+        DB2[("usage_db")]
+        DB3[("billing_db")]
+        DB4[("team_db")]
+        DB5[("notification_db")]
+        DB6[("agent_db")]
+    end
+
+    subgraph providers["AI Provider"]
+        P1["OpenAI"]
+        P2["Anthropic"]
+        P3["Gemini"]
+    end
+
+    BR --> WE
+    CL --> WE
+    CL --> ID
+
+    WE --> IW & UW & BW & TW & NW & AW
+    WE --> GW
+
+    IW -->|BFF 직연| ID
+    UW & BW -->|BFF| GW
+    TW -->|BFF| TM
+    NW -->|BFF| NT
+    AW -->|BFF 직연| AG
+
+    GW --> PX & US & BL & TM & ID & NT
+    PX --> P1 & P2 & P3
+    PX -->|내부 API 키| ID
+    PX -->|publish| RMQ
+    PX -.-> REDIS
+
+    ID --> DB1
+    US --> DB2
+    BL --> DB3
+    TM --> DB4
+    NT --> DB5
+    AG --> DB6
+
+    RMQ --> US & BL & NT & TM & AG
+    ID -->|publish| RMQ
+    TM -->|publish| RMQ
+    BL -->|publish| RMQ
+```
+
+### 1.1 배포 단위 · DB 소유권
+
+| `services/` | 전용 DB | 핵심 책임 |
+|-------------|---------|-----------|
+| `api-gateway-service` | 없음 | JWT·라우팅·trust headers |
+| `proxy-service` | 없음 | AI 중계, `usage.recorded` 발행 |
+| `identity-service` | `identity_db` | 인증·조직·개인 API 키 |
+| `usage-service` | `usage_db` | usage 로그·사용량 대시보드 |
+| `billing-service` | `billing_db` | 비용 집계·예산 임계 이벤트 |
+| `team-service` | `team_db` | 팀·멤버·팀 API 키 |
+| `notification-service` | `notification_db` | 인앱 알림 |
+| `agent-service` | `agent_db` | 스냅샷·추천·어시스턴트 |
+
+---
+
+## 2. web-edge 경로 분기 (`:8888`)
+
+정본: `docker/web-edge/nginx.conf.template`, [`contracts/web-split-boundary.md`](contracts/web-split-boundary.md).
+
+```mermaid
+flowchart LR
+    WE["web-edge :8888"]
+
+    WE -->|/ · /login · /settings<br/>/api/auth/* · /api/identity/*| IW["identity-web"]
+    WE -->|/dashboard/*| UW["usage-web"]
+    WE -->|/billing/*| BW["billing-web"]
+    WE -->|/teams/* · /teams/api/*<br/>/api/team/v1/*| TW["team-web"]
+    WE -->|/notifications/*| NW["notification-web"]
+    WE -->|/agent/*| AW["agent-web"]
+    WE -->|/api/v1/*| GW["api-gateway"]
+```
+
+---
+
+## 3. API Gateway 라우트 (코드 기준)
+
+정본: `services/api-gateway-service/src/main/resources/application.yml`.
+
+Gateway가 **프록시하는 업스트림**은 아래 6개이다. **`agent-service` 라우트는 없다.**
+
+| Gateway 경로 | 업스트림 | 비고 |
+|--------------|----------|------|
+| `/api/v1/ai/**` | `proxy-service` | → `/proxy/**` rewrite |
+| `/api/v1/ai/ext/**` | `proxy-service` | ext HMAC, JWT 아님 |
+| `/api/v1/usage/**` | `usage-service` | |
+| `/api/v1/expenditure/**` | `billing-service` | |
+| `/api/identity/**` | `identity-service` | → `/api/**` rewrite |
+| `/api/team/**` | `team-service` | → `/api/**` rewrite |
+| `/api/notification/**` | `notification-service` | → `/api/**` rewrite |
+
+Gateway **자체** 엔드포인트: `GET /internal/web-edge/auth/resolve` (`WebEdgeAuthController`, nginx `auth_request`).
+
+### 3.1 BFF가 Gateway를 타는지 (실제 트래픽)
+
+| BFF | Gateway 경유 | 실제 연결 |
+|-----|--------------|-----------|
+| `usage-web` | 예 | `API_GATEWAY_URL` → `/api/v1/usage/**` |
+| `billing-web` | 예 | `API_GATEWAY_URL` → `/api/v1/expenditure/**` |
+| `notification-web` | 설정에 따라 | gateway 또는 `NOTIFICATION_SERVICE_URL` 직연 |
+| `identity-web` | 보통 아님 | `IDENTITY_SERVICE_URL` 직연 |
+| `team-web` | 보통 아님 | nginx → team-web BFF → `team-service` |
+| `agent-web` | 아님 | `agent-service` 직연 |
+
+```mermaid
+flowchart LR
+    BR["Browser"] --> WE["web-edge"]
+
+    WE --> IW["identity-web"] --> ID["identity-service"]
+    WE --> UW["usage-web"] --> GW["gateway"] --> US["usage-service"]
+    WE --> BW["billing-web"] --> GW --> BL["billing-service"]
+    WE --> TW["team-web"] --> TM["team-service"]
+    WE --> NW["notification-web"] --> NT["notification-service"]
+    WE --> AW["agent-web"] --> AG["agent-service"]
+    WE --> GW
+    GW --> PX["proxy-service"]
+```
+
+---
+
+## 4. 동기 요청 — AI API (Proxy)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant E as web-edge
+    participant G as api-gateway
+    participant P as proxy-service
+    participant I as identity-service
+    participant PR as AI Provider
+
+    C->>E: POST /api/v1/ai/**
+    E->>G: proxy
+    G->>G: JWT · trust headers
+    G->>P: /proxy/**
+    P->>I: GET /internal/api-keys
+    P->>PR: Provider 중계
+    PR-->>P: 응답 + usage
+    P-->>C: HTTP 응답 (동기)
+    Note over P: 이후 RabbitMQ usage.recorded (비동기)
+```
+
+Proxy는 Usage DB에 **직접 쓰지 않고** 이벤트만 발행한다 ([`architecture.md`](architecture.md) §2·§6).
+
+---
+
+## 5. 비동기 이벤트 (RabbitMQ)
+
+```mermaid
+flowchart LR
+    subgraph pub["발행"]
+        PX["proxy-service"]
+        ID["identity-service"]
+        TM["team-service"]
+        BL["billing-service"]
+    end
+
+    subgraph ex["Exchange"]
+        U["usage.events"]
+        B["billing.events"]
+        I["identity.events"]
+        T["team.events"]
+    end
+
+    subgraph sub["소비 → 전용 DB"]
+        US["usage-service"]
+        BL2["billing-service"]
+        NT["notification-service"]
+        TM2["team-service"]
+        AG["agent-service"]
+    end
+
+    PX -->|usage.recorded| U
+    U --> US
+    U --> BL2
+
+    BL2 -->|usage.cost.finalized<br/>budget.threshold.*| B
+    B --> US
+    B --> NT
+
+    ID --> I
+    I --> TM2 & BL2 & US & NT & AG
+
+    TM -->|team.events| T
+    T --> NT
+    T --> BL2
+```
+
+| Exchange | 대표 routing key | 발행 | 주요 소비 |
+|----------|------------------|------|-----------|
+| `usage.events` | `usage.recorded` | Proxy | Usage, Billing |
+| `billing.events` | `usage.cost.finalized`, `billing.budget.threshold.reached`, … | Billing | Usage, Notification |
+| `identity.events` | `identity.user.sync`, `identity.external-api-key.status-changed`, … | Identity | Team, Usage, Billing, Notification, Agent |
+| `team.events` | 팀 도메인, `team.api.key.#` | Team | Notification, Billing |
+
+상세 토폴로지: [`architecture.md`](architecture.md) §6.2, [`billing-outbound-events.md`](billing-outbound-events.md).
+
+---
+
+## 6. 모노레포 · 배포 (패턴 B)
+
+```mermaid
+flowchart TB
+    subgraph repo["ai-api-usage-monitor"]
+        S["services/*<br/>8 MS + */web"]
+        L["libs/usage-events"]
+        P["packages/ui · shell"]
+        DC["docker-compose.yml<br/>postgres-* · rabbitmq · redis"]
+        EDGE["docker/web-edge"]
+    end
+
+    subgraph runtime["서비스별 이미지 + Compose"]
+        IMG["Spring JAR × N"]
+        WEBIMG["Next standalone × N"]
+        NG["web-edge nginx"]
+    end
+
+    repo --> runtime
+    DC --> runtime
+    EDGE --> NG
+```
+
+- **Kubernetes 미사용** — 로컬·배포는 Docker Compose + 서비스별 이미지 분리 ([`architecture.md`](architecture.md) §10.1).
+- 브라우저 **단일 진입:** `web-edge` `:8888` (`WEB_EDGE_PORT`).
+- Compose `profile: web`: `identity-web`, `usage-web`, `billing-web`, `team-web`, `notification-web`, `agent-web`, `web-edge` 등.
+
+---
+
+## 7. 문서 유지
+
+다음이 바뀌면 **본 문서·[`c4-architecture-diagrams.md`](c4-architecture-diagrams.md)·[`architecture.md`](architecture.md) §0** 을 함께 검토한다.
+
+- `services/api-gateway-service/.../application.yml` 라우트 추가·삭제
+- `docker/web-edge/nginx.conf.template` 공개 경로
+- `services/` 아래 신규·제거 마이크로서비스 또는 `web/` BFF 업스트림 변경
+- RabbitMQ exchange·큐 이름 ([`architecture.md`](architecture.md) §6.2)
+
+**구현과 문서가 어긋나면 코드·Compose를 정본**으로 둔다.

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -40,10 +40,13 @@ Gradle/Maven 등 **빌드 도구는 팀 설정을 따른다.** 본 문서는 **�
 - **`libs/`**: 아래 §3의 **허용 범위만** 공유한다(JVM·이벤트·계약 위주).
 - **`packages/`** (pnpm workspace): **`@ai-usage/ui`** — **UI 토큰, 공용 Shadcn 래퍼, `cn`** 등 얇은 프리미티브만. **`@ai-usage/shell`** — 콘솔 공통 **레이아웃·사이드바**와 **브라우저 공개 경로(라우팅 소유권)** 를 한곳에서 조립하는 패키지(identity / usage / billing 각 `web/` 의 `basePath`·`web-edge`·`NEXT_PUBLIC_*` 와 맞물리게 유지). 알림 메뉴 미확인 배지·읽음 후 즉시 갱신은 `notification-events.ts`(`dispatchNotificationsChanged`) 및 [`packages/shell/README.md`](packages/shell/README.md) §「Sidebar notification badge」·[`docs/contracts/web-notification-bff.md`](contracts/web-notification-bff.md) §4.7. 도메인 비즈니스 로직 공유는 하지 않는다(`docs/repository-structure.md` §3와 동일한 취지). usage 등 `basePath` 가 있는 앱에서 `next/link`만으로 타 앱 경로(`/settings` 등)를 쓰면 `/dashboard/settings` 처럼 잘못 붙을 수 있으므로, shell 은 필요 시 **루트 절대 경로 `<a href>` 또는 동일 오리진 절대 URL** 로 정본 경로를 맞춘다. Next Docker 빌드는 저장소 루트 context 로 `packages/ui`·`packages/shell` 을 함께 복사한다.
 - **`docs/`**: 팀 문서의 정본.
-- **`docker-compose.yml`**: **저장소 루트**에 두어 로컬에서 DB·브로커·캐시 등을 한 번에 기동하기 쉽게 한다. **배포·로컬 스택은 `docs/architecture.md` §10.1 패턴 B(백엔드·프론트 이미지 분리·Compose)** 를 따르며, 애플리케이션은 **서비스별 Spring 이미지 + 해당 서비스 `web/` Next 이미지**로 올리고 Compose·엣지 프록시로 연결한다(`profile: web` → **`identity-web`**, **`usage-web`**, **`web-edge`**). 단일 도메인용 Nginx 설정은 **`docker/web-edge/nginx.conf`**(호스트 포트 기본 `WEB_EDGE_PORT`=`8888`). Compose는 루트 **`.env`**만 자동 로드한다(`.env.example`은 샘플). **`GATEWAY_SHARED_SECRET`** 등은 Compose가 빈 문자열로 주입하면 Spring 기본값이 무력화될 수 있으므로 **루트 `.env.example` 주석·`docs/contracts/gateway-proxy.md` §5**를 따른다.
+- **`docker-compose.yml`**: **저장소 루트**에 두어 로컬에서 DB·브로커·캐시 등을 한 번에 기동하기 쉽게 한다. **배포·로컬 스택은 `docs/architecture.md` §10.1 패턴 B(백엔드·프론트 이미지 분리·Compose)** 를 따르며, 애플리케이션은 **서비스별 Spring 이미지 + 해당 서비스 `web/` Next 이미지**로 올리고 Compose·엣지 프록시로 연결한다(`profile: web` → **`identity-web`**, **`usage-web`**, **`billing-web`**, **`team-web`**, **`notification-web`**, **`agent-web`**, **`web-edge`** 등). 단일 도메인용 Nginx 설정은 **`docker/web-edge/nginx.conf.template`**(호스트 포트 기본 `WEB_EDGE_PORT`=`8888`). Compose는 루트 **`.env`**만 자동 로드한다(`.env.example`은 샘플). **`GATEWAY_SHARED_SECRET`** 등은 Compose가 빈 문자열로 주입하면 Spring 기본값이 무력화될 수 있으므로 **루트 `.env.example` 주석·`docs/contracts/gateway-proxy.md` §5**를 따른다.
 - **로컬 PostgreSQL:** 루트 Compose 에 **서비스별 전용 PostgreSQL 컨테이너**를 둔다(`postgres` → identity 등용 `app`, `postgres-team` → **team-service** 용 `team_db`·`TEAM_POSTGRES_*`, `postgres-usage` → **usage-service** 용 `usage_db`·`USAGE_POSTGRES_*`, `postgres-billing` → **billing-service** 용 `billing_db`·`BILLING_POSTGRES_*`, `postgres-agent` → **agent-service** 용 `agent_db`·`AGENT_POSTGRES_*`). 서비스 간 JDBC 교차 접근은 하지 않는다(`docker-compose.yml`, `docker/postgres/init/`, `.env.example` 참고). **identity-service** 의 `POSTGRES_*` 설정은 다른 서비스 작업에서 **변경하지 않는다.** 상세는 [`docs/msa-database-and-service-integration.md`](msa-database-and-service-integration.md)를 본다.
 
 ### 2.1 현재 저장소의 실제 서비스 트리(코드 기준)
+
+MSA 구조도(서비스·DB·Gateway·이벤트): [`msa-architecture-overview.md`](msa-architecture-overview.md).
+
 - `services/api-gateway-service`
 - `services/proxy-service`
 - `services/identity-service` + `services/identity-service/web`
@@ -51,8 +54,10 @@ Gradle/Maven 등 **빌드 도구는 팀 설정을 따른다.** 본 문서는 **�
 - `services/billing-service` + `services/billing-service/web`
 - `services/team-service` + `services/team-service/web` (Pages Router, `basePath=/teams`)
 - `services/notification-service` + `services/notification-service/web`
+- `services/agent-service` + `services/agent-service/web` (App Router, `basePath=/agent`)
 - `apps/web` (선택: web-host — 운영 진입은 `team-service/web` + `web-edge`)
 - `packages/ui`, `packages/shell`
+- `libs/usage-events` (Proxy·Usage·Billing 등이 공유하는 usage 이벤트 페이로드)
 
 ---
 
@@ -103,6 +108,7 @@ Gradle/Maven 등 **빌드 도구는 팀 설정을 따른다.** 본 문서는 **�
 |------|----------------|--------------------------------------|-----------|
 | Billing(지출·집계 BFF) | `services/billing-service/` | `services/billing-service/web/` | 백엔드·이벤트·BFF·팀 롤업 하드닝: [`billing-service-overview-20260412.md`](billing-service-overview-20260412.md) §4–§5, §4.10 · 경로 표: [`web-split-boundary.md`](contracts/web-split-boundary.md) §2.7 |
 | Notification(인앱 알림 UI·BFF) | `services/notification-service/`(Nest/Prisma) | `services/notification-service/web/` | [`web-notification-bff.md`](contracts/web-notification-bff.md) |
+| Agent(예산·정책 추천 UI·BFF) | `services/agent-service/` | `services/agent-service/web/` (`basePath=/agent`) | [`agent-service-overview-20260430.md`](agent-service-overview-20260430.md) · 경로: [`web-split-boundary.md`](contracts/web-split-boundary.md) §2 |
 
 - **라우트·BFF 경계 표:** [`web-split-boundary.md`](contracts/web-split-boundary.md)
 - **공유 프론트 자산:** 루트 **`pnpm` workspace**(`pnpm-workspace.yaml`, 루트 `package.json`, **`pnpm-lock.yaml`**)와 **`@ai-usage/ui`**(토큰·Shadcn 래퍼·`cn`), **`@ai-usage/shell`**(콘솔 네비·공개 경로 헬퍼)을 공유한다. 도메인 로직은 §3와 같이 서비스 경계 밖으로 복사하지 않는다. 콘솔 사이드바에 탭을 추가하는 절차는 [`howto-add-console-sidebar-route.md`](howto-add-console-sidebar-route.md)를 본다.
@@ -112,6 +118,6 @@ Gradle/Maven 등 **빌드 도구는 팀 설정을 따른다.** 본 문서는 **�
 
 - **도메인별 UI·BFF**는 `services/<svc>/web/`에 둔다. **운영 단일 도메인**에서는 **`web-edge`** 가 `/dashboard`·`/teams` 등을 각 `web`으로 프록시하며, 팀 UI 정본은 **`services/team-service/web/`**(`team-web`)이다.
 - **`apps/web`** 은 로컬·실험용 App Router 셸일 수 있다. **Module Federation·`web-mfe/`·`/mfe/usage`는 사용하지 않는다**(역사: [`mfe-pages-only-remote-split-guidance-20260414.md`](mfe-pages-only-remote-split-guidance-20260414.md)).
-- **단일 도메인:** 엣지 역프록시로 경로를 합친다. 로컬 Compose는 **`web-edge`** + `docker/web-edge/nginx.conf` — `/dashboard` → `/dashboard/`(308), **`/dashboard/`** 접두만 usage `web`, **`/api/v1/`** 접두는 API Gateway(버퍼링 끔·장시간 응답), 나머지는 identity `web`(`/dashboard2` 는 Usage가 아님). 상세: `docs/architecture.md` §10.2, `docs/contracts/web-split-boundary.md` §2.3.
+- **단일 도메인:** 엣지 역프록시로 경로를 합친다. 로컬 Compose는 **`web-edge`** + `docker/web-edge/nginx.conf.template` — `/dashboard`·`/billing`·`/teams`·`/notifications`·`/agent` 는 각 `web`, **`/api/v1/`** 접두는 API Gateway, `/teams/api/*`·`/api/team/v1/*` 는 Team BFF. 상세: `docs/architecture.md` §10.2, `docs/contracts/web-split-boundary.md` §2.
 - **게이트웨이·Proxy:** [`gateway-proxy.md`](contracts/gateway-proxy.md) §1.1·§3·§9 — **게이트웨이 팀·각 `web` BFF 담당**이 `API_GATEWAY_URL` 등을 합의한다.
 - **미들웨어·보호 라우트** 정본: [`web-identity-bff.md`](contracts/web-identity-bff.md) §6.2, [`web-split-boundary.md`](contracts/web-split-boundary.md) §3.

--- a/services/billing-service/src/main/resources/application.yml
+++ b/services/billing-service/src/main/resources/application.yml
@@ -88,6 +88,14 @@ billing:
       queue: ${BILLING_RABBIT_TEAM_DOMAIN_IN_QUEUE:billing-service.team.api-key.domain.queue}
   gateway:
     shared-secret: ${GATEWAY_SHARED_SECRET:local-dev-gateway-shared-secret-do-not-use-in-prod}
+  identity:
+    enabled: ${BILLING_IDENTITY_ENABLED:false}
+    base-url: ${BILLING_IDENTITY_BASE_URL:}
+    budget-path-template: ${BILLING_IDENTITY_BUDGET_PATH:/api/identity/v1/users/budget?email={userId}}
+  pricing:
+    # 기본(false): provider_model_price 테이블이 "완전히 비어있을 때만" seed 수행
+    # 옵션(true): 테이블이 비어있지 않아도 카탈로그에 없는 row만 추가 삽입(idempotent)
+    seed-missing: ${BILLING_PRICING_SEED_MISSING:false}
 
 # identity -> billing 회원 탈퇴 이벤트 소비 / ACK 발행
 identity:
@@ -99,11 +107,3 @@ identity:
   account-deletion-ack:
     exchange: ${IDENTITY_ACCOUNT_DELETION_ACK_EXCHANGE:identity.events}
     routing-key: ${IDENTITY_ACCOUNT_DELETION_ACK_ROUTING_KEY:identity.user.account-deletion-ack}
-  identity:
-    enabled: ${BILLING_IDENTITY_ENABLED:false}
-    base-url: ${BILLING_IDENTITY_BASE_URL:}
-    budget-path-template: ${BILLING_IDENTITY_BUDGET_PATH:/api/identity/v1/users/budget?email={userId}}
-  pricing:
-    # 기본(false): provider_model_price 테이블이 "완전히 비어있을 때만" seed 수행
-    # 옵션(true): 테이블이 비어있지 않아도 카탈로그에 없는 row만 추가 삽입(idempotent)
-    seed-missing: ${BILLING_PRICING_SEED_MISSING:false}


### PR DESCRIPTION
---

## #️⃣ 연관된 이슈
- 없음

## 작업 내용
- **해당 서비스**: 문서 (`docs/`) — 런타임 코드 변경 없음
> as-is MSA 구조를 한 문서로 모으고, `agent-service`·Gateway·web-edge 반영이 빠져 있던 아키텍처 문서 간 정합을 맞춤

## ✨ 변경 사항 (Checklist)
- [ ] 새로운 기능 추가 (`feat`)
- [ ] 버그 수정 (`fix`)
- [ ] 리팩토링 (`refactor`)
- [ ] 인프라/설정 변경 (`chore`)
- [x] 문서 추가·갱신 (`Docs`) — *코드 체크리스트 외, 본 PR 성격*

## 📝 상세 내용
- **신규** [`docs/msa-architecture-overview.md`](docs/msa-architecture-overview.md) (v1.0)
  - MSA 전체 구조, web-edge 경로, API Gateway 라우트, BFF별 Gateway 경유 여부, AI 동기 흐름, RabbitMQ 이벤트, 모노레포·배포 다이어그램
- **갱신** [`docs/c4-architecture-diagrams.md`](docs/c4-architecture-diagrams.md) (v1.0)
  - `agent-service` / `agent-web` / `team_db` / `agent_db` 반영
  - 중복 MSA 요약 → `msa-architecture-overview.md`로 위임
- **갱신** [`docs/repository-structure.md`](docs/repository-structure.md)
  - §2.1 서비스 트리에 `agent-service`·`libs/usage-events` 추가
  - Compose `profile: web`, nginx 경로, §6.1 Agent 행 보강
- **갱신** [`docs/architecture.md`](docs/architecture.md) (v0.6.5 → v0.6.6)
  - §0에 `msa-architecture-overview.md` 교차 링크

**문서상만 존재·별도 `services/` 없음:** Quota, Analytics, 독립 API Key(→ identity 포함)

## 🔗 인프라 및 통신 체크
- [ ] **Redis**: 캐시 또는 Quota 제한 로직 포함 여부
- [ ] **RabbitMQ**: 메시지 발행(Publish) 또는 소비(Consume) 로직 포함 여부
- [ ] **DB**: 스키마 변경 또는 새로운 Entity 추가 여부

→ **해당 없음** (문서만 변경, 애플리케이션·스키마·MQ 코드 미변경)

## 📸 스크린샷 / 테스트 결과 (선택)
- mermaid 미리보기: `docs/msa-architecture-overview.md` §1·§2·§5
- Gateway 라우트 표: 동 문서 §3 (`application.yml` 기준)

## 리뷰 요구사항
> 리뷰어에게 알릴 사항이나, 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
- **다이어그램 vs 코드:** Gateway 업스트림 6개·`agent-service` Gateway 미등록·identity/team/agent BFF 직연 여부가 실제 설정과 맞는지 확인 부탁드립니다 (`services/api-gateway-service/.../application.yml`, `docker/web-edge/nginx.conf.template`).
- **중복:** C4 문서의 MSA 요약은 새 overview로 옮겼습니다. overview와 C1/C2 내용이 충돌하면 **코드·Compose 정본**으로 맞추면 됩니다.
- **범위:** 런타임·CI·인프라 변경 없음 — 문서 링크·mermaid 렌더링만 검토해 주시면 됩니다.

---